### PR TITLE
Add EBSD.xmap class property storing a CrystalMap, read from EMsoft EBSD file

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -37,6 +37,9 @@ Added
 - Dependency on the diffsims package (https://github.com/pyxem/diffsims/) for
   handling of electron scattering and diffraction.
   (`#220 <https://github.com/pyxem/kikuchipy/pull/220>`_)
+- EBSD.xmap property storing an orix CrystalMap object. So far only read from
+  a EMsoft simulated EBSD pattern file. Relevant documentation updated.
+  (`#226 <https://github.com/pyxem/kikuchipy/pull/226>`_)
 
 Changed
 -------

--- a/doc/load_save_data.rst
+++ b/doc/load_save_data.rst
@@ -88,9 +88,10 @@ centre coordinate and static background pattern (stored as a
 
 In addition to the HyperSpy provided ``metadata``, ``original_metadata`` and
 ``axes_manager`` properties, kikuchipy tries to read a
-:class:`~orix.crystal_map.crystal_map.CrystalMap` object indexing results into a
-``xmap`` property and a :class:`~kikuchipy.detectors.ebsd_detector.EBSDDetector`
-object into a ``detector`` property:
+:class:`~orix.crystal_map.crystal_map.CrystalMap` object with indexing results
+into a ``xmap`` property and an
+:class:`~kikuchipy.detectors.ebsd_detector.EBSDDetector` object into a
+``detector`` property:
 
 .. code-block::
 
@@ -303,6 +304,11 @@ the kikuchipy format, e.g. one containing only ``Scan 1``, by passing:
     >>> s.save('patterns.h5', add_scan=True, scan_number=2)
 
 Here, the h5ebsd :func:`~kikuchipy.io.plugins.h5ebsd.file_writer` is called.
+
+.. note::
+
+    The ``xmap`` and ``detector`` EBSD class properties are so far not written
+    to this file format.
 
 .. _nordif-format:
 

--- a/doc/load_save_data.rst
+++ b/doc/load_save_data.rst
@@ -86,6 +86,22 @@ centre coordinate and static background pattern (stored as a
     >>> s.set_experimental_parameters(
     ...     beam_energy=15, xpc=0.5073, static_bg=static_bg)
 
+In addition to the HyperSpy provided ``metadata``, ``original_metadata`` and
+``axes_manager`` properties, kikuchipy tries to read a
+:class:`~orix.crystal_map.crystal_map.CrystalMap` object indexing results into a
+``xmap`` property and a :class:`~kikuchipy.detectors.ebsd_detector.EBSDDetector`
+object into a ``detector`` property:
+
+.. code-block::
+
+    >>> s.xmap
+    Phase  Orientations  Name  Space group  Point group  Proper point group     Color
+        0  200 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue
+    Properties:
+    Scan unit: um
+    >>> s.detector
+    EBSDDetector (60, 60), px_size 70.0 um, binning 8, tilt 0, pc (0.5, 0.5, 0.5)
+
 .. _from-numpy-array:
 
 From a NumPy array

--- a/kikuchipy/io/plugins/emsoft_ebsd.py
+++ b/kikuchipy/io/plugins/emsoft_ebsd.py
@@ -18,11 +18,15 @@
 
 """Read support for simulated EBSD patterns in EMsoft's HDF5 format."""
 
+import os
 from typing import List, Tuple, Union
 
 import dask.array as da
+from diffpy.structure import Atom, Lattice, Structure
 from h5py import File
 import numpy as np
+from orix.crystal_map import CrystalMap, Phase, PhaseList
+from orix.quaternion import Rotation
 
 from kikuchipy.io.plugins.h5ebsd import hdf5group2dict
 from kikuchipy.io.plugins.emsoft_ebsd_master_pattern import (
@@ -153,6 +157,15 @@ def file_reader(
         for i in range(patterns.ndim)
     ]
 
+    # Get crystal map
+    phase = _crystaldata2phase(hdf5group2dict(f["CrystalData"]))
+    xtal_fname = f["EMData/EBSD/xtalname"][()][0].decode().split("/")[-1]
+    phase.name, _ = os.path.splitext(xtal_fname)
+    scan["xmap"] = CrystalMap(
+        rotations=Rotation.from_euler(f["EMData/EBSD/EulerAngles"][()]),
+        phase_list=PhaseList(phase),
+    )
+
     if not lazy:
         f.close()
 
@@ -217,3 +230,44 @@ def _get_metadata(omd: dict) -> dict:
     }
     _set_metadata_from_mapping(omd, md, mapping)
     return md.as_dictionary()
+
+
+def _crystaldata2phase(dictionary: dict) -> Phase:
+    """Return a :class:`~orix.crystal_map.Phase` object from a
+    dictionary with EMsoft CrystalData group content.
+
+    Parameters
+    ----------
+    dictionary
+        Dictionary with phase information.
+
+    Returns
+    -------
+    Phase
+    """
+    # TODO: Move this to orix.io.plugins.emsoft_h5ebsd as part of v0.6
+    # Get list of atoms
+    n_atoms = dictionary["Natomtypes"]
+    atom_data = dictionary["AtomData"]
+    atom_types = dictionary["Atomtypes"]
+    if n_atoms == 1:
+        atom_types = (atom_types,)  # Make iterable
+    atoms = []
+    for i in range(n_atoms):
+        # TODO: Convert atom type integer to element name, like Ni for 26
+        atoms.append(
+            Atom(
+                atype=atom_types[i],
+                xyz=atom_data[:3, i],
+                occupancy=atom_data[3, i],
+                Uisoequiv=atom_data[4, i] / (8 * np.pi ** 2) * 1e2,  # Å^-2
+            )
+        )
+
+    # TODO: Use space group setting
+    return Phase(
+        space_group=int(dictionary["SpaceGroupNumber"]),
+        structure=Structure(
+            lattice=Lattice(*dictionary["LatticeParameters"].T), atoms=atoms
+        ),
+    )

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -35,6 +35,7 @@ from hyperspy.roi import BaseInteractiveROI
 from hyperspy.api import interactive
 from h5py import File
 import numpy as np
+from orix.crystal_map import CrystalMap
 from scipy.ndimage import correlate, gaussian_filter
 from skimage.util.dtype import dtype_range
 
@@ -97,6 +98,11 @@ class EBSD(CommonImage, Signal2D):
                 px_size=self.axes_manager.signal_axes[0].scale,
             )
 
+        if "xmap" in kwargs:
+            self._xmap = kwargs.pop("xmap")
+        else:
+            self._xmap = None
+
         # Update metadata if object is initialised from numpy array
         if not self.metadata.has_item(metadata_nodes("ebsd")):
             md = self.metadata.as_dictionary()
@@ -104,6 +110,14 @@ class EBSD(CommonImage, Signal2D):
             self.metadata = DictionaryTreeBrowser(md)
         if not self.metadata.has_item("Sample.Phases"):
             self.set_phase_parameters()
+
+    @property
+    def xmap(self) -> CrystalMap:
+        """A :class:`~orix.crystal_map.CrystalMap` containing the
+        phases, unit cell rotations and auxiliary properties of the EBSD
+        data set.
+        """
+        return self._xmap
 
     def set_experimental_parameters(
         self,

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -25,6 +25,7 @@ from hyperspy.misc.utils import DictionaryTreeBrowser
 import matplotlib
 from matplotlib.pyplot import close
 import numpy as np
+from orix.crystal_map import CrystalMap
 import pytest
 from scipy.ndimage import correlate
 from skimage.exposure import rescale_intensity
@@ -39,6 +40,7 @@ matplotlib.use("Agg")  # For plotting
 
 DIR_PATH = os.path.dirname(__file__)
 KIKUCHIPY_FILE = os.path.join(DIR_PATH, "../../data/kikuchipy/patterns.h5")
+EMSOFT_FILE = os.path.join(DIR_PATH, "../../data/emsoft_ebsd/simulated_ebsd.h5")
 
 
 def assert_dictionary(input_dict, output_dict):
@@ -1193,3 +1195,20 @@ class TestNormalizeIntensityEBSD:
 
         assert isinstance(lazy_signal, LazyEBSD)
         assert np.allclose(np.mean(lazy_signal.data.compute()), 0, atol=1e-6)
+
+
+class TestEBSDxmapProperty:
+    def test_init_xmap(self, dummy_signal):
+        """The attribute is set correctly."""
+        assert dummy_signal.xmap is None
+
+        ssim = load(EMSOFT_FILE)
+        xmap = ssim.xmap
+        assert isinstance(xmap, CrystalMap)
+        assert xmap.phases[0].name == "ni"
+
+
+class TestEBSDdetectorProperty:
+    def test_init_detector(self):
+        """The attribute is set correctly."""
+        pass


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Add `EBSD.xmap` class property storing a CrystalMap
* Read orientations and phase information from EMsoft simulated EBSD file into this `xmap` property
* Add short note in IO user guide

Must be added in other PRs:
* Make property setable
* Slice xmap when slicing a signal using `s.inav[]`
* Read this info from TSL/Bruker h5ebsd files.

This was added quickly now because @onatlandsmyr needs it.

The `_crystaldata2phase()` IO function should be moved to `orix.io.plugins.emsoft_h5ebsd`.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### Minimal example of the bug fix or new feature

```python
>>> import kikuchipy as kp
>>> s = kp.load("my_data.h5")
>>> s.xmap
Phase  Orientations  Name  Space group  Point group  Proper point group     Color
    0  200 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue
```

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
