### PR TITLE
Set correct shape for gnomonic_radius in KikuchiBand computations

### DIFF
--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -320,7 +320,3 @@ class TestKikuchiBand:
                 ]
             ),
         )
-
-    def test_hesse_alpha(self):
-        """Expected behaviour with varying shapes."""
-        pass

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -144,6 +144,48 @@ class TestKikuchiBand:
                     (2, 2, 1, 1),
                 ),
             ),
+            (
+                np.array([[-1, 1, 1], [2, 0, 0]]),
+                np.tile(
+                    np.array([[0.26, 0.32, 0.26], [-0.21, 0.45, -0.27]]),
+                    (5, 1, 1),  # shape (5, 2, 3)
+                ),
+                10,
+                np.tile(
+                    np.array(
+                        [[7.3480, -8.1433, -6.7827, 5.8039], [np.nan] * 4]
+                    ),
+                    (5, 1, 1),
+                ),
+            ),
+            (
+                np.array([[-1, 1, 1], [2, 0, 0]]),
+                np.tile(
+                    np.array([[0.26, 0.32, 0.26], [-0.21, 0.45, -0.27]]),
+                    (5, 1, 1, 1),  # shape (5, 1, 2, 3)
+                ),
+                10,
+                np.tile(
+                    np.array(
+                        [[7.3480, -8.1433, -6.7827, 5.8039], [np.nan] * 4]
+                    ),
+                    (5, 1, 1, 1),  # shape (5, 1, 2, 3)
+                ),
+            ),
+            (
+                np.array([[-1, 1, 1], [2, 0, 0]]),
+                np.tile(
+                    np.array([[0.26, 0.32, 0.26], [-0.21, 0.45, -0.27]]),
+                    (1, 5, 1, 1),  # shape (1, 5, 2, 3)
+                ),
+                10,
+                np.tile(
+                    np.array(
+                        [[7.3480, -8.1433, -6.7827, 5.8039], [np.nan] * 4]
+                    ),
+                    (1, 5, 1, 1),  # shape (1, 5, 2, 3)
+                ),
+            ),
         ],
     )
     def test_plane_trace_coordinates(
@@ -278,3 +320,7 @@ class TestKikuchiBand:
                 ]
             ),
         )
+
+    def test_hesse_alpha(self):
+        """Expected behaviour with varying shapes."""
+        pass


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Set correct shape for `gnomonic_radius` in `KikuchiBand` computations. Add a private convenience method to return `gnomonic_radius` with required added dimensions.

Will merge after checks pass.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
