### PR TITLE
Depend on orix v0.5, use spherical coordiantes from Vector3d directly

### DIFF
--- a/kikuchipy/generators/ebsd_simulation_generator.py
+++ b/kikuchipy/generators/ebsd_simulation_generator.py
@@ -19,11 +19,11 @@
 from copy import deepcopy
 from typing import Optional
 
-from kikuchipy.crystallography import ReciprocalLatticePoint
 import numpy as np
 from orix.crystal_map import Phase
 from orix.quaternion.rotation import Rotation
 
+from kikuchipy.crystallography import ReciprocalLatticePoint
 from kikuchipy.detectors import EBSDDetector
 from kikuchipy.projections.ebsd_projections import (
     detector2reciprocal_lattice,
@@ -174,7 +174,7 @@ class EBSDSimulationGenerator:
         bands = KikuchiBand(
             phase=phase,
             hkl=hkl,
-            coordinates=band_coordinates,
+            hkl_detector=band_coordinates,
             in_pattern=hkl_in_pattern,
             gnomonic_radius=self.detector.r_max,
         )

--- a/kikuchipy/projections/gnomonic_projection.py
+++ b/kikuchipy/projections/gnomonic_projection.py
@@ -28,7 +28,7 @@ class GnomonicProjection(SphericalProjection):
     """Gnomonic projection of a vector as implemented in MTEX."""
 
     @classmethod
-    def project(self, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+    def project(cls, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
         """Convert from Cartesian to the Gnomonic projection."""
         polar = super().project(v)
         theta, phi = polar[..., 0], polar[..., 1]
@@ -41,7 +41,7 @@ class GnomonicProjection(SphericalProjection):
         theta[is_upper] -= np.pi
 
         # Turn around antipodal vectors
-        is_antipodal = v < self.spherical_region
+        is_antipodal = v < cls.spherical_region
         phi[is_antipodal] += np.pi
 
         # Formula for gnomonic projection

--- a/kikuchipy/projections/gnomonic_projection.py
+++ b/kikuchipy/projections/gnomonic_projection.py
@@ -29,7 +29,28 @@ class GnomonicProjection(SphericalProjection):
 
     @classmethod
     def project(cls, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-        """Convert from Cartesian to the Gnomonic projection."""
+        """Convert from 3D cartesian coordinates (x, y, z) to 2D
+        Gnomonic coordinates (x_g, y_g).
+
+        Parameters
+        ----------
+        v
+            3D vector(s) on the form [[x0, y0, z0], [x1, y1, z1], ...].
+
+        Returns
+        -------
+        gnomonic_coordinates
+            Gnomonic coordinates on the form [[x0, y0], [x1, y1], ...].
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from kikuchipy.projections.gnomonic_projection import (
+        ...     GnomonicProjection
+        ... )
+        >>> v = np.random.random_sample(30).reshape((10, 3))
+        >>> xy = GnomonicProjection.project(v)
+        """
         polar = super().project(v)
         theta, phi = polar[..., 0], polar[..., 1]
 
@@ -39,10 +60,6 @@ class GnomonicProjection(SphericalProjection):
         else:
             is_upper = v[..., 2] > 0
         theta[is_upper] -= np.pi
-
-        # Turn around antipodal vectors
-        is_antipodal = v < cls.spherical_region
-        phi[is_antipodal] += np.pi
 
         # Formula for gnomonic projection
         r = np.tan(theta)
@@ -54,8 +71,32 @@ class GnomonicProjection(SphericalProjection):
         return np.column_stack((x, y))
 
     @staticmethod
-    def iproject(x: np.ndarray, y: np.ndarray) -> Vector3d:
-        """Convert from the Gnomonic projection to Cartesian coordinates."""
+    def iproject(xy: np.ndarray) -> Vector3d:
+        """Convert from 2D Gnomonic coordinates (x_g, y_g) to 3D
+        cartesian coordiantes (x, y, z).
+
+        Parameters
+        ----------
+        xy
+            2D coordinates on the form
+            [[x_g0, y_g0], [x_g1, y_g1], ...].
+
+        Returns
+        -------
+        cartesian_coordinates
+            Cartesian coordinates (x, y, z) on the form
+            [[x0, y0, z0], [x1, y1, z1], ...].
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from kikuchipy.projections.gnomonic_projection import (
+        ...     GnomonicProjection
+        ... )
+        >>> xy_g = np.random.random_sample(20).reshape((10, 2))
+        >>> xyz = GnomonicProjection.iproject(xy_g)
+        """
+        x, y = xy[..., 0], xy[..., 1]
         theta = np.arctan(np.sqrt(x ** 2 + y ** 2))
         phi = np.arctan2(y, x)
         return Vector3d.from_polar(theta=theta, phi=phi)

--- a/kikuchipy/projections/hesse_normal_form.py
+++ b/kikuchipy/projections/hesse_normal_form.py
@@ -30,13 +30,13 @@ class HesseNormalForm:
     def project_polar(
         polar: np.ndarray, radius: Optional[float] = 10
     ) -> np.ndarray:
-        """Return the Hesse normal form of plane(s) given by polar
+        """Return the Hesse normal form of plane(s) given by spherical
         coordinates.
 
         Parameters
         ----------
         polar
-            Polar coordinates theta, phi, r.
+            Spherical coordinates theta, phi, r.
         radius
             Hesse radius. Default is 10.
 

--- a/kikuchipy/projections/lambert_projection.py
+++ b/kikuchipy/projections/lambert_projection.py
@@ -106,7 +106,7 @@ class LambertProjection:
         Lambert."""
         # These two functions could probably be combined into 1 to decrease
         # runtime
-        vec = GnomonicProjection.iproject(xy[..., 0], xy[..., 1])
+        vec = GnomonicProjection.iproject(xy)
         xy = LambertProjection.project(vec)
         return xy
 

--- a/kikuchipy/projections/spherical_projection.py
+++ b/kikuchipy/projections/spherical_projection.py
@@ -24,23 +24,51 @@ from orix.vector.spherical_region import SphericalRegion
 
 
 class SphericalProjection:
-    """Spherical projection of a vector as implemented in MTEX."""
+    """Spherical projection of a cartesian vector according to the ISO
+    31-11 standard [SphericalWolfram]_.
+
+    References
+    ----------
+    .. [SphericalWolfram] Weisstein, Eric W. "Spherical Coordinates,"
+        *From MathWorld--A Wolfram Web Resource*,
+        url: https://mathworld.wolfram.com/SphericalCoordinates.html
+    """
 
     spherical_region = SphericalRegion([0, 0, 1])
 
-    def project(self, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-        """Convert from cartesian to spherical coordinates."""
-        polar = get_polar(v)
+    @classmethod
+    def project(cls, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+        """Convert from cartesian to spherical coordinates according to
+        the ISO 31-11 standard [SphericalWolfram]_.
 
-        # Restrict to plotable domain
-        is_antipodal = v < self.spherical_region
-        polar[is_antipodal, 1] += np.pi
+        Parameters
+        ----------
+        v
+            3D vector(s) on the form [[x0, y0, z0], [x1, y1, z1], ...].
 
-        return polar
+        Returns
+        -------
+        spherical_coordinates
+            Spherical coordinates theta, phi and r on the form
+            [[theta1, phi1, r1], [theta2, phi2, r2], ...].
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from kikuchipy.projections.spherical_projection import (
+        ...     SphericalProjection
+        ... )
+        >>> v = np.random.random_sample(30).reshape((10, 3))
+        >>> theta, phi, r = SphericalProjection.project(v)
+        >>> np.allclose(np.arccos(v[: 2] / r), theta)
+        True
+        >>> np.allclose(np.arctan2(v[:, 1], v[:, 2]), phi)
+        True
+        """
+        return _get_polar(v)
 
 
-def get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Convert from cartesian to spherical coordinates."""
+def _get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
     if isinstance(v, Vector3d):
         x, y, z = v.xyz
     else:
@@ -53,7 +81,19 @@ def get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
 
 def get_theta(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get spherical coordinate theta from cartesian."""
+    """Get spherical coordinate theta from cartesian according to the
+    ISO 31-11 standard [SphericalWolfram]_.
+
+    Parameters
+    ----------
+    v
+        3D vector(s) on the form [[x0, y0, z0], [x1, y1, z1], ...].
+
+    Returns
+    -------
+    theta
+        Spherical coordinate theta.
+    """
     if isinstance(v, Vector3d):
         x, y, z = v.xyz
     else:
@@ -63,7 +103,19 @@ def get_theta(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
 
 def get_phi(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get spherical coordinate phi from cartesian."""
+    """Get spherical coordinate phi from cartesian according to the ISO
+    31-11 standard [SphericalWolfram]_.
+
+    Parameters
+    ----------
+    v
+        3D vector(s) on the form [[x0, y0, z0], [x1, y1, z1], ...].
+
+    Returns
+    -------
+    phi
+        Spherical coordinate phi.
+    """
     if isinstance(v, Vector3d):
         x, y, _ = v.xyz
     else:
@@ -74,7 +126,18 @@ def get_phi(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
 
 def get_r(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get spherical coordinate radius from cartesian."""
+    """Get radial spherical coordinate from cartesian coordinates.
+
+    Parameters
+    ----------
+    v
+        3D vector(s) on the form [[x0, y0, z0], [x1, y1, z1], ...].
+
+    Returns
+    -------
+    phi
+        Spherical coordinate phi.
+    """
     if isinstance(v, Vector3d):
         x, y, z = v.xyz
     else:

--- a/kikuchipy/projections/spherical_projection.py
+++ b/kikuchipy/projections/spherical_projection.py
@@ -28,7 +28,6 @@ class SphericalProjection:
 
     spherical_region = SphericalRegion([0, 0, 1])
 
-    @classmethod
     def project(self, v: Union[Vector3d, np.ndarray]) -> np.ndarray:
         """Convert from cartesian to spherical coordinates."""
         polar = get_polar(v)

--- a/kikuchipy/projections/tests/test_gnomonic_projection.py
+++ b/kikuchipy/projections/tests/test_gnomonic_projection.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+from orix.vector import Vector3d
+import numpy as np
+
+from kikuchipy.projections.gnomonic_projection import GnomonicProjection
+
+
+class TestGnomonicProjection:
+    def test_project(self):
+        """Projecting cartesian coordinates to Gnomonic coordinates
+        yields expected result.
+        """
+        v = np.array(
+            [
+                [0.5901, 0.8439, 0.4139],
+                [0.4994, 0.744, 0.6386],
+                [0.8895, 0.7788, 0.5597],
+                [0.6673, 0.8619, 0.6433],
+                [0.7605, 0.0647, 0.9849],
+                [0.5852, 0.3946, 0.5447],
+                [0.4647, 0.7181, 0.6571],
+                [0.8806, 0.5106, 0.6244],
+                [0.0816, 0.4489, 0.0296],
+                [0.7585, 0.1885, 0.2678],
+            ]
+        )
+        xy = GnomonicProjection.project(v)
+
+        # Desired project result?
+        assert np.allclose(
+            xy,
+            np.array(
+                [
+                    [1.42, 2.03],
+                    [0.78, 1.16],
+                    [1.58, 1.39],
+                    [1.03, 1.33],
+                    [0.77, 0.06],
+                    [1.07, 0.72],
+                    [0.70, 1.09],
+                    [1.41, 0.81],
+                    [2.75, 15.14],
+                    [2.83, 0.70],
+                ]
+            ),
+            atol=1e-1,
+        )
+
+        # Same result passing Vector3d
+        assert np.allclose(xy, GnomonicProjection.project(Vector3d(v)))
+
+    def test_iproject(self):
+        """Projecting Gnomonic coordinates to cartesian coordinates
+        yields expected result.
+        """
+        xy = np.array(
+            [
+                [1.4254, 2.0385],
+                [0.7819, 1.1650],
+                [1.5892, 1.3915],
+                [1.0372, 1.3397],
+                [0.7721, 0.0656],
+                [1.0743, 0.7245],
+                [0.7072, 1.0928],
+                [1.4103, 0.8177],
+                [2.7529, 15.1496],
+                [2.8328, 0.7039],
+            ]
+        )
+
+        assert np.allclose(
+            GnomonicProjection.iproject(xy).data,
+            np.array(
+                [
+                    [0.5316, 0.7603, 0.3729],
+                    [0.4538, 0.6761, 0.5803],
+                    [0.6800, 0.5954, 0.4278],
+                    [0.5272, 0.6809, 0.5082],
+                    [0.6103, 0.0519, 0.7904],
+                    [0.6563, 0.4426, 0.6109],
+                    [0.4308, 0.6657, 0.6091],
+                    [0.7374, 0.4275, 0.5228],
+                    [0.1784, 0.9818, 0.06480],
+                    [0.9181, 0.2281, 0.3240],
+                ]
+            ),
+            atol=1e-2,
+        )

--- a/kikuchipy/projections/tests/test_hesse_normal_form.py
+++ b/kikuchipy/projections/tests/test_hesse_normal_form.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from kikuchipy.projections.hesse_normal_form import HesseNormalForm
+from kikuchipy.projections.spherical_projection import _get_polar
+
+
+class TestHesseNormalForm:
+    @pytest.mark.parametrize(
+        "radius, desired_result",
+        [
+            (
+                10,
+                np.array(
+                    [
+                        [0.4020, 1.5306],
+                        [0.7127, 1.4995],
+                        [0.4734, 1.5234],
+                        [0.5902, 1.5117],
+                        [1.2904, 1.4414],
+                    ]
+                ),
+            ),
+            (
+                2,
+                np.array(
+                    [
+                        [0.4020, 1.3684],
+                        [0.7127, 1.2064],
+                        [0.4734, 1.3318],
+                        [0.5902, 1.2712],
+                        [1.2904, 0.8695],
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_project_polar(self, radius, desired_result):
+        """Project yields expected result."""
+        v = np.array(
+            [
+                [0.5900, 0.8438, 0.4139],
+                [0.4993, 0.7440, 0.6386],
+                [0.8894, 0.7788, 0.5596],
+                [0.6672, 0.8618, 0.6433],
+                [0.7605, 0.0647, 0.9848],
+            ]
+        )
+        polar = _get_polar(v)
+        assert np.allclose(
+            HesseNormalForm.project_polar(polar, radius=radius),
+            desired_result,
+            atol=1e-3,
+        )
+
+    @pytest.mark.parametrize(
+        "radius, desired_result",
+        [
+            (
+                10,
+                np.array(
+                    [
+                        [0.4020, 1.5306],
+                        [0.7127, 1.4995],
+                        [0.4734, 1.5234],
+                        [0.5902, 1.5117],
+                        [1.2904, 1.4414],
+                    ]
+                ),
+            ),
+            (
+                2,
+                np.array(
+                    [
+                        [0.4020, 1.3684],
+                        [0.7127, 1.2064],
+                        [0.4734, 1.3318],
+                        [0.5902, 1.2712],
+                        [1.2904, 0.8695],
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_project_cartesian(self, radius, desired_result):
+        """Inverse projection yields expected result."""
+        v = np.array(
+            [
+                [0.5900, 0.8438, 0.4139],
+                [0.4993, 0.7440, 0.6386],
+                [0.8894, 0.7788, 0.5596],
+                [0.6672, 0.8618, 0.6433],
+                [0.7605, 0.0647, 0.9848],
+            ]
+        )
+        assert np.allclose(
+            HesseNormalForm.project_cartesian(v, radius=radius),
+            desired_result,
+            atol=1e-3,
+        )

--- a/kikuchipy/projections/tests/test_lambert_projection.py
+++ b/kikuchipy/projections/tests/test_lambert_projection.py
@@ -40,14 +40,8 @@ class TestLambertProjection:
             )
         )
         output_b = LambertProjection.project(vector_two)
-
-        expected_b = np.array(
-            (
-                (0.814172, 0.814172, 0.814172),
-                (0, 0, 0),
-                (0.6784123, 0, 0.6784123),
-            )
-        )
+        expected_b = np.array([[0.8147, 0.8147], [0, 0.6782], [0.6782, 0]])
+        assert np.allclose(output_b, expected_b, atol=1e-4)
 
         assert output_a[..., 0][0] == pytest.approx(expected_a[..., 0], rel=1e4)
         assert output_a[..., 1][0] == pytest.approx(expected_a[..., 1], rel=1e4)

--- a/kikuchipy/projections/tests/test_spherical_projection.py
+++ b/kikuchipy/projections/tests/test_spherical_projection.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from orix.vector import Vector3d
+
+from kikuchipy.projections.spherical_projection import (
+    SphericalProjection,
+    get_theta,
+    get_phi,
+    get_r,
+)
+
+
+def test_spherical_projection():
+    """Compared against tests in orix."""
+    n = 10
+    v_arr = np.random.random_sample(n * 3).reshape((n, 3))
+    v = Vector3d(v_arr)
+
+    # Vector3d
+    polar = SphericalProjection.project(v_arr)
+    assert np.allclose(polar[..., 0], v.theta.data)
+    assert np.allclose(polar[..., 1], v.phi.data)
+    assert np.allclose(polar[..., 2], v.r.data)
+    assert np.allclose(get_theta(v), v.theta.data)
+    assert np.allclose(get_phi(v), v.phi.data)
+    assert np.allclose(get_r(v), v.r.data)
+
+    # NumPy array
+    polar2 = SphericalProjection.project(v)
+    assert np.allclose(polar2[..., 0], v.theta.data)
+    assert np.allclose(polar2[..., 1], v.phi.data)
+    assert np.allclose(polar2[..., 2], v.r.data)
+    assert np.allclose(get_theta(v_arr), v.theta.data)
+    assert np.allclose(get_phi(v_arr), v.phi.data)
+    assert np.allclose(get_r(v_arr), v.r.data)

--- a/kikuchipy/simulations/features.py
+++ b/kikuchipy/simulations/features.py
@@ -95,11 +95,7 @@ class KikuchiBand(ReciprocalLatticePoint):
     @property
     def navigation_shape(self) -> tuple:
         """Navigation shape."""
-        coordinate_shape = self.hkl_detector.shape
-        if len(coordinate_shape) == 2:
-            return (1,)
-        else:
-            return coordinate_shape[:-1]
+        return self.hkl_detector.shape[:-1]
 
     @property
     def navigation_dimension(self) -> int:

--- a/kikuchipy/simulations/features.py
+++ b/kikuchipy/simulations/features.py
@@ -18,20 +18,19 @@
 
 from typing import Union
 
-from kikuchipy.crystallography import ReciprocalLatticePoint
 import numpy as np
 from orix.crystal_map import Phase
 from orix.vector import Vector3d
 
-from kikuchipy.projections.spherical_projection import get_phi, get_theta, get_r
+from kikuchipy.crystallography import ReciprocalLatticePoint
 
 
 class KikuchiBand(ReciprocalLatticePoint):
     def __init__(
         self,
         phase: Phase,
-        hkl: Union[Vector3d, np.ndarray, list, tuple],
-        coordinates: np.ndarray,
+        hkl: Union[Vector3d, np.ndarray],
+        hkl_detector: Union[Vector3d, np.ndarray],
         in_pattern: np.ndarray,
         gnomonic_radius: Union[float, np.ndarray] = 10,
     ):
@@ -45,22 +44,19 @@ class KikuchiBand(ReciprocalLatticePoint):
             point group describing the allowed symmetry operations.
         hkl
             All Miller indices present in any of the n patterns.
-        coordinates
-            Detector coordinates per pattern for each hkl, in the shape
-            (n, n_hkl, 3).
+        hkl_detector
+            Detector coordinates for all Miller indices per pattern, in
+            the shape navigation_shape + (n_hkl, 3).
         in_pattern
-            Boolean array of shape (n, n_hkl) indicating whether an hkl
-            is visible in a pattern.
+            Boolean array of shape navigation_shape + (n_hkl,)
+            indicating whether an hkl is visible in a pattern.
         gnomonic_radius
             Only plane trace coordinates of bands with Hesse normal
             form distances below this radius is returned when called
             for.
         """
         super().__init__(phase=phase, hkl=hkl)
-        if coordinates.ndim == 2:
-            self._coordinates = coordinates[np.newaxis, ...]
-        else:  # ndim == 3
-            self._coordinates = coordinates
+        self._hkl_detector = Vector3d(hkl_detector)
         self._in_pattern = np.atleast_2d(in_pattern)
         self.gnomonic_radius = gnomonic_radius
 
@@ -69,14 +65,15 @@ class KikuchiBand(ReciprocalLatticePoint):
         return KikuchiBand(
             phase=self.phase,
             hkl=self.hkl,
-            coordinates=self.coordinates[key],
+            hkl_detector=self.hkl_detector[key],
             in_pattern=self.in_pattern[key],
             gnomonic_radius=self.gnomonic_radius,
         )
 
     @property
-    def coordinates(self) -> np.ndarray:
-        return self._coordinates
+    def hkl_detector(self) -> Vector3d:
+        """Detector coordinates for all Miller indices per pattern."""
+        return self._hkl_detector
 
     @property
     def gnomonic_radius(self) -> np.ndarray:
@@ -93,17 +90,16 @@ class KikuchiBand(ReciprocalLatticePoint):
         r = np.asarray(value)
         if r.size == 1:
             self._gnomonic_radius = r * np.ones(self.navigation_shape)
-        else:
-            self._gnomonic_radius = r.reshape(self.navigation_shape)
+        self._gnomonic_radius = r.reshape(self.navigation_shape)
 
     @property
     def navigation_shape(self) -> tuple:
         """Navigation shape."""
-        coordinate_shape = self.coordinates.shape
+        coordinate_shape = self.hkl_detector.shape
         if len(coordinate_shape) == 2:
             return (1,)
         else:
-            return coordinate_shape[:-2]
+            return coordinate_shape[:-1]
 
     @property
     def navigation_dimension(self) -> int:
@@ -117,15 +113,15 @@ class KikuchiBand(ReciprocalLatticePoint):
 
     @property
     def x_detector(self) -> np.ndarray:
-        return self.coordinates[..., 0]
+        return self.hkl_detector.data[..., 0]
 
     @property
     def y_detector(self) -> np.ndarray:
-        return self.coordinates[..., 1]
+        return self.hkl_detector.data[..., 1]
 
     @property
     def z_detector(self) -> np.ndarray:
-        return self.coordinates[..., 2]
+        return self.hkl_detector.data[..., 2]
 
     @property
     def x_gnomonic(self) -> np.ndarray:
@@ -136,19 +132,11 @@ class KikuchiBand(ReciprocalLatticePoint):
         return self.y_detector / self.z_detector
 
     @property
-    def phi_polar(self) -> np.ndarray:
-        return get_phi(self.coordinates)
-
-    @property
-    def theta_polar(self) -> np.ndarray:
-        return get_theta(self.coordinates)
-
-    @property
     def hesse_distance(self) -> np.ndarray:
         """Distance from the PC (origin), i.e. the right-angle component
-        of the distance to pole.
+        of the distance to the pole.
         """
-        return np.tan(0.5 * np.pi - self.theta_polar)
+        return np.tan(0.5 * np.pi - self.hkl_detector.theta.data)
 
     @property
     def within_gnomonic_radius(self) -> np.ndarray:
@@ -178,7 +166,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         returned.
         """
         # Get alpha1 and alpha2 angles
-        phi = self.phi_polar
+        phi = self.hkl_detector.phi.data
         hesse_alpha = self.hesse_alpha
         plane_trace = np.zeros(self.navigation_shape + (self.size, 4))
         alpha1 = phi - np.pi + hesse_alpha
@@ -196,11 +184,11 @@ class KikuchiBand(ReciprocalLatticePoint):
 
     @property
     def hesse_line_x(self) -> np.ndarray:
-        return -self.hesse_distance * np.cos(self.phi_polar)
+        return -self.hesse_distance * np.cos(self.hkl_detector.phi.data)
 
     @property
     def hesse_line_y(self) -> np.ndarray:
-        return -self.hesse_distance * np.sin(self.phi_polar)
+        return -self.hesse_distance * np.sin(self.hkl_detector.phi.data)
 
 
 class ZoneAxis(ReciprocalLatticePoint):

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -94,10 +94,10 @@ class GeometricalEBSDSimulation:
         # X and Y coordinates are now in place (0, 2) and (1, 3) respectively
         band_coords_detector[..., ::2] = (
             band_coords_gnomonic[..., :2] + (pcx / pcz)
-        ) / self.detector.x_scale[..., np.newaxis]
+        ) / self.detector.x_scale[..., np.newaxis, np.newaxis]
         band_coords_detector[..., 1::2] = (
             -band_coords_gnomonic[..., 2:] + (pcy / pcz)
-        ) / self.detector.y_scale[..., np.newaxis]
+        ) / self.detector.y_scale[..., np.newaxis, np.newaxis]
 
         return band_coords_detector
 

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -16,18 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from orix.quaternion.orientation import Orientation
-import pytest
-
-from kikuchipy.detectors import EBSDDetector
-from kikuchipy.generators import EBSDSimulationGenerator
-
 
 class TestKikuchiBand:
-    @pytest.mark.parametrize(
-        "shape, desired_shapes", [],
-    )
-    def test_property_shapes(self, shape, desired_shapes):
-        """Expected property shapes when varying navigation shape."""
-        pass
+    pass

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -25,4 +25,9 @@ from kikuchipy.generators import EBSDSimulationGenerator
 
 
 class TestKikuchiBand:
-    pass
+    @pytest.mark.parametrize(
+        "shape, desired_shapes", [],
+    )
+    def test_property_shapes(self, shape, desired_shapes):
+        """Expected property shapes when varying navigation shape."""
+        pass

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "matplotlib >= 3.2",
         "numpy >= 1.18",
         "numba >= 0.48",
-        "orix <= 0.4",
+        "orix >= 0.5",
         "scikit-image >= 0.16",
         "scikit-learn",
         "scipy",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Require `orix >= v0.5`, and exploit the availability of spherical coordinates from `Vector3d`.
* This means using `Vector3d` to represent cartesian coordinates for crystal plane normals on the EBSD detector in the `KikuchiBand` class, namely the `hkl_detector` property. Spherical coordinates are then available as `Kikuchiband.hkl_detector.theta`, `Kikuchiband.hkl_detector.phi`, and `Kikuchiband.hkl_detector.r`.
* Closes #213 
* Note that `kikuchipy.projections.gnomonic_projection.GnomonicProjection().iproject()` now takes x, y as *one* `xy` array, not two (@friedkitteh). Relevant tests are updated accordingly.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)
- [x] Use spherical coordinates in `KikuchiBand`
- [x] Fix issue with array shapes in `KikuchiBand` properties

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
