### PR TITLE
Update old kikuchipy/kikuchipy links to pyxem/kikuchipy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 .. Travis CI
-.. image:: https://travis-ci.com/kikuchipy/kikuchipy.svg?branch=master
-    :target: https://travis-ci.com/kikuchipy/kikuchipy
+.. image:: https://travis-ci.com/pyxem/kikuchipy.svg?branch=master
+    :target: https://travis-ci.com/pyxem/kikuchipy
     :alt: Build status
 
 .. Coveralls
-.. image:: https://img.shields.io/coveralls/github/kikuchipy/kikuchipy.svg
-    :target: https://coveralls.io/github/kikuchipy/kikuchipy?branch=master
+.. image:: https://img.shields.io/coveralls/github/pyxem/kikuchipy.svg
+    :target: https://coveralls.io/github/pyxem/kikuchipy?branch=master
     :alt: Coveralls status
 
 .. Read the Docs
@@ -49,7 +49,7 @@ Tutorials and example workflows
 -------------------------------
 Jupyter Notebooks that you can work through and modify to perform processing and
 analyses of EBSD patterns are available `here
-<https://github.com/kikuchipy/kikuchipy-demos>`_. For learning purposes, we
+<https://github.com/pyxem/kikuchipy-demos>`_. For learning purposes, we
 recommend to use them alongside our user guide.
 
 Contributing

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,10 +20,12 @@ Contributors
 
 Changed
 -------
+- Move GitHub repository to the pyxem organization. Update relevant URLs.
+  (`#198 <https://github.com/pyxem/kikuchipy/pull/198>`_)
 - Allow scikit-image >= 0.16.
-  (`#196 <https://github.com/kikuchipy/kikuchipy/pull/196>`_)
+  (`#196 <https://github.com/pyxem/kikuchipy/pull/196>`_)
 - Removed language_version in pre-commit config file.
-  (`#195 <https://github.com/kikuchipy/kikuchipy/pull/195>`_)
+  (`#195 <https://github.com/pyxem/kikuchipy/pull/195>`_)
 
 0.2.2 (2020-05-24)
 ==================
@@ -39,7 +41,7 @@ Fixed
 -------
 - Allow reading of EBSD patterns from h5ebsd files with arbitrary scan group
   names, not just "Scan 1", "Scan 2", etc., like was the case before.
-  (`#188 <https://github.com/kikuchipy/kikuchipy/pull/188>`_)
+  (`#188 <https://github.com/pyxem/kikuchipy/pull/188>`_)
 
 0.2.1 (2020-05-20)
 ==================
@@ -55,19 +57,19 @@ Changed
 -------
 - Use numpy.fft instead of scipy.fft because HyperSpy requires scipy < 1.4 on
   conda-forge, while scipy.fft was introduced in scipy 1.4.
-  (`#180 <https://github.com/kikuchipy/kikuchipy/pull/180>`_)
+  (`#180 <https://github.com/pyxem/kikuchipy/pull/180>`_)
 
 Fixed
 -----
 - With the change above, kikuchipy 0.2 should be installable from Anaconda and
   not just PyPI.
-  (`#180 <https://github.com/kikuchipy/kikuchipy/pull/180>`_)
+  (`#180 <https://github.com/pyxem/kikuchipy/pull/180>`_)
 
 0.2.0 (2020-05-19)
 ==================
 
 Details of all development associated with this release are available `here
-<https://github.com/kikuchipy/kikuchipy/milestone/2?closed=1>`_.
+<https://github.com/pyxem/kikuchipy/milestone/2?closed=1>`_.
 
 Contributors
 ------------
@@ -77,44 +79,44 @@ Contributors
 Added
 -----
 - Jupyter Notebooks with tutorials and example workflows available via
-  https://github.com/kikuchipy/kikuchipy-demos.
+  https://github.com/pyxem/kikuchipy-demos.
 - Grey scale and RGB virtual backscatter electron (BSE) images can be easily
   generated with the VirtualBSEGenerator class. The generator return objects of
   the new signal class VirtualBSEImage, which inherit functionality from
   HyperSpy's Signal2D class.
-  (`#170 <https://github.com/kikuchipy/kikuchipy/pull/170>`_)
+  (`#170 <https://github.com/pyxem/kikuchipy/pull/170>`_)
 - EBSD master pattern class and reader of master patterns from EMsoft's EBSD
   master pattern file.
-  (`#159 <https://github.com/kikuchipy/kikuchipy/pull/159>`_)
+  (`#159 <https://github.com/pyxem/kikuchipy/pull/159>`_)
 - Python 3.8 support.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - The public API has been restructured. The pattern processing used by the EBSD
   class is available in the kikuchipy.pattern subpackage, and
   filters/kernels used in frequency domain filtering and pattern averaging are
   available in the kikuchipy.filters subpackage.
-  (`#169 <https://github.com/kikuchipy/kikuchipy/pull/169>`_)
+  (`#169 <https://github.com/pyxem/kikuchipy/pull/169>`_)
 - Intensity normalization of scan or single patterns.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Fast Fourier Transform (FFT) filtering of scan or single patterns using
   SciPy's fft routines and `Connelly Barnes' filterfft
   <https://www.connellybarnes.com/code/python/filterfft>`_.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Numba dependency to improve pattern rescaling and normalization.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Computing of the dynamic background in the spatial or frequency domain for
   scan or single patterns.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Image quality (IQ) computation for scan or single patterns based on N. C. K.
   Lassen's definition.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Averaging of patterns with nearest neighbours with an arbitrary kernel, e.g.
   rectangular or Gaussian.
-  (`#134 <https://github.com/kikuchipy/kikuchipy/pull/134>`_)
+  (`#134 <https://github.com/pyxem/kikuchipy/pull/134>`_)
 - Window/kernel/filter/mask class to handle such things, e.g. for pattern
   averaging or filtering in the frequency or spatial domain. Available in the
   kikuchipy.filters module.
-  (`#134 <https://github.com/kikuchipy/kikuchipy/pull/134>`_,
-  `#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#134 <https://github.com/pyxem/kikuchipy/pull/134>`_,
+  `#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 
 Changed
 -------
@@ -123,35 +125,35 @@ Changed
   remove_dynamic_background, rescale_intensities to rescale_intensity,
   virtual_backscatter_electron_imaging to plot_virtual_bse_intensity, and
   get_virtual_image to get_virtual_bse_intensity.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_,
-  `#170 <https://github.com/kikuchipy/kikuchipy/pull/170>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_,
+  `#170 <https://github.com/pyxem/kikuchipy/pull/170>`_)
 - Renamed kikuchipy_metadata to ebsd_metadata.
-  (`#169 <https://github.com/kikuchipy/kikuchipy/pull/169>`_)
+  (`#169 <https://github.com/pyxem/kikuchipy/pull/169>`_)
 - Source code link in the documentation should point to proper GitHub line. This
   `linkcode_resolve` in the `conf.py` file is taken from SciPy.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Read the Docs CSS style.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - New logo with a gradient from experimental to simulated pattern (with EMsoft),
   with a color gradient from the plasma color maps.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 - Dynamic background correction can be done faster due to Gaussian blurring in
   the frequency domain to get the dynamic background to remove.
-  (`#157 <https://github.com/kikuchipy/kikuchipy/pull/157>`_)
+  (`#157 <https://github.com/pyxem/kikuchipy/pull/157>`_)
 
 Removed
 -------
 - Explicit dependency on scikit-learn (it is imported via HyperSpy).
-  (`#168 <https://github.com/kikuchipy/kikuchipy/pull/168>`_)
+  (`#168 <https://github.com/pyxem/kikuchipy/pull/168>`_)
 - Dependency on pyxem. Parts of their virtual imaging methods are adapted
   here---a big thank you to the pyxem/HyperSpy team!
-  (`#168 <https://github.com/kikuchipy/kikuchipy/pull/168>`_)
+  (`#168 <https://github.com/pyxem/kikuchipy/pull/168>`_)
 
 Fixed
 -----
 - RtD builds documentation with Python 3.8 (fixed problem of missing .egg
   leading build to fail).
-  (`#158 <https://github.com/kikuchipy/kikuchipy/pull/158>`_)
+  (`#158 <https://github.com/pyxem/kikuchipy/pull/158>`_)
 
 0.1.3 (2020-05-11)
 ==================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,9 +86,9 @@ pygments_style = "friendly"
 
 # Logo
 cmap = "plasma"
-version = "v0.2.0"
-html_logo = f"_static/icon/{version}/{cmap}_logo.svg"
-html_favicon = f"_static/icon/{version}/{cmap}_favicon.png"
+logo_version = "v0.2.0"
+html_logo = f"_static/icon/{logo_version}/{cmap}_logo.svg"
+html_favicon = f"_static/icon/{logo_version}/{cmap}_favicon.png"
 
 # Read the Docs theme options
 html_theme_options = {
@@ -101,9 +101,7 @@ def linkcode_resolve(domain, info):
 
     This is taken from SciPy's conf.py:
     https://github.com/scipy/scipy/blob/master/doc/source/conf.py.
-
     """
-
     if domain != "py":
         return None
 
@@ -148,22 +146,12 @@ def linkcode_resolve(domain, info):
 
     if fn.startswith("kikuchipy/"):
         m = re.match(r"^.*dev0\+([a-f0-9]+)$", kikuchipy.__version__)
+        pre_link = "https://github.com/pyxem/kikuchipy/blob/"
         if m:
-            return "https://github.com/kikuchipy/kikuchipy/blob/%s/%s%s" % (
-                m.group(1),
-                fn,
-                linespec,
-            )
+            return pre_link + "%s/%s%s" % (m.group(1), fn, linespec)
         elif "dev" in kikuchipy.__version__:
-            return "https://github.com/kikuchipy/kikuchipy/blob/master/%s%s" % (
-                fn,
-                linespec,
-            )
+            return pre_link + "master/%s%s" % (fn, linespec)
         else:
-            return "https://github.com/kikuchipy/kikuchipy/blob/v%s/%s%s" % (
-                kikuchipy.__version__,
-                fn,
-                linespec,
-            )
+            return pre_link + "v%s/%s%s" % (kikuchipy.__version__, fn, linespec)
     else:
         return None

--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,9 @@ setup(
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,
     project_urls={
-        "Bug Tracker": "https://github.com/kikuchipy/kikuchipy/issues",
+        "Bug Tracker": "https://github.com/pyxem/kikuchipy/issues",
         "Documentation": "https://kikuchipy.org",
-        "Source Code": "https://github.com/kikuchipy/kikuchipy",
+        "Source Code": "https://github.com/pyxem/kikuchipy",
     },
     # Dependencies
     # Update in .travis.yml if this list is updated!


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

* Update Travis CI and Coveralls badges to point to pyxem/kikuchipy
* Update any other links in setup.py etc. previously pointing to kikuchipy/kikuchipy

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
