### PR TITLE
EMsoft EBSD master pattern plugin can read a single energy, change energy parameter name

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file. The format
 is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_, and this
 project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Contributors to each release are listed in alphabetical order by first name.
+Contributors to each release are listed in alphabetical order by first name. 
+List entries are sorted in descending chronological order.
 
 Unreleased
 ==========
@@ -29,29 +30,32 @@ Added
   dictionary of simulated patterns with known orientations.
   (`#231 <https://github.com/pyxem/kikuchipy/pull/231>`_,
   `#233 <https://github.com/pyxem/kikuchipy/pull/233>`_)
-- Reader for EMsoft's simulated EBSD patterns returned by their ``EMEBSD.f90``
-  program. (`#202 <https://github.com/pyxem/kikuchipy/pull/202>`_)
+- EBSD.xmap property storing an orix CrystalMap object. So far only read from
+  a EMsoft simulated EBSD pattern file. Relevant documentation updated.
+  (`#226 <https://github.com/pyxem/kikuchipy/pull/226>`_)
+- Dependency on the diffsims package (https://github.com/pyxem/diffsims/) for
+  handling of electron scattering and diffraction.
+  (`#220 <https://github.com/pyxem/kikuchipy/pull/220>`_)
 - Modified Lambert mapping, and its inverse, from points on the unit sphere to a
   2D square grid, as implemented in Callahan and De Graef (2013).
   (`#214 <https://github.com/pyxem/kikuchipy/pull/214>`_)
-- EBSD detector class to handle detector parameters, including detector pixels'
-  gnomonic coordinates. EBSD reference frame documentation.
-  (`#204 <https://github.com/pyxem/kikuchipy/pull/204>`_,
-  `#215 <https://github.com/pyxem/kikuchipy/pull/215>`_)
 - Geometrical EBSD simulations, projecting a set of Kikuchi bands and zone axes
   onto a detector, which can be added to an EBSD signal as markers.
   (`#204 <https://github.com/pyxem/kikuchipy/pull/204>`_,
   `#219 <https://github.com/pyxem/kikuchipy/pull/219>`_,
   `#232 <https://github.com/pyxem/kikuchipy/pull/232>`_)
-- Dependency on the diffsims package (https://github.com/pyxem/diffsims/) for
-  handling of electron scattering and diffraction.
-  (`#220 <https://github.com/pyxem/kikuchipy/pull/220>`_)
-- EBSD.xmap property storing an orix CrystalMap object. So far only read from
-  a EMsoft simulated EBSD pattern file. Relevant documentation updated.
-  (`#226 <https://github.com/pyxem/kikuchipy/pull/226>`_)
+- EBSD detector class to handle detector parameters, including detector pixels'
+  gnomonic coordinates. EBSD reference frame documentation.
+  (`#204 <https://github.com/pyxem/kikuchipy/pull/204>`_,
+  `#215 <https://github.com/pyxem/kikuchipy/pull/215>`_)
+- Reader for EMsoft's simulated EBSD patterns returned by their ``EMEBSD.f90``
+  program. (`#202 <https://github.com/pyxem/kikuchipy/pull/202>`_)
 
 Changed
 -------
+- EMsoft EBSD master pattern plugin can read a single energy pattern. Parameter
+  `energy_range`  changed to `energy`.
+  (`240 <https://github.com/pyxem/kikuchipy/pull/240>`_)
 - Migrating the user guide from `reStructuredText` files to Jupyter Notebooks
   built to HTML via the `nbsphinx` package.
   (`#236 <https://github.com/pyxem/kikuchipy/pull/236>`_)

--- a/doc/load_save_data.rst
+++ b/doc/load_save_data.rst
@@ -392,13 +392,13 @@ can be read into an :class:`~kikuchipy.signals.EBSDMasterPattern` object:
 Here, the EMsoft EBSD master pattern
 :func:`~kikuchipy.io.plugins.emsoft_ebsd_master_pattern.file_reader` is called,
 which takes the optional arguments ``projection``, ``hemisphere`` and
-``energy_range``. The spherical projection is read by default. Passing
+``energy``. The spherical projection is read by default. Passing
 ``projection="lambert"`` will read the square Lambert projection instead. The
 northern hemisphere is read by default. Passing ``hemisphere="south"`` or
 ``hemisphere="both"`` will read the southern hemisphere projection or both,
 respectively. Master patterns for all beam energies are read by default. Passing
-``energy_range=(10, 20)`` will read the master patterns with beam energies from
-10 to 20 keV.
+``energy=(10, 20)`` or ``energy=15`` will read the master pattern(s) with beam
+energies from 10 to 20 keV, or just 15 keV, respectively:
 
 .. code-block::
 
@@ -406,7 +406,7 @@ respectively. Master patterns for all beam energies are read by default. Passing
     ...     "master_patterns.h5",
     ...     projection="lambert",
     ...     hemisphere="both",
-    ...     energy_range=(10, 20)
+    ...     energy=(10, 20)
     ... )
     >>> s
     <EBSDMasterPattern, title: , dimensions: (2, 11|1001, 1001)>


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* An EMsoft master pattern file with a single beam energy pattern (e.g. only 20 keV) can now be read
* The `energy_range` parameter to the EMsoft master pattern reader is therefore changed to `energy` (in code and tests)
* Necessary updates to the tests and documentation are added.

This functionality is needed before PR #237 can progress, as a modified (uint8, not float32) single beam energy master pattern file is planned to be included in the `kikuchipy.data` module.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### Minimal example of the bug fix or new feature

All these values to `energy` is now allowed:

```python
>>> import kikuchipy as kp
>>> mp = kp.load("my/data.h5", energy=20)
>>> mp2 = kp.load("my/data.h5", energy=(10, 20))
>>> mp3 = kp.load("my/data.h5", energy=None)
```

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.