### PR TITLE
Array creation in filters.window.distance_to_origin is not ragged anymore

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -47,6 +47,11 @@ Changed
 - Remove language_version in pre-commit config file.
   (`#195 <https://github.com/pyxem/kikuchipy/pull/195>`_)
 
+Fixed
+-----
+- NumPy array creation when calculating window pixel's distance to the origin is
+  not ragged anymore. (`#221 <https://github.com/pyxem/kikuchipy/pull/221>`_)
+
 0.2.2 (2020-05-24)
 ==================
 

--- a/kikuchipy/filters/window.py
+++ b/kikuchipy/filters/window.py
@@ -395,7 +395,7 @@ def distance_to_origin(
     coordinates = np.ogrid[tuple(slice(None, i) for i in shape)]
     if len(origin) == 2:
         squared = [(i - o) ** 2 for i, o in zip(coordinates, origin)]
-        return np.sqrt(np.sum(squared))
+        return np.sqrt(np.add.outer(*squared).squeeze())
     else:
         return abs(coordinates[0] - origin[0])
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Closes #206. 
* Add fix to changelog.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
