### PR TITLE
Add zone axes to geometrical EBSD simulations, improve plotting of simulation features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 #auto changing files
 build/
 src/
+
+# Visual Studo Code
+*.code-workspace

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,10 +34,11 @@ Added
   gnomonic coordinates. EBSD reference frame documentation.
   (`#204 <https://github.com/pyxem/kikuchipy/pull/204>`_,
   `#215 <https://github.com/pyxem/kikuchipy/pull/215>`_)
-- Geometrical EBSD simulations, projecting a set of Kikuchi bands onto a
-  detector, which can be added to an EBSD signal as markers.
+- Geometrical EBSD simulations, projecting a set of Kikuchi bands and zone axes
+  onto a detector, which can be added to an EBSD signal as markers.
   (`#204 <https://github.com/pyxem/kikuchipy/pull/204>`_,
-  `#219 <https://github.com/pyxem/kikuchipy/pull/219>`_)
+  `#219 <https://github.com/pyxem/kikuchipy/pull/219>`_,
+  `#232 <https://github.com/pyxem/kikuchipy/pull/232>`_)
 - Dependency on the diffsims package (https://github.com/pyxem/diffsims/) for
   handling of electron scattering and diffraction.
   (`#220 <https://github.com/pyxem/kikuchipy/pull/220>`_)

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -25,6 +25,7 @@ The list of top modules (and the load function):
     io
     load
     pattern
+    projections
     signals
     simulations
 
@@ -91,12 +92,15 @@ markers
     get_line_segment_list
     get_point_list
     get_text_list
-    permanent_on_signal
 
 .. autofunction:: get_line_segment_list
 .. autofunction:: get_point_list
 .. autofunction:: get_text_list
-.. autofunction:: permanent_on_signal
+
+colors
+------
+
+.. automodule:: kikuchipy.draw.colors
 
 ....
 
@@ -552,11 +556,24 @@ features
 
 .. autosummary::
     KikuchiBand
+    ZoneAxis
 
 KikuchiBand
 ~~~~~~~~~~~
 
 .. autoclass:: kikuchipy.simulations.features.KikuchiBand
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :exclude-members: from_highest_hkl, from_min_dspacing, symmetrise, unique
+
+    .. automethod:: __init__
+    .. automethod:: __getitem__
+
+ZoneAxis
+~~~~~~~~
+
+.. autoclass:: kikuchipy.simulations.features.ZoneAxis
     :members:
     :undoc-members:
     :show-inheritance:

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -30,7 +30,9 @@ import pytest
 
 from kikuchipy.detectors import EBSDDetector
 from kikuchipy.generators import EBSDSimulationGenerator
+from kikuchipy.projections.ebsd_projections import detector2reciprocal_lattice
 from kikuchipy.signals import EBSD
+from kikuchipy.simulations.features import KikuchiBand
 
 
 @pytest.fixture
@@ -181,4 +183,56 @@ def nickel_ebsd_simulation_generator(
         detector=detector,
         phase=nickel_phase,
         rotations=nickel_rotations * r_tsl2bruker,
+    )
+
+
+@pytest.fixture
+def nickel_kikuchi_band(nickel_rlp, nickel_rotations, pc1):
+    rlp = nickel_rlp.symmetrise()
+
+    phase = rlp.phase
+    hkl = rlp._hkldata
+
+    nav_shape = (5, 5)
+
+    detector = EBSDDetector(
+        shape=(60, 60),
+        binning=8,
+        px_size=70,
+        pc=np.ones(nav_shape + (3,)) * pc1,
+        sample_tilt=70,
+        tilt=0,
+        convention="tsl",
+    )
+
+    nav_dim = detector.navigation_dimension
+    navigation_axes = (1, 2)[:nav_dim]
+
+    # Output shape is (3, n, 3) or (3, ny, nx, 3)
+    det2recip = detector2reciprocal_lattice(
+        sample_tilt=detector.sample_tilt,
+        detector_tilt=detector.tilt,
+        lattice=phase.structure.lattice,
+        rotation=nickel_rotations.reshape(*nav_shape),
+    )
+
+    # Output shape is (nhkl, n, 3) or (nhkl, ny, nx, 3)
+    hkl_detector = np.tensordot(hkl, det2recip, axes=(1, 0))
+    # Determine whether a band is visible in a pattern
+    upper_hemisphere = hkl_detector[..., 2] > 0
+    is_in_some_pattern = np.sum(upper_hemisphere, axis=navigation_axes) != 0
+    # Get bands that are in some pattern and their coordinates in the
+    # proper shape
+    hkl = hkl[is_in_some_pattern, ...]
+    hkl_in_pattern = upper_hemisphere[is_in_some_pattern, ...].T
+    hkl_detector = np.moveaxis(
+        hkl_detector[is_in_some_pattern], source=0, destination=nav_dim
+    )
+
+    return KikuchiBand(
+        phase=phase,
+        hkl=hkl,
+        hkl_detector=hkl_detector,
+        in_pattern=hkl_in_pattern,
+        gnomonic_radius=detector.r_max,
     )

--- a/kikuchipy/crystallography/__init__.py
+++ b/kikuchipy/crystallography/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-"""Crystallographic computations."""
+"""Crystallographic computations not found (easily) elsewhere."""
 
 from kikuchipy.crystallography.matrices import (
     get_direct_structure_matrix,

--- a/kikuchipy/crystallography/_computations.py
+++ b/kikuchipy/crystallography/_computations.py
@@ -18,9 +18,15 @@
 
 """Crystallographic computations."""
 
-from typing import Union
+from collections import defaultdict
+from typing import List, Optional, Tuple, Union
 
+from diffsims.crystallography import ReciprocalLatticePoint
+import matplotlib.colors as mcolors
 import numpy as np
+from orix.crystal_map import Phase
+
+from kikuchipy.draw.colors import TSL_COLORS
 
 
 def _get_uvw_from_hkl(hkl: Union[np.ndarray, list, tuple]) -> np.ndarray:
@@ -35,3 +41,115 @@ def _get_uvw_from_hkl(hkl: Union[np.ndarray, list, tuple]) -> np.ndarray:
         uvw = uvw / np.gcd.reduce(uvw, axis=1)[:, np.newaxis]
     uvw = np.unique(uvw, axis=0).astype(int)
     return uvw
+
+
+def _get_hkl_family(
+    hkl: Union[np.ndarray, list], reduce: bool = False
+) -> Tuple[dict, dict]:
+    # TODO: Almost identical to
+    #  diffsims.crystallography.ReciprocalLatticePoint.unique, improve
+    #  this instead!
+    hkl = np.atleast_2d(hkl)
+    # Remove [0, 0, 0] points
+    hkl = hkl[~np.all(np.isclose(hkl, 0), axis=1)]
+    families = defaultdict(list)
+    families_idx = defaultdict(list)
+    for i, this_hkl in enumerate(hkl.tolist()):
+        for that_hkl in families.keys():
+            if _is_equivalent(this_hkl, that_hkl, reduce=reduce):
+                families[tuple(that_hkl)].append(this_hkl)
+                families_idx[tuple(that_hkl)].append(i)
+                break
+        else:
+            families[tuple(this_hkl)].append(this_hkl)
+            families_idx[tuple(this_hkl)].append(i)
+    n_families = len(families)
+    unique_hkl = np.zeros((n_families, 3), dtype=int)
+    for i, all_hkl_in_family in enumerate(families.values()):
+        unique_hkl[i] = np.sort(all_hkl_in_family)[-1]
+    return families, families_idx
+
+
+def _is_equivalent(
+    this_hkl: list, that_hkl: list, reduce: bool = False
+) -> bool:
+    """Determine whether two Miller index 3-tuples are equivalent.
+    Symmetry is not considered.
+    """
+    if reduce:
+        this_hkl, _ = _reduce_hkl(this_hkl)
+        that_hkl, _ = _reduce_hkl(that_hkl)
+    return np.allclose(
+        np.sort(np.abs(this_hkl).astype(int)),
+        np.sort(np.abs(that_hkl).astype(int)),
+    )
+
+
+def _reduce_hkl(hkl: Union[list, np.ndarray]) -> Tuple[np.ndarray, np.ndarray]:
+    """Reduce Miller indices 3-tuples by a greatest common divisor."""
+    hkl = np.atleast_2d(hkl)
+    divisor = np.gcd.reduce(hkl, axis=1)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        hkl = hkl / divisor[:, np.newaxis]
+    return hkl.astype(int), divisor
+
+
+def _get_colors_for_allowed_bands(
+    phase: Phase,
+    highest_hkl: Union[List[int], np.ndarray, None] = None,
+    color_cycle: Optional[List[str]] = None,
+):
+    """Return an array of Miller indices of allowed Kikuchi bands for a
+    point group and a corresponding color.
+
+    The idea with this function is to always get the same color for the
+    same band in the same point group.
+
+    Parameters
+    ----------
+    phase
+        A phase container with a space and point group describing the
+        allowed symmetry operations.
+    highest_hkl
+        Highest Miller indices to consider. If None (default), [9, 9, 9]
+        is used.
+    color_cycle
+        A list of color names recognized by Matplotlib. If None
+        (default), a color palette based on EDAX TSL's coloring of bands
+        is cycled through.
+
+    Returns
+    -------
+    hkl_color
+        Array with Miller indices and corresponding colors of shape
+        (nhkl, 2, 3), with hkl and color in index 0 and 1 along axis=1,
+        respectively.
+    """
+    if highest_hkl is None:
+        highest_hkl = [9, 9, 9]
+    rlp = ReciprocalLatticePoint.from_highest_hkl(
+        phase=phase, highest_hkl=highest_hkl,
+    )
+
+    rlp2 = rlp[rlp.allowed]
+    # TODO: Replace this ordering with future ordering method in
+    #  diffsims
+    g_order = np.argsort(rlp2.gspacing)
+    new_hkl = np.atleast_2d(rlp2._hkldata)[g_order]
+    rlp3 = ReciprocalLatticePoint(phase=rlp.phase, hkl=new_hkl)
+    hkl = np.atleast_2d(rlp3._hkldata)
+    families, families_idx = _get_hkl_family(hkl=hkl, reduce=True)
+
+    if color_cycle is None:
+        color_cycle = TSL_COLORS
+    n_families = len(families)
+    n_times = int(np.ceil(n_families / len(color_cycle)))
+    colors = (color_cycle * n_times)[:n_families]
+    colors = [mcolors.to_rgb(i) for i in colors]
+
+    hkl_colors = np.zeros(shape=(rlp3.size, 2, 3))
+    for hkl_idx, color in zip(families_idx.values(), colors):
+        hkl_colors[hkl_idx, 0] = hkl[hkl_idx]
+        hkl_colors[hkl_idx, 1] = color
+
+    return hkl_colors

--- a/kikuchipy/crystallography/_computations.py
+++ b/kikuchipy/crystallography/_computations.py
@@ -18,14 +18,20 @@
 
 """Crystallographic computations."""
 
-from kikuchipy.crystallography.matrices import (
-    get_direct_structure_matrix,
-    get_reciprocal_structure_matrix,
-    get_reciprocal_metric_tensor,
-)
+from typing import Union
 
-__all__ = [
-    "get_direct_structure_matrix",
-    "get_reciprocal_structure_matrix",
-    "get_reciprocal_metric_tensor",
-]
+import numpy as np
+
+
+def _get_uvw_from_hkl(hkl: Union[np.ndarray, list, tuple]) -> np.ndarray:
+    """Return a unique set of zone axes from the cross product of Miller
+    indices, without 000.
+    """
+    hkl = np.atleast_2d(hkl)
+    uvw = np.cross(hkl[:, np.newaxis, :], hkl).reshape((len(hkl) ** 2, 3))
+    not000 = np.count_nonzero(uvw, axis=1) != 0
+    uvw = uvw[not000]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        uvw = uvw / np.gcd.reduce(uvw, axis=1)[:, np.newaxis]
+    uvw = np.unique(uvw, axis=0).astype(int)
+    return uvw

--- a/kikuchipy/crystallography/matrices.py
+++ b/kikuchipy/crystallography/matrices.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Crystallographic matrices not computed in diffpy.structure."""
+
+from diffpy.structure import Lattice
+import numpy as np
+
+# TODO: Implement these in diffpy.structure (see
+#  https://github.com/diffpy/diffpy.structure/issues/46)
+
+
+def get_direct_structure_matrix(lattice: Lattice) -> np.ndarray:
+    """Direct structure matrix as defined in EMsoft.
+
+    Parameters
+    ----------
+    lattice
+        Crystal structure lattice.
+
+    Returns
+    -------
+    np.ndarray
+    """
+    a, b, c = lattice.abcABG()[:3]
+    ca, cb, cg = lattice.ca, lattice.cb, lattice.cg
+    sa, sb, sg = lattice.sa, lattice.sb, lattice.sg
+    return np.array(
+        [
+            [a, b * cg, c * cb],
+            [0, b * sg, -c * (cb * cg - ca) / sg],
+            [0, 0, lattice.volume / (a * b * sg)],
+        ]
+    )
+
+
+def get_reciprocal_structure_matrix(lattice: Lattice) -> np.ndarray:
+    """Reciprocal structure matrix as defined in EMsoft.
+
+    Parameters
+    ----------
+    lattice
+        Crystal structure lattice.
+
+    Returns
+    -------
+    np.ndarray
+    """
+    return np.linalg.inv(get_direct_structure_matrix(lattice)).T
+
+
+def get_reciprocal_metric_tensor(lattice: Lattice) -> np.ndarray:
+    """Reciprocal metric tensor as defined in EMsoft.
+
+    Parameters
+    ----------
+    lattice
+        Crystal structure lattice.
+
+    Returns
+    -------
+    np.ndarray
+    """
+    a, b, c = lattice.abcABG()[:3]
+    ca, cb, cg = lattice.ca, lattice.cb, lattice.cg
+    sa, sb, sg = lattice.sa, lattice.sb, lattice.sg
+    terms_12_21 = a * b * (c ** 2) * (ca * cb - cg)
+    terms_13_31 = a * (b ** 2) * c * (cg * ca - cb)
+    terms_23_32 = (a ** 2) * b * c * (cb * cg - ca)
+    return np.array(
+        [
+            [(b * c * sa) ** 2, terms_12_21, terms_13_31],
+            [terms_12_21, (a * c * sb) ** 2, terms_23_32],
+            [terms_13_31, terms_23_32, (a * b * sg) ** 2],
+        ]
+    ) / np.linalg.det(lattice.metrics)

--- a/kikuchipy/crystallography/matrices.py
+++ b/kikuchipy/crystallography/matrices.py
@@ -35,7 +35,6 @@ def get_direct_structure_matrix(lattice: Lattice) -> np.ndarray:
 
     Returns
     -------
-    np.ndarray
     """
     a, b, c = lattice.abcABG()[:3]
     ca, cb, cg = lattice.ca, lattice.cb, lattice.cg
@@ -59,7 +58,6 @@ def get_reciprocal_structure_matrix(lattice: Lattice) -> np.ndarray:
 
     Returns
     -------
-    np.ndarray
     """
     return np.linalg.inv(get_direct_structure_matrix(lattice)).T
 
@@ -74,7 +72,6 @@ def get_reciprocal_metric_tensor(lattice: Lattice) -> np.ndarray:
 
     Returns
     -------
-    np.ndarray
     """
     a, b, c = lattice.abcABG()[:3]
     ca, cb, cg = lattice.ca, lattice.cb, lattice.cg

--- a/kikuchipy/crystallography/tests/test_crystallographic_computations.py
+++ b/kikuchipy/crystallography/tests/test_crystallographic_computations.py
@@ -16,16 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-"""Crystallographic computations."""
+import numpy as np
+import pytest
 
-from kikuchipy.crystallography.matrices import (
-    get_direct_structure_matrix,
-    get_reciprocal_structure_matrix,
-    get_reciprocal_metric_tensor,
-)
+from kikuchipy.crystallography._computations import _get_uvw_from_hkl
 
-__all__ = [
-    "get_direct_structure_matrix",
-    "get_reciprocal_structure_matrix",
-    "get_reciprocal_metric_tensor",
-]
+
+class TestCrystallographicComputations:
+    @pytest.mark.parametrize(
+        "hkl, desired_uvw",
+        [
+            ([1, 1, 1], np.array([]).reshape((0, 3))),
+            ([[1, 1, 1], [2, 2, 2]], np.array([]).reshape((0, 3))),
+            ([[1, 1, 1], [1, 1, -1]], [[-1, 1, 0], [1, -1, 0]]),
+        ],
+    )
+    def test_get_uvw_from_hkl(self, hkl, desired_uvw):
+        """Desired uvw from the cross product of hkl."""
+        assert np.allclose(_get_uvw_from_hkl(hkl), desired_uvw)

--- a/kikuchipy/crystallography/tests/test_crystallographic_computations.py
+++ b/kikuchipy/crystallography/tests/test_crystallographic_computations.py
@@ -16,10 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from diffsims.crystallography import ReciprocalLatticePoint
+import matplotlib.colors as mcolors
 import numpy as np
 import pytest
+from orix.crystal_map import Phase
 
-from kikuchipy.crystallography._computations import _get_uvw_from_hkl
+from kikuchipy.crystallography._computations import (
+    _get_colors_for_allowed_bands,
+    _get_hkl_family,
+    _get_uvw_from_hkl,
+)
 
 
 class TestCrystallographicComputations:
@@ -34,3 +41,160 @@ class TestCrystallographicComputations:
     def test_get_uvw_from_hkl(self, hkl, desired_uvw):
         """Desired uvw from the cross product of hkl."""
         assert np.allclose(_get_uvw_from_hkl(hkl), desired_uvw)
+
+    @pytest.mark.parametrize(
+        (
+            "hkl, desired_family_keys, desired_family_values, desired_indices, "
+            "reduce"
+        ),
+        [
+            ([1, 1, 1], [[1, 1, 1]], [1, 1, 1], [0], False),
+            ([1, 1, 1], [[1, 1, 1]], [1, 1, 1], [0], True),
+            (
+                [[1, 1, 1], [2, 0, 0]],
+                [[1, 1, 1], [2, 0, 0]],
+                [[[1, 1, 1]], [[2, 0, 0]]],
+                [[0], [1]],
+                False,
+            ),
+            (
+                ReciprocalLatticePoint(
+                    phase=Phase(space_group=225), hkl=[1, 1, 1]
+                )
+                .symmetrise()
+                ._hkldata,
+                [1, 1, 1],
+                [
+                    [
+                        [1, 1, 1],
+                        [-1, 1, 1],
+                        [-1, -1, 1],
+                        [1, -1, 1],
+                        [1, -1, -1],
+                        [1, 1, -1],
+                        [-1, 1, -1],
+                        [-1, -1, -1],
+                    ]
+                ],
+                [np.arange(8)],
+                False,
+            ),
+            (
+                ReciprocalLatticePoint(
+                    phase=Phase(space_group=225), hkl=[[1, 1, 1], [2, 0, 0]]
+                )
+                .symmetrise()
+                ._hkldata,
+                [[1, 1, 1], [2, 0, 0]],
+                [
+                    [
+                        [1, 1, 1],
+                        [-1, 1, 1],
+                        [-1, -1, 1],
+                        [1, -1, 1],
+                        [1, -1, -1],
+                        [1, 1, -1],
+                        [-1, 1, -1],
+                        [-1, -1, -1],
+                    ],
+                    [
+                        [2, 0, 0],
+                        [0, 2, 0],
+                        [-2, 0, 0],
+                        [0, -2, 0],
+                        [0, 0, 2],
+                        [0, 0, -2],
+                    ],
+                ],
+                [np.arange(8).tolist(), np.arange(8, 14).tolist()],
+                False,
+            ),
+            (
+                ReciprocalLatticePoint(
+                    phase=Phase(space_group=225), hkl=[[1, 1, 1], [2, 2, 2]]
+                )
+                .symmetrise()
+                ._hkldata,
+                [1, 1, 1],
+                [
+                    [
+                        [1, 1, 1],
+                        [-1, 1, 1],
+                        [-1, -1, 1],
+                        [1, -1, 1],
+                        [1, -1, -1],
+                        [1, 1, -1],
+                        [-1, 1, -1],
+                        [-1, -1, -1],
+                        [2, 2, 2],
+                        [-2, 2, 2],
+                        [-2, -2, 2],
+                        [2, -2, 2],
+                        [2, -2, -2],
+                        [2, 2, -2],
+                        [-2, 2, -2],
+                        [-2, -2, -2],
+                    ]
+                ],
+                [np.arange(16)],
+                True,
+            ),
+        ],
+    )
+    def test_get_hkl_family(
+        self,
+        hkl,
+        desired_family_keys,
+        desired_family_values,
+        desired_indices,
+        reduce,
+    ):
+        """Desired sets of families and indices."""
+        families, families_idx = _get_hkl_family(hkl, reduce=reduce)
+
+        for i, (k, v) in enumerate(families.items()):
+            assert np.allclose(k, desired_family_keys[i])
+            assert np.allclose(v, desired_family_values[i])
+            assert np.allclose(families_idx[k], desired_indices[i])
+
+    @pytest.mark.parametrize(
+        "highest_hkl, color_cycle, desired_hkl_colors",
+        [
+            ([1, 1, 1], ["C0", "C1"], [[1, 1, 1], [0.12, 0.47, 0.71]]),
+            (
+                [2, 2, 2],
+                ["g", "b"],
+                [
+                    [[1, 1, 1], [0, 0.5, 0]],
+                    [[2, 0, 0], [0, 0, 1]],
+                    [[2, 2, 0], [0, 0.5, 0]],
+                    [[2, 2, 2], [0, 0.5, 0]],
+                ],
+            ),
+            (
+                [2, 2, 2],
+                None,
+                [
+                    [[1, 1, 1], [1, 0, 0]],
+                    [[2, 0, 0], [1, 1, 0]],
+                    [[2, 2, 0], [0, 1, 0]],
+                    [[2, 2, 2], [1, 0, 0]],
+                ],
+            ),
+        ],
+    )
+    def test_get_colors_for_allowed_bands(
+        self, nickel_phase, highest_hkl, color_cycle, desired_hkl_colors
+    ):
+        """Desired colors for bands."""
+        hkl_colors = _get_colors_for_allowed_bands(
+            phase=nickel_phase, highest_hkl=highest_hkl, color_cycle=color_cycle
+        )
+
+        assert np.allclose(hkl_colors, desired_hkl_colors, atol=1e-2)
+
+    def test_get_colors_for_allowed_bands_999(self, nickel_phase):
+        """Not passing `highest_hkl` works fine."""
+        hkl_colors = _get_colors_for_allowed_bands(phase=nickel_phase)
+
+        assert np.shape(hkl_colors) == (69, 2, 3)

--- a/kikuchipy/draw/__init__.py
+++ b/kikuchipy/draw/__init__.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-"""Create HyperSpy markers to add to signals."""
+"""Creation of HyperSpy markers to add to signals."""
 
-from kikuchipy.draw import markers
+from kikuchipy.draw import markers, colors
 
-__all__ = ["markers"]
+__all__ = ["markers", "colors"]

--- a/kikuchipy/draw/colors.py
+++ b/kikuchipy/draw/colors.py
@@ -19,9 +19,9 @@
 """Color palettes for Kikuchi bands."""
 
 import matplotlib.colors as mcolors
-import numpy as np
 
 
+# Kikuchi band color palette from EDAX TSL Data Collection version 7
 RED = (1, 0, 0)
 GREEN = (0, 1, 0)
 BLUE = (0, 0, 1)
@@ -49,84 +49,5 @@ TSL_COLORS = [
     DARKER_GREEN,
 ]
 
+# Matplotlib tableau color palette
 TABLEAU_COLORS = [mcolors.to_rgb(f"C{i}") for i in range(10)]
-
-# TSL Kikuchi band colors (custom names)
-# Don't know how to replicate this automatically, and it is too cumbersome (and
-# inelegant) to write down this list for all point groups. Will therefore leave
-# this list, with just the m-3m point group, as a reference, unused.
-_KIKUCHI_BAND_COLORS_TSL = {
-    "m-3m": np.array(
-        [
-            ([1, -1, -1], RED),
-            ([0, -2, 0], YELLOW),
-            ([0, -2, 2], GREEN),
-            ([1, -3, -1], BLUE),
-            ([2, -2, -2], RED),
-            ([0, -4, 0], YELLOW),
-            ([1, -3, -3], PINK),
-            ([0, -4, 2], CYAN),
-            ([2, -4, -2], BROWN),
-            ([1, -5, -1], DARK_GREEN),
-            ([3, -3, -3], RED),
-            ([0, -4, 4], GREEN),
-            ([1, -5, -3], PURPLE),
-            ([0, -6, 0], YELLOW),
-            ([2, -4, -4], DARK_BLUE),
-            #            ([6, 2, 0], ?),  # Jumped over this in the list??
-            ([3, -5, -3], GREEN),
-            ([2, -6, -2], BLUE),
-            ([4, -4, -4], RED),
-            ([1, -5, -5], RED),
-            ([1, -7, -1], YELLOW),
-            ([0, -6, 4], GREEN),
-            ([2, -6, -4], BLUE),
-            ([1, -7, -3], PINK),
-            ([3, -5, -5], CYAN),
-            ([0, -8, 0], YELLOW),
-            ([3, -7, -3], BROWN),
-            ([0, -8, 2], DARK_GREEN),
-            ([4, -6, -4], PURPLE),
-            ([0, -6, 6], GREEN),
-            ([2, -8, -2], DARK_BLUE),
-            ([5, -5, -5], RED),
-            ([1, -7, -5], EARTH),
-            ([2, -6, -6], PINK),
-            ([0, -8, 4], CYAN),
-            ([1, -9, -1], DARKER_GREEN),
-            ([3, -7, -5], RED),
-            ([2, -8, -4], YELLOW),
-            ([4, -6, -6], GREEN),
-            ([1, -9, -3], BLUE),
-            ([4, -8, -4], BROWN),
-            ([3, -9, -3], BLUE),
-            ([1, -7, -7], PINK),
-            ([5, -7, -5], CYAN),
-            ([0, -8, 6], BROWN),
-            ([2, -8, -6], DARK_GREEN),
-            ([3, -7, -7], PURPLE),
-            ([1, -9, -5], DARK_BLUE),
-            ([6, -6, -6], RED),
-            ([3, -9, -5], EARTH),
-            ([4, -8, -6], DARKER_GREEN),
-            ([5, -7, -7], RED),
-            ([0, -8, 8], GREEN),
-            ([5, -9, -5], YELLOW),
-            ([1, -9, -7], GREEN),
-            ([2, -8, -8], BLUE),
-            ([6, -8, -6], PINK),
-            ([3, -9, -7], CYAN),
-            ([4, -8, -8], DARK_BLUE),
-            ([7, -7, -7], RED),
-            ([5, -9, -7], BROWN),
-            ([1, -9, -9], DARK_GREEN),
-            ([6, -8, -8], PURPLE),
-            ([3, -9, -9], PINK),
-            ([7, -9, -7], DARK_BLUE),
-            ([5, -9, -9], EARTH),
-            ([8, -8, -8], RED),
-            ([7, -9, -9], DARKER_GREEN),
-            ([9, -9, -9], RED),
-        ],
-    )
-}

--- a/kikuchipy/draw/colors.py
+++ b/kikuchipy/draw/colors.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-"""Color palettes for Kikuchi bands."""
+"""Color palettes for plotting Kikuchi bands."""
 
 # Kikuchi band color palette from EDAX TSL Data Collection version 7
 RED = (1, 0, 0)

--- a/kikuchipy/draw/colors.py
+++ b/kikuchipy/draw/colors.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Color palettes for Kikuchi bands."""
+
+import numpy as np
+
+
+# TSL Kikuchi band colors (custom names)
+RED = (1, 0, 0)
+GREEN = (0, 1, 0)
+BLUE = (0, 0, 1)
+YELLOW = (1.0, 1, 0)
+CYAN = (0, 1, 1)
+PINK = (1, 0, 1)
+BROWN = (0.5, 0, 0)
+EARTH = (0.5, 0.5, 0)
+PURPLE = (0.5, 0, 0.5)
+DARK_GREEN = (0, 0.5, 0)
+DARKER_GREEN = (0, 0.5, 0.5)
+DARK_BLUE = (0, 0, 0.5)
+# TODO: More colors!
+KIKUCHI_BAND_COLORS_TSL = {
+    "m-3m": np.array(
+        [
+            ([1, -1, -1], RED),
+            ([0, -2, 0], YELLOW),
+            ([0, -2, 2], GREEN),
+            ([1, -3, -1], BLUE),
+            ([2, -2, -2], RED),
+            ([0, -4, 0], YELLOW),
+            ([1, -3, -3], PINK),
+            ([0, -4, 2], CYAN),
+            ([2, -4, -2], BROWN),
+            ([1, -5, -1], DARK_GREEN),
+            ([3, -3, -3], RED),
+            ([0, -4, 4], GREEN),
+            ([1, -5, -3], PURPLE),
+            ([2, -4, -4], DARK_BLUE),
+            ([0, -6, 0], YELLOW),
+            ([3, -5, -3], GREEN),
+            ([2, -6, -2], BLUE),
+            ([4, -4, -4], RED),
+            ([1, -5, -5], RED),
+            ([1, -7, -1], YELLOW),
+            ([0, -6, 4], GREEN),
+            ([2, -6, -4], BLUE),
+            ([1, -7, -3], PINK),
+            ([3, -5, -5], CYAN),
+            ([0, -8, 0], YELLOW),
+            ([3, -7, -3], BROWN),
+            ([0, -8, 2], DARK_GREEN),
+            ([4, -6, -4], PURPLE),
+            ([0, -6, 6], GREEN),
+            ([2, -8, -2], DARK_BLUE),
+            ([5, -5, -5], RED),
+            ([1, -7, -5], EARTH),
+            ([2, -6, -6], PINK),
+            ([0, -8, 4], CYAN),
+            ([1, -9, -1], DARKER_GREEN),
+            ([3, -7, -5], RED),
+            ([2, -8, -4], YELLOW),
+            ([4, -6, -6], GREEN),
+            ([1, -9, -3], BLUE),
+            ([4, -8, -4], BROWN),
+            ([3, -9, -3], BLUE),
+            ([1, -7, -7], PINK),
+            ([5, -7, -5], CYAN),
+            ([0, -8, 6], BROWN),
+            ([2, -8, -6], DARK_GREEN),
+            ([3, -7, -7], PURPLE),
+            ([1, -9, -5], DARK_BLUE),
+            ([6, -6, -6], RED),
+            ([3, -9, -5], EARTH),
+            ([4, -8, -6], DARKER_GREEN),
+            ([5, -7, -7], RED),
+            ([0, -8, 8], GREEN),
+            ([5, -9, -5], YELLOW),
+            ([1, -9, -7], GREEN),
+            ([2, -8, -8], BLUE),
+            ([6, -8, -6], PINK),
+            ([3, -9, -7], CYAN),
+            ([4, -8, -8], DARK_BLUE),
+            ([7, -7, -7], RED),
+            ([5, -9, -7], BROWN),
+            ([1, -9, -9], DARK_GREEN),
+            ([6, -8, -8], PURPLE),
+            ([3, -9, -9], PINK),
+            ([7, -9, -7], DARK_BLUE),
+            ([5, -9, -9], EARTH),
+            ([8, -8, -8], RED),
+            ([7, -9, -9], DARKER_GREEN),
+            ([9, -9, -9], RED),
+        ],
+    )
+}

--- a/kikuchipy/draw/colors.py
+++ b/kikuchipy/draw/colors.py
@@ -18,14 +18,14 @@
 
 """Color palettes for Kikuchi bands."""
 
+import matplotlib.colors as mcolors
 import numpy as np
 
 
-# TSL Kikuchi band colors (custom names)
 RED = (1, 0, 0)
 GREEN = (0, 1, 0)
 BLUE = (0, 0, 1)
-YELLOW = (1.0, 1, 0)
+YELLOW = (1, 1, 0)
 CYAN = (0, 1, 1)
 PINK = (1, 0, 1)
 BROWN = (0.5, 0, 0)
@@ -34,8 +34,28 @@ PURPLE = (0.5, 0, 0.5)
 DARK_GREEN = (0, 0.5, 0)
 DARKER_GREEN = (0, 0.5, 0.5)
 DARK_BLUE = (0, 0, 0.5)
-# TODO: More colors!
-KIKUCHI_BAND_COLORS_TSL = {
+TSL_COLORS = [
+    RED,
+    YELLOW,
+    GREEN,
+    BLUE,
+    PINK,
+    CYAN,
+    BROWN,
+    DARK_GREEN,
+    PURPLE,
+    DARK_BLUE,
+    EARTH,
+    DARKER_GREEN,
+]
+
+TABLEAU_COLORS = [mcolors.to_rgb(f"C{i}") for i in range(10)]
+
+# TSL Kikuchi band colors (custom names)
+# Don't know how to replicate this automatically, and it is too cumbersome (and
+# inelegant) to write down this list for all point groups. Will therefore leave
+# this list, with just the m-3m point group, as a reference, unused.
+_KIKUCHI_BAND_COLORS_TSL = {
     "m-3m": np.array(
         [
             ([1, -1, -1], RED),
@@ -51,8 +71,9 @@ KIKUCHI_BAND_COLORS_TSL = {
             ([3, -3, -3], RED),
             ([0, -4, 4], GREEN),
             ([1, -5, -3], PURPLE),
-            ([2, -4, -4], DARK_BLUE),
             ([0, -6, 0], YELLOW),
+            ([2, -4, -4], DARK_BLUE),
+            #            ([6, 2, 0], ?),  # Jumped over this in the list??
             ([3, -5, -3], GREEN),
             ([2, -6, -2], BLUE),
             ([4, -4, -4], RED),

--- a/kikuchipy/draw/markers.py
+++ b/kikuchipy/draw/markers.py
@@ -38,7 +38,7 @@ def get_line_segment_list(lines: Union[list, np.ndarray], **kwargs) -> list:
         List of :class:`hyperspy.utils.markers.line_segment`.
     """
     lines = np.asarray(lines)
-    if lines.ndim == 1:
+    if lines.ndim == 1:  # No navigation shape, one line
         lines = lines[np.newaxis, ...]
 
     marker_list = []
@@ -83,7 +83,9 @@ def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
 
 
 def get_text_list(
-    texts: Union[list, np.ndarray], coordinates: np.ndarray, **kwargs,
+    texts: Union[list, np.ndarray],
+    coordinates: Union[np.ndarray, list],
+    **kwargs,
 ) -> list:
     """Return a list of text markers.
 
@@ -109,21 +111,22 @@ def get_text_list(
     is_finite = np.isfinite(coordinates)[..., 0]
     coordinates[~is_finite] = -1
     for i in range(coordinates.shape[-2]):  # Iterate over zone axes
-        x = coordinates[..., i, 0]
-        y = coordinates[..., i, 1]
-        x[~is_finite[..., i]] = np.nan
-        y[~is_finite[..., i]] = np.nan
-        text_marker = text(x=x, y=y, text=texts[i], **kwargs,)
-        # TODO: Pass "visible" parameter to text() when HyperSpy allows
-        #  it (merges this PR
-        #  https://github.com/hyperspy/hyperspy/pull/2558 and publishes
-        #  a minor release with that update)
-        # text_marker = text(
-        #     x=coordinates[..., i, 0],
-        #     y=coordinates[..., i, 1],
-        #     text=texts[i],
-        #     visible=is_finite[..., i],
-        #     **kwargs
-        # )
-        marker_list.append(text_marker)
+        if not np.allclose(coordinates[..., i, :], -1):  # All NaNs
+            x = coordinates[..., i, 0]
+            y = coordinates[..., i, 1]
+            x[~is_finite[..., i]] = np.nan
+            y[~is_finite[..., i]] = np.nan
+            text_marker = text(x=x, y=y, text=texts[i], **kwargs,)
+            # TODO: Pass "visible" parameter to text() when HyperSpy allows
+            #  it (merges this PR
+            #  https://github.com/hyperspy/hyperspy/pull/2558 and publishes
+            #  a minor release with that update)
+            # text_marker = text(
+            #     x=coordinates[..., i, 0],
+            #     y=coordinates[..., i, 1],
+            #     text=texts[i],
+            #     visible=is_finite[..., i],
+            #     **kwargs
+            # )
+            marker_list.append(text_marker)
     return marker_list

--- a/kikuchipy/draw/markers.py
+++ b/kikuchipy/draw/markers.py
@@ -62,7 +62,7 @@ def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
     points
         On the form [[x0, y0], [x1, y1], ...].
     kwargs
-        Keyword arguments allowed by :class:`matplotlib.pyplot.axvline`.
+        Keyword arguments allowed by :class:`matplotlib.pyplot.scatter`.
 
     Returns
     -------

--- a/kikuchipy/draw/markers.py
+++ b/kikuchipy/draw/markers.py
@@ -30,12 +30,13 @@ def get_line_segment_list(lines: Union[list, np.ndarray], **kwargs) -> list:
     lines
         On the form [[x00, y00, x01, y01], [x10, y10, x11, y11], ...].
     kwargs
-        Keyword arguments allowed by :class:`matplotlib.pyplot.axvline`.
+        Keyword arguments allowed by :func:`matplotlib.pyplot.axvline`.
 
     Returns
     -------
-    marker_list
-        List of :class:`hyperspy.utils.markers.line_segment`.
+    marker_list : list
+        List of
+        :class:`hyperspy.drawing._markers.line_segment.LineSegment`.
     """
     lines = np.asarray(lines)
     if lines.ndim == 1:  # No navigation shape, one line
@@ -62,12 +63,12 @@ def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
     points
         On the form [[x0, y0], [x1, y1], ...].
     kwargs
-        Keyword arguments allowed by :class:`matplotlib.pyplot.scatter`.
+        Keyword arguments allowed by :func:`matplotlib.pyplot.scatter`.
 
     Returns
     -------
-    marker_list
-        List of :class:`hyperspy.utils.markers.point`.
+    marker_list : list
+        List of :class:`hyperspy.drawing._markers.point.Point`.
     """
     points = np.asarray(points)
     if points.ndim == 1:
@@ -96,12 +97,12 @@ def get_text_list(
     coordinates
         On the form [[x0, y0], [x1, y1], ...].
     kwargs
-        Keyword arguments allowed by :class:`matplotlib.pyplot.axvline.`
+        Keyword arguments allowed by :func:`matplotlib.pyplot.axvline.`
 
     Returns
     -------
-    marker_list
-        List of :class:`hyperspy.utils.markers.text`.
+    marker_list : list
+        List of :class:`hyperspy.drawing._markers.text.Text`.
     """
     coordinates = np.asarray(coordinates)
     if coordinates.ndim == 1:

--- a/kikuchipy/draw/tests/test_colors.py
+++ b/kikuchipy/draw/tests/test_colors.py
@@ -16,32 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-"""Color palettes for Kikuchi bands."""
+import matplotlib.colors as mcolors
 
-# Kikuchi band color palette from EDAX TSL Data Collection version 7
-RED = (1, 0, 0)
-GREEN = (0, 1, 0)
-BLUE = (0, 0, 1)
-YELLOW = (1, 1, 0)
-CYAN = (0, 1, 1)
-PINK = (1, 0, 1)
-BROWN = (0.5, 0, 0)
-EARTH = (0.5, 0.5, 0)
-PURPLE = (0.5, 0, 0.5)
-DARK_GREEN = (0, 0.5, 0)
-DARKER_GREEN = (0, 0.5, 0.5)
-DARK_BLUE = (0, 0, 0.5)
-TSL_COLORS = [
-    RED,
-    YELLOW,
-    GREEN,
-    BLUE,
-    PINK,
-    CYAN,
-    BROWN,
-    DARK_GREEN,
-    PURPLE,
-    DARK_BLUE,
-    EARTH,
-    DARKER_GREEN,
-]
+from kikuchipy.draw.colors import TSL_COLORS
+
+
+class TestColors:
+    def test_tsl_colors(self):
+        assert isinstance(TSL_COLORS, list)
+        assert len(TSL_COLORS) == 12
+        for c in TSL_COLORS:
+            assert len(c) == 3
+            assert isinstance(c, tuple)
+            assert mcolors.is_color_like(c)

--- a/kikuchipy/draw/tests/test_markers.py
+++ b/kikuchipy/draw/tests/test_markers.py
@@ -16,6 +16,293 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from hyperspy.utils.markers import line_segment, point, text
+import numpy as np
+import pytest
+
+from kikuchipy.draw.markers import (
+    get_line_segment_list,
+    get_point_list,
+    get_text_list,
+)
+
 
 class TestMarkers:
-    pass
+    @pytest.mark.parametrize("n_lines", [1, 2, 3])
+    def test_get_line_segment_list0d(self, n_lines):
+        """Lines in 0D () navigation space."""
+        nav_shape = ()
+        size = int(np.prod(nav_shape) * n_lines * 4)
+        lines = np.random.random(size=size).reshape(nav_shape + (n_lines, 4))
+        kwargs = dict(linewidth=1, color="red", alpha=1, zorder=1)
+        line_markers = get_line_segment_list(list(lines), **kwargs)
+
+        # Number of markers
+        assert isinstance(line_markers, list)
+        assert len(line_markers) == n_lines
+        assert isinstance(line_markers[0], line_segment)
+
+        # Coordinates, data shape and marker properties
+        for line, marker in zip(lines, line_markers):
+            assert np.allclose(
+                [
+                    marker.get_data_position("x1"),
+                    marker.get_data_position("y1"),
+                    marker.get_data_position("x2"),
+                    marker.get_data_position("y2"),
+                ],
+                line,
+            )
+            assert marker._get_data_shape() == nav_shape
+            for k, v in kwargs.items():
+                assert marker.marker_properties[k] == v
+
+    def test_get_line_segment_0d_2(self):
+        """A line in 0d but no (1,) navigation shape."""
+        lines = np.random.random(size=4).reshape((4,))
+        line_markers = get_line_segment_list(lines)
+
+        assert len(line_markers) == 1
+        assert np.allclose(
+            [
+                line_markers[0].get_data_position("x1"),
+                line_markers[0].get_data_position("y1"),
+                line_markers[0].get_data_position("x2"),
+                line_markers[0].get_data_position("y2"),
+            ],
+            lines,
+        )
+
+    def test_get_line_segment_list1d(self):
+        """Lines in 1D (2,) navigation space."""
+        nav_shape = (2,)
+        n_lines = 2
+        size = int(np.prod(nav_shape) * n_lines * 4)
+        lines = np.random.random(size=size).reshape(nav_shape + (n_lines, 4))
+        line_markers = get_line_segment_list(lines)
+
+        assert len(line_markers) == n_lines
+
+        # Iterate over lines
+        for i in range(n_lines):
+            assert line_markers[i]._get_data_shape() == nav_shape  # 1d
+            assert np.allclose(
+                np.dstack(line_markers[i].data.tolist()[:4]), lines[:, i],
+            )
+
+    def test_get_line_segment_list2d(self):
+        """Lines in 2D (2, 3) navigation space."""
+        nav_shape = (2, 3)
+        n_lines = 3
+        size = int(np.prod(nav_shape) * n_lines * 4)
+        lines = np.random.random(size=size).reshape(nav_shape + (n_lines, 4))
+        line_markers = get_line_segment_list(lines)
+
+        assert len(line_markers) == n_lines
+
+        # Iterate over lines
+        for i in range(n_lines):
+            assert line_markers[i]._get_data_shape() == nav_shape
+            assert np.allclose(
+                np.dstack(line_markers[i].data.tolist()[:4]), lines[:, :, i],
+            )
+
+    def test_get_line_segment_list_nans(self):
+        lines = np.ones((2, 3, 4)) * np.nan
+        assert len(get_line_segment_list(lines)) == 0
+
+    @pytest.mark.parametrize("n_points", [1, 2, 3])
+    def test_get_point_list0d(self, n_points):
+        """Points in 0D () navigation space."""
+        nav_shape = ()
+        size = int(np.prod(nav_shape) * n_points * 2)
+        points = np.random.random(size=size).reshape(nav_shape + (n_points, 2))
+        kwargs = dict(
+            s=40, marker="o", facecolor="w", edgecolor="k", zorder=5, alpha=1
+        )
+        point_markers = get_point_list(list(points), **kwargs)
+
+        # Number of markers
+        assert isinstance(point_markers, list)
+        assert len(point_markers) == n_points
+        assert isinstance(point_markers[0], point)
+
+        # Coordinates, data shape and marker properties
+        for i, marker in zip(points, point_markers):
+            assert np.allclose(
+                [
+                    marker.get_data_position("x1"),
+                    marker.get_data_position("y1"),
+                ],
+                i,
+            )
+            assert marker._get_data_shape() == nav_shape
+            for k, v in kwargs.items():
+                assert marker.marker_properties[k] == v
+
+    def test_get_point_list0d_2(self):
+        """One point in 0d but no (1,) navigation shape."""
+        points = np.random.random(size=2).reshape((2,))
+        point_marker = get_point_list(points)
+
+        assert len(point_marker) == 1
+        assert np.allclose(
+            [
+                point_marker[0].get_data_position("x1"),
+                point_marker[0].get_data_position("y1"),
+            ],
+            points,
+        )
+
+    def test_get_point_list1d(self):
+        """Points in 1D (2,) navigation space."""
+        nav_shape = (2,)
+        n_points = 2
+        size = int(np.prod(nav_shape) * n_points * 2)
+        points = np.random.random(size=size).reshape(nav_shape + (n_points, 2))
+        point_markers = get_point_list(points)
+
+        assert len(point_markers) == n_points
+
+        # Iterate over points
+        for i in range(n_points):
+            assert point_markers[i]._get_data_shape() == nav_shape  # 1d
+            assert np.allclose(
+                np.dstack(point_markers[i].data.tolist()[:2]), points[:, i],
+            )
+
+    def test_get_point_list2d(self):
+        """Points in 2D (2, 3) navigation space."""
+        nav_shape = (2, 3)
+        n_points = 3
+        size = int(np.prod(nav_shape) * n_points * 2)
+        points = np.random.random(size=size).reshape(nav_shape + (n_points, 2))
+        point_markers = get_point_list(points)
+
+        assert len(point_markers) == n_points
+
+        # Iterate over points
+        for i in range(n_points):
+            assert point_markers[i]._get_data_shape() == nav_shape
+            assert np.allclose(
+                np.dstack(point_markers[i].data.tolist()[:2]), points[:, :, i],
+            )
+
+    def test_get_point_list_nans(self):
+        points = np.ones((2, 3, 2)) * np.nan
+        assert len(get_point_list(points)) == 0
+
+    @pytest.mark.parametrize("n_labels", [1, 2, 3])
+    def test_get_text_list0d(self, n_labels):
+        """Text labels in 0D () navigation space."""
+        nav_shape = ()
+        size = int(np.prod(nav_shape) * n_labels * 2)
+        texts = ["111", "220", "-220"][:n_labels]
+        text_coords = np.random.random(size=size).reshape(
+            nav_shape + (n_labels, 2)
+        )
+        kwargs = dict(
+            color="k",
+            zorder=5,
+            ha="center",
+            bbox=dict(
+                facecolor="w",
+                edgecolor="k",
+                boxstyle="round, rounding_size=0.2",
+                pad=0.1,
+                alpha=0.1,
+            ),
+        )
+        text_markers = get_text_list(
+            texts=texts, coordinates=list(text_coords), **kwargs
+        )
+
+        # Number of markers
+        assert isinstance(text_markers, list)
+        assert len(text_markers) == n_labels
+        assert isinstance(text_markers[0], text)
+
+        # Coordinates, data shape and marker properties
+        for i, (t, marker) in enumerate(zip(text_coords, text_markers)):
+            assert np.allclose(
+                [
+                    marker.get_data_position("x1"),
+                    marker.get_data_position("y1"),
+                ],
+                t,
+            )
+            assert marker.get_data_position("text") == texts[i]
+            assert marker._get_data_shape() == nav_shape
+            for k, v in kwargs.items():
+                assert marker.marker_properties[k] == v
+
+    def test_get_text_list0d_2(self):
+        """One text label in 0d but no (1,) navigation shape."""
+        text_coords = np.random.random(size=2).reshape((2,))
+        texts = ["123"]
+        text_markers = get_text_list(texts=texts, coordinates=text_coords)
+
+        assert len(text_markers) == 1
+        assert np.allclose(
+            [
+                text_markers[0].get_data_position("x1"),
+                text_markers[0].get_data_position("y1"),
+            ],
+            text_coords,
+        )
+        assert text_markers[0].get_data_position("text") == texts[0]
+
+    def test_get_text_list1d(self):
+        """Text labels in 1D (2,) navigation space."""
+        nav_shape = (2,)
+        n_labels = 2
+        size = int(np.prod(nav_shape) * n_labels * 2)
+        texts = ["111", "-220"]
+        text_coords = np.random.random(size=size).reshape(
+            nav_shape + (n_labels, 2)
+        )
+        text_markers = get_text_list(texts=texts, coordinates=text_coords)
+
+        assert len(text_markers) == n_labels
+
+        # Iterate over text labels
+        for i in range(n_labels):
+            assert text_markers[i]._get_data_shape() == nav_shape
+            assert np.allclose(
+                np.dstack(text_markers[i].data.tolist()[:2]), text_coords[:, i],
+            )
+            assert text_markers[i].data["text"] == texts[i]
+
+    def test_get_text_list2d(self):
+        """Text labels in 2D (2, 3) navigation space."""
+        nav_shape = (2, 3)
+        n_labels = 3
+        size = int(np.prod(nav_shape) * n_labels * 2)
+        texts = ["111", "-2-20", "311"]
+        text_coords = np.random.random(size=size).reshape(
+            nav_shape + (n_labels, 2)
+        )
+        text_markers = get_text_list(texts=texts, coordinates=text_coords)
+
+        assert len(text_markers) == n_labels
+
+        # Iterate over text labels
+        for i in range(n_labels):
+            assert text_markers[i]._get_data_shape() == nav_shape
+            assert np.allclose(
+                np.dstack(text_markers[i].data.tolist()[:2]),
+                text_coords[:, :, i],
+            )
+            assert text_markers[i].data["text"] == texts[i]
+
+    def test_get_text_list_nans(self):
+        """Returns"""
+        text_coords = np.ones((2, 3, 2)) * np.nan
+        assert (
+            len(
+                get_text_list(
+                    texts=["111", "200", "220"], coordinates=text_coords
+                )
+            )
+            == 0
+        )

--- a/kikuchipy/generators/ebsd_simulation_generator.py
+++ b/kikuchipy/generators/ebsd_simulation_generator.py
@@ -151,7 +151,7 @@ class EBSDSimulationGenerator:
 
         Parameters
         ----------
-        reciprocal_lattice_point :
+        reciprocal_lattice_point
             Crystal planes to project onto the detector. If None, and
             the generator has a phase with a unit cell with a point
             group, a set of planes with minimum distance of 1 Å and

--- a/kikuchipy/generators/ebsd_simulation_generator.py
+++ b/kikuchipy/generators/ebsd_simulation_generator.py
@@ -143,8 +143,10 @@ class EBSDSimulationGenerator:
     def geometrical_simulation(
         self, reciprocal_lattice_point: Optional[ReciprocalLatticePoint] = None
     ) -> GeometricalEBSDSimulation:
-        """Project a set of center positions of Kikuchi bands on the
+        """Project a set of Kikuchi bands and zone axes onto the
         detector, one set for each rotation of the unit cell.
+
+        The zone axes are calculated from the Kikuchi bands.
 
         Parameters
         ----------

--- a/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
+++ b/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
@@ -256,7 +256,7 @@ class TestEBSDSimulationGenerator:
         )
         assert np.allclose(bands.gnomonic_radius, simgen[:2].detector.r_max)
 
-    def test_get_coordinates_in_upper_hemisphere_1d(self):
+    def test_get_coordinates_in_upper_hemisphere_2d(self):
         """Coordinates are considered correctly whether to be in the
         upper hemisphere and visible in a point (pattern).
         """
@@ -267,8 +267,10 @@ class TestEBSDSimulationGenerator:
                 [[[1, 2, -3], [1, 2, 3]], [[1, 2, 1e-3], [1, 2, -3]]],
             ]
         )
+        n_nav_dims = 2
+        navigation_axes = (1, 2)[:n_nav_dims]
         is_upper, in_a_point = _get_coordinates_in_upper_hemisphere(
-            z_coordinates=coords[..., 2], navigation_axes=(1, 2)
+            z_coordinates=coords[..., 2], navigation_axes=navigation_axes
         )
         assert np.allclose(
             is_upper,
@@ -276,15 +278,32 @@ class TestEBSDSimulationGenerator:
         )
         assert np.allclose(in_a_point, [False, True])
 
-    def test_get_coordinates_in_upper_hemisphere_2d(self):
+    def test_get_coordinates_in_upper_hemisphere_1d(self):
         """Coordinates are considered correctly whether to be in the
         upper hemisphere and visible in a point (pattern).
         """
         # Shape (2, 2, 3): (n bands/zone axes, i, xyz)
         coords = np.array([[[1, 2, -1], [1, 2, -2]], [[1, 2, -3], [1, 2, 3]]])
+        n_nav_dims = 1
+        navigation_axes = (1, 2)[:n_nav_dims]
         is_upper, in_a_point = _get_coordinates_in_upper_hemisphere(
-            z_coordinates=coords[..., 2], navigation_axes=(1,)
+            z_coordinates=coords[..., 2], navigation_axes=navigation_axes
         )
 
         assert np.allclose(is_upper, [[False, False], [False, True]])
+        assert np.allclose(in_a_point, [False, True])
+
+    def test_get_coordinates_in_upper_hemisphere_0d(self):
+        """Coordinates are considered correctly whether to be in the
+        upper hemisphere and visible in a point (pattern).
+        """
+        # Shape (2, 3): (n bands/zone axes, xyz)
+        coords = np.array([[1, 2, -1], [1, 2, 2]])
+        n_nav_dims = 0
+        navigation_axes = (1, 2)[:n_nav_dims]
+        is_upper, in_a_point = _get_coordinates_in_upper_hemisphere(
+            z_coordinates=coords[..., 2], navigation_axes=navigation_axes
+        )
+
+        assert np.allclose(is_upper, [False, True])
         assert np.allclose(in_a_point, [False, True])

--- a/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
+++ b/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
@@ -163,7 +163,7 @@ class TestEBSDSimulationGenerator:
         simgen2.detector.pc[0] = new_pc
         assert not np.allclose(simgen[nav_idx].detector.pc, simgen2.detector.pc)
 
-    def test_geometrical_simulation(
+    def test_geometrical_simulation2d(
         self, nickel_ebsd_simulation_generator, nickel_rlp,
     ):
         """Desired output EBSDGeometricalSimulation object."""
@@ -183,6 +183,43 @@ class TestEBSDSimulationGenerator:
 
         sim2 = simgen.geometrical_simulation()
         assert sim2.bands.size == 132
+
+    def test_geometrical_simulation1d(
+        self, nickel_ebsd_simulation_generator, nickel_rlp,
+    ):
+        """Geometrical EBSD simulations handle 1d."""
+        simgen = nickel_ebsd_simulation_generator[:5]
+
+        rlp = nickel_rlp[nickel_rlp.allowed].symmetrise()
+        assert rlp.size == 26
+
+        sim1 = simgen.geometrical_simulation(rlp)
+        assert np.allclose(sim1.detector.pc, simgen.detector.pc)
+        assert np.allclose(
+            sim1.bands.phase.point_group.data, simgen.phase.point_group.data
+        )
+        assert np.allclose(sim1.rotations.data, simgen.rotations.data)
+        assert sim1.bands.navigation_shape == (5,)
+        assert sim1.bands.size == 15
+
+    def test_geometrical_simulation0d(
+        self, nickel_ebsd_simulation_generator, nickel_rlp,
+    ):
+        """Geometrical EBSD simulations handle 0d."""
+        simgen = nickel_ebsd_simulation_generator[0]
+        simgen.navigation_shape = ()
+
+        rlp = nickel_rlp[nickel_rlp.allowed].symmetrise()
+        assert rlp.size == 26
+
+        sim1 = simgen.geometrical_simulation(rlp)
+        assert np.allclose(sim1.detector.pc, simgen.detector.pc)
+        assert np.allclose(
+            sim1.bands.phase.point_group.data, simgen.phase.point_group.data
+        )
+        assert np.allclose(sim1.rotations.data, simgen.rotations.data)
+        assert sim1.bands.navigation_shape == ()
+        assert sim1.bands.size == 13
 
     def test_geometrical_simulation_raises(
         self, nickel_ebsd_simulation_generator,

--- a/kikuchipy/projections/ebsd_projections.py
+++ b/kikuchipy/projections/ebsd_projections.py
@@ -17,7 +17,8 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 """Rotations to align the EBSD detector with the tilted sample. Notation
-from [Britton2016]_."""
+from [Britton2016]_.
+"""
 
 from diffpy.structure import Lattice
 import numpy as np

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -90,13 +90,13 @@ class EBSD(CommonImage, Signal2D):
         """
         Signal2D.__init__(self, *args, **kwargs)
 
-        if "detector_dict" in kwargs:
-            self.detector = EBSDDetector(kwargs.pop("detector_dict"))
-        else:
-            self.detector = EBSDDetector(
-                shape=self.axes_manager.signal_shape,
-                px_size=self.axes_manager.signal_axes[0].scale,
-            )
+        #        if "detector_dict" in kwargs:
+        #            self.detector = EBSDDetector(kwargs.pop("detector_dict"))
+        #        else:
+        self.detector = EBSDDetector(
+            shape=self.axes_manager.signal_shape,
+            px_size=self.axes_manager.signal_axes[0].scale,
+        )
 
         if "xmap" in kwargs:
             self._xmap = kwargs.pop("xmap")

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -320,7 +320,7 @@ class EBSD(CommonImage, Signal2D):
         """
         # Ensure atom coordinates are numpy arrays
         if atom_coordinates is not None:
-            for phase, val in atom_coordinates.items():
+            for phase, _ in atom_coordinates.items():
                 atom_coordinates[phase]["coordinates"] = np.array(
                     atom_coordinates[phase]["coordinates"]
                 )
@@ -1345,7 +1345,7 @@ class EBSD(CommonImage, Signal2D):
             else:
                 raise ValueError("Filename not defined.")
         if extension is not None:
-            basename, ext = os.path.splitext(filename)
+            basename, _ = os.path.splitext(filename)
             filename = basename + "." + extension
         _save(filename, self, overwrite=overwrite, **kwargs)
 

--- a/kikuchipy/simulations/features.py
+++ b/kikuchipy/simulations/features.py
@@ -32,9 +32,9 @@ class KikuchiBand(ReciprocalLatticePoint):
     def __init__(
         self,
         phase: Phase,
-        hkl: Union[Vector3d, np.ndarray],
-        hkl_detector: Union[Vector3d, np.ndarray],
-        in_pattern: np.ndarray,
+        hkl: Union[Vector3d, np.ndarray, tuple],
+        hkl_detector: Union[Vector3d, np.ndarray, list, tuple],
+        in_pattern: Union[np.ndarray, list, tuple],
         gnomonic_radius: Union[float, np.ndarray] = 10,
     ):
         """Center positions of Kikuchi bands on the detector for n
@@ -92,7 +92,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         """
         super().__init__(phase=phase, hkl=hkl)
         self._hkl_detector = Vector3d(hkl_detector)
-        self._in_pattern = in_pattern
+        self._in_pattern = np.asarray(in_pattern)
         self.gnomonic_radius = gnomonic_radius
 
     @property
@@ -316,8 +316,8 @@ class ZoneAxis(ReciprocalLatticePoint):
         self,
         phase: Phase,
         uvw: Union[Vector3d, np.ndarray, list, tuple],
-        uvw_detector: np.ndarray,
-        in_pattern: np.ndarray,
+        uvw_detector: Union[Vector3d, np.ndarray, list, tuple],
+        in_pattern: Union[np.ndarray, list, tuple],
         gnomonic_radius: Union[float, np.ndarray] = 10,
     ):
         """Positions of zone axes on the detector.
@@ -341,7 +341,7 @@ class ZoneAxis(ReciprocalLatticePoint):
         """
         super().__init__(phase=phase, hkl=uvw)
         self._uvw_detector = Vector3d(uvw_detector)
-        self._in_pattern = in_pattern
+        self._in_pattern = np.asarray(in_pattern)
         self.gnomonic_radius = gnomonic_radius
 
     @property

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -46,12 +46,12 @@ class GeometricalEBSDSimulation:
         self,
         detector: EBSDDetector,
         rotations: Rotation,
-        bands: Optional[KikuchiBand] = None,
-        zone_axes: Optional[ZoneAxis] = None,
+        bands: KikuchiBand,
+        zone_axes: ZoneAxis,
     ):
         """Create a geometrical EBSD simulation storing a set of center
-        positions of Kikuchi bands on the detector, one set for each
-        orientation of the unit cell.
+        positions of Kikuchi bands and zone axes on the detector, one
+        set for each orientation of the unit cell.
 
         Parameters
         ----------
@@ -82,8 +82,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         band_coords
-            On the form [[x00, y00, x01, y01], [x10, y10, x11, y11],
-            ...].
+            Band coordinates on the detector.
         """
         # Get start and end points for the plane traces in gnomonic coordinates
         # and set up output array in uncalibrated detector coordinates
@@ -111,10 +110,14 @@ class GeometricalEBSDSimulation:
         """Coordinates of zone axes in uncalibrated detector
         coordinates.
 
+        If `GeometricalEBSDSimulation.exclude_outside_detector` is True,
+        the coordinates of the zone axes outside the detector are set to
+        `np.nan`.
+
         Returns
         -------
         za_coords
-            Column sorted, on the form [[x0, y0], [x1, y1], ...].
+            Zone axis coordinates on the detector.
         """
         xyg = self.zone_axes._xy_within_gnomonic_radius
         xg = xyg[..., 0]
@@ -148,7 +151,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         np.ndarray
-            Column sorted, on the form [[x0, y0], [x1, y1], ...].
+            Zone axes labels placed just above the zone axes.
         """
         za_coords = self.zone_axes_detector_coordinates
         za_coords[..., 1] -= 0.02 * self.detector.nrows

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -33,7 +33,7 @@ from kikuchipy.draw.markers import (
     get_point_list,
     get_text_list,
 )
-from kikuchipy.draw.colors import TABLEAU_COLORS, TSL_COLORS
+from kikuchipy.draw.colors import TSL_COLORS
 from kikuchipy.simulations.features import KikuchiBand, ZoneAxis
 
 
@@ -190,7 +190,6 @@ class GeometricalEBSDSimulation:
             colors = _get_colors_for_allowed_bands(
                 phase=self.bands.phase,
                 highest_hkl=np.max(np.abs(self.bands._hkldata), axis=0),
-                color_cycle=TSL_COLORS,
             )
             for hkl in families.keys():
                 for table_hkl, color in colors:
@@ -530,7 +529,7 @@ def _get_colors_for_allowed_bands(
     families, families_idx = _get_hkl_family(hkl=hkl, reduce=True)
 
     if color_cycle is None:
-        color_cycle = TABLEAU_COLORS
+        color_cycle = TSL_COLORS
     n_color_cycle = len(color_cycle)
     n_families = len(families)
     colors = np.tile(

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -509,7 +509,8 @@ def _get_colors_for_allowed_bands(
         [9, 9, 9] is used.
     color_cycle
         A list of color names recognized by Matplotlib. If None
-        (default), the Matplotlib Tableau colors are cycled through.
+        (default), a color palette based on EDAX TSL's coloring of bands
+        is cycled through.
 
     Returns
     -------

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -82,7 +82,7 @@ class GeometricalEBSDSimulation:
 
         Returns
         -------
-        band_coords
+        band_coords_detector : numpy.ndarray
             Band coordinates on the detector.
         """
         # Get start and end points for the plane traces in gnomonic coordinates
@@ -117,7 +117,7 @@ class GeometricalEBSDSimulation:
 
         Returns
         -------
-        za_coords
+        za_coords : numpy.ndarray
             Zone axis coordinates on the detector.
         """
         xyg = self.zone_axes._xy_within_gnomonic_radius
@@ -151,7 +151,7 @@ class GeometricalEBSDSimulation:
 
         Returns
         -------
-        np.ndarray
+        za_coords : numpy.ndarray
             Zone axes labels placed just above the zone axes.
         """
         za_coords = self.zone_axes_detector_coordinates
@@ -178,6 +178,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         list
+            List with line segment markers.
         """
         if self.bands.navigation_shape == (1,):
             lines = np.squeeze(self.bands_detector_coordinates)
@@ -230,6 +231,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         list
+            List with point markers.
         """
         # TODO: Give them some descriptive colors (facecolor)!
         # TODO: Marker style based on symmetry (2, 3, 4 and 6-fold):
@@ -257,6 +259,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         list
+            List of text markers.
         """
         # TODO: Remove warning after HyperSpy merges this PR
         #  https://github.com/hyperspy/hyperspy/pull/2558 and publishes
@@ -301,6 +304,7 @@ class GeometricalEBSDSimulation:
         Returns
         -------
         list
+            List of point markers.
         """
         # Set up (x, y) detector coordinate array of final shape
         # nav_shape + (n_patterns, 2)
@@ -364,8 +368,8 @@ class GeometricalEBSDSimulation:
 
         Returns
         -------
-        markers
-            A list with all markers.
+        markers : hyperspy.drawing.marker.MarkerBase
+            List with all markers.
         """
         markers = []
         if bands:
@@ -395,7 +399,7 @@ class GeometricalEBSDSimulation:
 
         Returns
         -------
-        within_gnomonic_bounds
+        within_gnomonic_bounds : numpy.ndarray
             Boolean array with True for zone axes within the detector's
             gnomonic bounds.
         """

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from copy import deepcopy
 import numpy as np
 import pytest
 
@@ -320,6 +321,64 @@ class TestKikuchiBand:
                 ]
             ),
         )
+
+    def test_get_item(self, nickel_kikuchi_band):
+        """KikuchiBand.__getitem__() works as desired."""
+        bands = nickel_kikuchi_band
+        nav_shape = bands.navigation_shape
+
+        # Zero getitem keys
+        assert np.allclose(bands[:].hkl_detector.data, bands.hkl_detector.data)
+        assert bands[:].navigation_shape == nav_shape
+        assert np.allclose(bands[()].hkl_detector.data, bands.hkl_detector.data)
+        assert bands[()].navigation_shape == nav_shape
+        assert np.allclose(
+            bands[slice(None)].hkl_detector.data, bands.hkl_detector.data
+        )
+        assert bands[slice(None)].navigation_shape == nav_shape
+
+        # One getitem key
+        # All bands visible in first pattern
+        assert np.allclose(
+            bands[0].hkl_detector.data, bands.hkl_detector.data[0]
+        )
+        assert bands[0].navigation_shape == (5,)
+
+        # Two getitem keys
+        with pytest.raises(IndexError, match="Not enough axes to slice"):
+            # Slicing shape () with two keys
+            _ = bands[0, 0][0, 0]
+        # Slicing ndim == 1 with two keys
+        assert np.allclose(bands[0][0, :2]._hkldata, bands._hkldata[:2])
+        assert bands[0][0, :2].navigation_shape == ()
+
+        # Three getitem keys
+        with pytest.raises(IndexError, match="Not enough axes to slice"):
+            # Slicing ndim == 1 with three keys
+            _ = bands[0][0, :2, :3]
+        this_slice = (0, slice(0, 2), slice(0, 3))
+        bands2 = bands[this_slice]
+        assert np.allclose(
+            bands2.hkl_detector.data, bands.hkl_detector.data[this_slice]
+        )
+        assert bands2.size == 3
+        assert bands[this_slice].navigation_shape == (2,)
+
+    def test_unique(self, nickel_kikuchi_band):
+        with pytest.raises(NotImplementedError):
+            _ = nickel_kikuchi_band.unique()
+
+    def test_symmetrise(self, nickel_kikuchi_band):
+        with pytest.raises(NotImplementedError):
+            _ = nickel_kikuchi_band.symmetrise()
+
+    def test_from_min_dspacing(self, nickel_kikuchi_band):
+        with pytest.raises(NotImplementedError):
+            _ = nickel_kikuchi_band.from_min_dspacing()
+
+    def test_from_highest_hkl(self, nickel_kikuchi_band):
+        with pytest.raises(NotImplementedError):
+            _ = nickel_kikuchi_band.from_highest_hkl()
 
 
 class TestZoneAxis:

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -320,3 +320,8 @@ class TestKikuchiBand:
                 ]
             ),
         )
+
+
+class TestZoneAxis:
+    def test_init(self):
+        pass

--- a/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
@@ -31,10 +31,92 @@ class TestGeometricalEBSDSimulation:
         """Setting the navigation shape changes all derived navigation
         shapes.
         """
-        sim_gen = nickel_ebsd_simulation_generator
-        sim_gen.navigation_shape = nav_shape
-        sim = sim_gen.geometrical_simulation(nickel_rlp)
+        simgen = nickel_ebsd_simulation_generator
+        simgen.navigation_shape = nav_shape
+        sim = simgen.geometrical_simulation(nickel_rlp)
 
         assert sim.detector.navigation_shape == nav_shape
         assert sim.rotations.shape == nav_shape
         assert sim.bands.navigation_shape == nav_shape
+        assert sim.bands_detector_coordinates.shape == (
+            nav_shape + (sim.bands.size, 4)
+        )
+        n_za = sim.zone_axes.size
+        za_shape = nav_shape + (n_za, 2)
+        assert sim.zone_axes_detector_coordinates.shape == za_shape
+        assert sim.zone_axes_label_detector_coordinates.shape == za_shape
+        assert sim.zone_axes_within_gnomonic_bounds.shape == nav_shape + (n_za,)
+
+    def test_bands_detector_coordinates(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired band detector coordinates."""
+        pass
+
+    def test_zone_axes_coordinates(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired zone axes coordinates."""
+        pass
+
+    def test_zone_axes_label_detector_coordinates(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired zone axes label coordinates."""
+        pass
+
+    def test_bands_as_markers(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired line markers."""
+        pass
+
+    def test_zone_axes_as_markers(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired point markers."""
+        pass
+
+    def test_zone_axes_labels_as_markers(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired text markers."""
+        pass
+
+    def test_plot_zone_axes_labels_warns(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Matplotlib warns when plotting text with NaN coordinates."""
+        pass
+
+    def test_pc_as_markers(self, nickel_ebsd_simulation_generator, nickel_rlp):
+        """Desired point markers."""
+        pass
+
+    def test_as_markers(self, nickel_ebsd_simulation_generator, nickel_rlp):
+        """Desired set of markers."""
+        pass
+
+    def test_zone_axes_within_gnomonic_bounds(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired boolean array."""
+        pass
+
+    def test_repr(self, nickel_ebsd_simulation_generator, nickel_rlp):
+        """Desired string representation."""
+        pass
+
+    def test_get_hkl_family(self, nickel_ebsd_simulation_generator, nickel_rlp):
+        """Desired sets of families and indices."""
+        pass
+
+    def test_is_equivalent(self, nickel_ebsd_simulation_generator, nickel_rlp):
+        """Desired equivalency, with reducing HKL."""
+        pass
+
+    def test_get_colors_for_allowed_bands(
+        self, nickel_ebsd_simulation_generator, nickel_rlp
+    ):
+        """Desired colors for bands."""
+        pass

--- a/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
@@ -51,7 +51,36 @@ class TestGeometricalEBSDSimulation:
         self, nickel_ebsd_simulation_generator, nickel_rlp
     ):
         """Desired band detector coordinates."""
-        pass
+        simgen = nickel_ebsd_simulation_generator
+        simgen.navigation_shape = (5, 5)
+        rlp = nickel_rlp.symmetrise()
+
+        # 0d
+        nav_shape = ()
+        simgen1 = simgen[0, 0]
+        simgen1.navigation_shape = nav_shape
+        sim1 = simgen1.geometrical_simulation(rlp[:2])
+        assert sim1.bands.navigation_shape == nav_shape
+        assert sim1.bands._data_shape == (1,)
+        assert sim1.bands_detector_coordinates.shape == (1, 4)
+
+        # 1d
+        nav_shape = (3,)
+        simgen2 = simgen[0, :3]
+        assert simgen2.navigation_shape == nav_shape
+        sim2 = simgen2.geometrical_simulation(rlp[:3])
+        assert sim2.bands.navigation_shape == nav_shape
+        assert sim2.bands._data_shape == (3, 2)
+        assert sim2.bands_detector_coordinates.shape == (3, 2, 4)
+
+        # 2d
+        nav_shape = (4, 2)
+        simgen3 = simgen[:4, :2]
+        assert simgen3.navigation_shape == nav_shape
+        sim3 = simgen3.geometrical_simulation(rlp[:4])
+        assert sim3.bands.navigation_shape == nav_shape
+        assert sim3.bands._data_shape == (4, 2, 3)
+        assert sim3.bands_detector_coordinates.shape == (4, 2, 3, 4)
 
     def test_zone_axes_coordinates(
         self, nickel_ebsd_simulation_generator, nickel_rlp


### PR DESCRIPTION
#### Description of the change

This PR concludes the basic functionality of simulations of geometrical EBSD patterns.

* Add zone axes attribute to the `GeometricalEBSDSimulation` class. These are calculated from the cross product of the present Kikuchi bands, and can be plotted along with the bands.
* Default Kikuchi band coloring using the color palette from EDAX TSL. The user can provide custom colors if desired.
* PC plotting is fixed, ensuring that only one PC is plotted per pattern
* Which zone axes to plot can be set in two ways: (1) on the detector, and (2) within a gnomonic radius (of course centered on the PC). Default is to exclude zone axis outside the detector
* Plotting of zone axes labels is updated, however, a warning is raised before plotting, see this pending HyperSpy PR for details: https://github.com/hyperspy/hyperspy/pull/2558
* Some routines for getting which HKL family a certain HKL belongs to are added as private functions in the geometrical simulation script. The extra functionality in these functions should be added to the already existing `diffsims.crystallography.ReciprocalLatticePoint.unique()` method.
* `KikuchiBand` and `ZoneAxis` `__getitem__()` methods are added. These should also, I think, be moved to `ReciprocalLatticePoint.__getitem__()`.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)
- [x] Test it all for signal navigation dimensions 0, 1 and 2 (coverage should be 100% after this PR)
- ~Jupyter Notebook showing how to simulate geometrical EBSD patterns and plot them as markers. This notebook should be placed in `doc/notebook.ipynb` and included in the user guide with `nbsphinx` (https://nbsphinx.readthedocs.io/en/0.7.1/index.html)~ will do this in a later PR.

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
