### PR TITLE
Add external 13 MB Ni EBSD dataset to module, pooch/tqdm dependencies

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,10 +23,11 @@ Contributors
 
 Added
 -----
-- A kikuchipy.data module with a small Nickel EBSD data set and master
-  pattern.
+- A data module with a small Nickel EBSD data set and master pattern, and a
+  larger EBSD data set downloadable via the module.
   (`#236 <https://github.com/pyxem/kikuchipy/pull/236>`_,
-  `#237 <https://github.com/pyxem/kikuchipy/pull/237>`_)
+  `#237 <https://github.com/pyxem/kikuchipy/pull/237>`_,
+  `#243 <https://github.com/pyxem/kikuchipy/pull/243>`_)
 - Indexing of EBSD patterns through matching of patterns with a static
   dictionary of simulated patterns with known orientations.
   (`#231 <https://github.com/pyxem/kikuchipy/pull/231>`_,

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -184,6 +184,13 @@ terminal. For an even nicer presentation, you can use ``coverage.py`` directly::
 Then, you can open the created ``htmlcov/index.html`` in the browser and inspect
 the coverage in more detail.
 
+.. note::
+
+   Some :mod:`kikuchipy.data` module tests check that data not part of the
+   package distribution can be downloaded from the `kikuchipy-data GitHub
+   repository <https://github.com/pyxem/kikuchipy-data>`_, thus downloading some
+   datasets of ~15 MB to your local cache.
+
 Code of Conduct
 ===============
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,11 +28,11 @@ Anaconda
 Anaconda provides the easiest installation. In the Anaconda Prompt, terminal or
 Command Prompt, install with::
 
-    $conda install kikuchipy --channel conda-forge
+    $ conda install kikuchipy --channel conda-forge
 
 If you at a later time need to update the package::
 
-    $conda update kikuchipy
+    $ conda update kikuchipy
 
 .. _install-with-pip:
 
@@ -42,11 +42,11 @@ Pip
 To install with ``pip``, run the following in the Anaconda Prompt, terminal or
 Command Prompt::
 
-    $pip install kikuchipy
+    $ pip install kikuchipy
 
 If you at a later time need to update the package::
 
-    $pip install --upgrade kikuchipy
+    $ pip install --upgrade kikuchipy
 
 .. note::
 
@@ -62,9 +62,9 @@ Install from source
 To install kikuchipy from source, clone the repository from `GitHub
 <https://github.com/pyxem/kikuchipy>`_::
 
-    $git clone https://github.com/pyxem/kikuchipy.git
-    $cd kikuchipy
-    $pip install --editable .
+    $ git clone https://github.com/pyxem/kikuchipy.git
+    $ cd kikuchipy
+    $ pip install --editable .
 
 See the :ref:`contributing guidelines <setting-up-a-development-installation>`
 for how to set up a development installation.

--- a/doc/load_save_data.ipynb
+++ b/doc/load_save_data.ipynb
@@ -25,7 +25,7 @@
     "load patterns from file use the [load()](reference.rst#kikuchipy.io._io.load)\n",
     "function. Let's import the necessary libraries and read the Nickel EBSD test\n",
     "data set directly from file (not via\n",
-    "[kikuchipy.data.nickel_ebsd()](reference.rst#kikuchipy.data.nickel_ebsd)):"
+    "[kikuchipy.data.nickel_ebsd_small()](reference.rst#kikuchipy.data.nickel_ebsd_small)):"
    ]
   },
   {
@@ -79,7 +79,7 @@
    "source": [
     "Both the spherical and Lambert projections of this master pattern data is\n",
     "available via\n",
-    "[kikuchipy.data.nickel_master_pattern()](reference.rst#kikuchipy.data.nickel_master_pattern)."
+    "[kikuchipy.data.nickel_ebsd_master_pattern_uint8()](reference.rst#kikuchipy.data.nickel_ebsd_master_pattern_uint8)."
    ]
   },
   {

--- a/doc/load_save_data.ipynb
+++ b/doc/load_save_data.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "Both the spherical and Lambert projections of this master pattern data is\n",
     "available via\n",
-    "[kikuchipy.data.nickel_ebsd_master_pattern_uint8()](reference.rst#kikuchipy.data.nickel_ebsd_master_pattern_uint8)."
+    "[kikuchipy.data.nickel_ebsd_master_pattern_small()](reference.rst#kikuchipy.data.nickel_ebsd_master_pattern_small)."
    ]
   },
   {

--- a/doc/pattern_processing.ipynb
+++ b/doc/pattern_processing.ipynb
@@ -46,7 +46,7 @@
     "import kikuchipy as kp\n",
     "\n",
     "\n",
-    "s = kp.data.nickel_ebsd()  # Use kp.load(\"data.h5\") to load your own data"
+    "s = kp.data.nickel_ebsd_small()  # Use kp.load(\"data.h5\") to load your own data"
    ]
   },
   {

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -56,8 +56,9 @@ data
 .. currentmodule:: kikuchipy.data
 
 .. autosummary::
-    nickel_ebsd
-    nickel_master_pattern
+    nickel_ebsd_small
+    nickel_ebsd_large
+    nickel_ebsd_master_pattern_uint8
 
 .. automodule:: kikuchipy.data
     :members:

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -58,7 +58,7 @@ data
 .. autosummary::
     nickel_ebsd_small
     nickel_ebsd_large
-    nickel_ebsd_master_pattern_uint8
+    nickel_ebsd_master_pattern_small
 
 .. automodule:: kikuchipy.data
     :members:

--- a/kikuchipy/data/__init__.py
+++ b/kikuchipy/data/__init__.py
@@ -18,7 +18,8 @@
 
 """Test data.
 
-For more test data sets, see :doc:`open datasets <open_datasets>`.
+Some datasets must be downloaded from the web. For more test datasets,
+see :doc:`open datasets <open_datasets>`.
 """
 
 from pathlib import Path

--- a/kikuchipy/data/__init__.py
+++ b/kikuchipy/data/__init__.py
@@ -21,42 +21,78 @@
 For more test data sets, see :doc:`open datasets <open_datasets>`.
 """
 
+from pathlib import Path
 import os
 from typing import Union
 
+import pooch as ppooch
+
 from kikuchipy.signals import EBSD, EBSDMasterPattern
 from kikuchipy import load
+from kikuchipy.release import version
+from kikuchipy.data._registry import registry, registry_urls
 
 
 __all__ = [
-    "nickel_ebsd",
-    "nickel_master_pattern",
+    "nickel_ebsd_small",
+    "nickel_ebsd_master_pattern_uint8",
+    "nickel_ebsd_large",
 ]
 
 
-DATA_DIR = os.path.dirname(__file__)
+fetcher = ppooch.create(
+    path=ppooch.os_cache("kikuchipy"),
+    base_url="",
+    version=version.replace(".dev", "+"),
+    env="KIKUCHIPY_DATA_DIR",
+    registry=registry,
+    urls=registry_urls,
+)
+cache_data_path = fetcher.path.joinpath("data")
+package_data_path = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+def _has_hash(path, expected_hash):
+    """Check if the provided path has the expected hash."""
+    if not os.path.exists(path):
+        return False
+    else:
+        return ppooch.utils.file_hash(path) == expected_hash
+
+
+def _cautious_downloader(url, output_file, pooch):
+    if pooch.allow_download:
+        delattr(pooch, "allow_download")
+        # HTTPDownloader() requires tqdm, a HyperSpy dependency, so
+        # adding it to our dependencies doesn't cost anything
+        download = ppooch.HTTPDownloader(progressbar=True)
+        download(url, output_file, pooch)
+    else:
+        raise ValueError(
+            "The dataset must be (re)downloaded from the kikuchipy-data "
+            "repository on GitHub (https://github.com/pyxem/kikuchipy-data) to "
+            "your local cache with the pooch Python package. Pass "
+            "`allow_download=True` to allow this download."
+        )
+
+
+def _fetch(filename: str, allow_download: bool = False):
+    resolved_path = os.path.join(package_data_path, "..", filename)
+    expected_hash = registry[filename]
+    if _has_hash(resolved_path, expected_hash):  # File already in data module
+        return resolved_path
+    else:  # Pooch must download the data to the local cache
+        fetcher.allow_download = allow_download  # Extremely ugly
+        resolved_path = fetcher.fetch(filename, downloader=_cautious_downloader)
+    return resolved_path
 
 
 def _load(filename: str, **kwargs) -> Union[EBSD, EBSDMasterPattern]:
-    """Load a data set located in the data directory.
-
-    Parameters
-    ----------
-    filename : str
-        File name.
-    kwargs
-        Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
-
-    Returns
-    -------
-    signal : EBSD or EBSDMasterPattern
-        EBSD or master pattern signal.
-    """
-    file = os.path.join(DATA_DIR, filename)
-    return load(file, **kwargs)
+    allow_download = kwargs.pop("allow_download", False)
+    return load(_fetch(filename, allow_download=allow_download), **kwargs)
 
 
-def nickel_ebsd(**kwargs) -> EBSD:
+def nickel_ebsd_small(**kwargs) -> EBSD:
     """9 EBSD patterns in a (3, 3) navigation shape of (60, 60) detector
     pixels from Nickel, acquired on a NORDIF UF-1100 detector.
 
@@ -70,10 +106,10 @@ def nickel_ebsd(**kwargs) -> EBSD:
     signal : EBSD
         EBSD signal.
     """
-    return _load(filename="kikuchipy/patterns.h5", **kwargs)
+    return _load(filename="data/kikuchipy/patterns.h5", **kwargs)
 
 
-def nickel_master_pattern(**kwargs) -> EBSDMasterPattern:
+def nickel_ebsd_master_pattern_uint8(**kwargs) -> EBSDMasterPattern:
     """(401, 401) `uint8` square Lambert or spherical projection of the
     northern and southern hemisphere of a Nickel master pattern at 20
     keV accelerating voltage.
@@ -100,9 +136,30 @@ def nickel_master_pattern(**kwargs) -> EBSDMasterPattern:
     keyword arguments `compression="gzip"` and `compression_opts=9`. All
     other HDF5 groups and datasets are the same as in the original file.
     """
+    fname = "data/emsoft_ebsd_master_pattern/ni_mc_mp_20kv_uint8_gzip_opts9.h5"
+    return _load(fname, **kwargs)
+
+
+def nickel_ebsd_large(allow_download: bool = False, **kwargs) -> EBSD:
+    """4125 EBSD patterns in a (55, 75) navigation shape of (60, 60)
+    detector pixels from Nickel, acquired on a NORDIF UF-1100 detector.
+
+    Parameters
+    ----------
+    allow_download : bool
+        Whether to allow downloading the dataset from the kikuchipy-data
+        GitHub repository to the local cache with the pooch Python
+        package. Default is False.
+    kwargs
+        Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
+
+    Returns
+    -------
+    signal : EBSD
+        EBSD signal.
+    """
     return _load(
-        filename=os.path.join(
-            "emsoft_ebsd_master_pattern", "ni_mc_mp_20kv_uint8_gzip_opts9.h5",
-        ),
+        filename="data/nickel_ebsd_large/patterns.h5",
+        allow_download=allow_download,
         **kwargs,
     )

--- a/kikuchipy/data/__init__.py
+++ b/kikuchipy/data/__init__.py
@@ -36,8 +36,8 @@ from kikuchipy.data._registry import registry, registry_urls
 
 __all__ = [
     "nickel_ebsd_small",
-    "nickel_ebsd_master_pattern_uint8",
     "nickel_ebsd_large",
+    "nickel_ebsd_master_pattern_small",
 ]
 
 
@@ -110,7 +110,7 @@ def nickel_ebsd_small(**kwargs) -> EBSD:
     return _load(filename="data/kikuchipy/patterns.h5", **kwargs)
 
 
-def nickel_ebsd_master_pattern_uint8(**kwargs) -> EBSDMasterPattern:
+def nickel_ebsd_master_pattern_small(**kwargs) -> EBSDMasterPattern:
     """(401, 401) `uint8` square Lambert or spherical projection of the
     northern and southern hemisphere of a Nickel master pattern at 20
     keV accelerating voltage.
@@ -149,8 +149,8 @@ def nickel_ebsd_large(allow_download: bool = False, **kwargs) -> EBSD:
     ----------
     allow_download : bool
         Whether to allow downloading the dataset from the kikuchipy-data
-        GitHub repository to the local cache with the pooch Python
-        package. Default is False.
+        GitHub repository (https://github.com/pyxem/kikuchipy-data) to
+        the local cache with the pooch Python package. Default is False.
     kwargs
         Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
 

--- a/kikuchipy/data/_registry.py
+++ b/kikuchipy/data/_registry.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+# fmt: off
+registry = {
+    "data/kikuchipy/patterns.h5": "7a99ce88174c725f5407b6fcc1eab0c4255694ca8e6029fde7f372f3ab40897f",
+    "data/emsoft_ebsd_master_pattern/ni_mc_mp_20kv_uint8_gzip_opts9.h5": "8a7c1fb471d9ce750f0332a154e87cf41eed7529be508548e0c0f51ec6f92bc2",
+    "data/nickel_ebsd_large/patterns.h5": "3ea6e729c3adfdea9dce461806f011c24bf70b011dcf4d90a23a6aa29f15872c",
+}
+registry_urls = {
+    "data/nickel_ebsd_large/patterns.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/nickel_ebsd_large/patterns.h5"
+}
+# fmt: on

--- a/kikuchipy/data/tests/test_data.py
+++ b/kikuchipy/data/tests/test_data.py
@@ -43,9 +43,9 @@ class TestData:
         assert isinstance(s_lazy, LazyEBSD)
         assert isinstance(s_lazy.data, Array)
 
-    def test_load_nickel_ebsd_master_pattern_uint8(self):
+    def test_load_nickel_ebsd_master_pattern_small(self):
         """Can be read."""
-        mp = data.nickel_ebsd_master_pattern_uint8()
+        mp = data.nickel_ebsd_master_pattern_small()
         assert mp.data.shape == (401, 401)
 
     @pytest.mark.parametrize(
@@ -57,13 +57,13 @@ class TestData:
             ("spherical", "both", (2, 401, 401)),
         ],
     )
-    def test_load_nickel_ebsd_master_pattern_uint8_kwargs(
+    def test_load_nickel_ebsd_master_pattern_small_kwargs(
         self, projection, hemisphere, desired_shape
     ):
         """Master patterns in both spherical and Lambert projections
         can be loaded as expected.
         """
-        mp = data.nickel_ebsd_master_pattern_uint8(
+        mp = data.nickel_ebsd_master_pattern_small(
             projection=projection, hemisphere=hemisphere,
         )
 
@@ -83,7 +83,7 @@ class TestData:
             == hemisphere
         )
 
-        mp_lazy = data.nickel_ebsd_master_pattern_uint8(lazy=True)
+        mp_lazy = data.nickel_ebsd_master_pattern_small(lazy=True)
 
         assert isinstance(mp_lazy, LazyEBSDMasterPattern)
         assert isinstance(mp_lazy.data, Array)
@@ -97,10 +97,10 @@ class TestData:
         with pytest.raises(ValueError, match="The dataset must be"):
             _ = data.nickel_ebsd_large(allow_download=False)
 
-    def test_load_nickel_ebsd_large_allow(self):
+    def test_load_nickel_ebsd_large_allow_download(self):
         """Download from external."""
-        s = data.nickel_ebsd_large(allow_download=True)
+        s = data.nickel_ebsd_large(lazy=True, allow_download=True)
 
-        assert isinstance(s, EBSD)
+        assert isinstance(s, LazyEBSD)
         assert s.data.shape == (55, 75, 60, 60)
         assert np.issubdtype(s.data.dtype, np.uint8)

--- a/kikuchipy/data/tests/test_data.py
+++ b/kikuchipy/data/tests/test_data.py
@@ -91,7 +91,7 @@ class TestData:
     def test_load_nickel_ebsd_large_raises(self):
         """Raises desired error message."""
         file = data.cache_data_path.joinpath("nickel_ebsd_large/patterns.h5")
-        if file.exists():
+        if file.exists():  # pragma: no cover
             os.remove(file)
             os.rmdir(file.parent)
         with pytest.raises(ValueError, match="The dataset must be"):

--- a/kikuchipy/data/tests/test_data.py
+++ b/kikuchipy/data/tests/test_data.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from dask.array import Array
 import numpy as np
 import pytest
@@ -30,20 +32,20 @@ from kikuchipy.signals import (
 
 
 class TestData:
-    def test_load_nickel_ebsd(self):
-        s = data.nickel_ebsd()
+    def test_load_nickel_ebsd_small(self):
+        s = data.nickel_ebsd_small()
 
         assert isinstance(s, EBSD)
         assert s.data.shape == (3, 3, 60, 60)
 
-        s_lazy = data.nickel_ebsd(lazy=True)
+        s_lazy = data.nickel_ebsd_small(lazy=True)
 
         assert isinstance(s_lazy, LazyEBSD)
         assert isinstance(s_lazy.data, Array)
 
-    def test_load_nickel_master_pattern(self):
+    def test_load_nickel_ebsd_master_pattern_uint8(self):
         """Can be read."""
-        mp = data.nickel_master_pattern()
+        mp = data.nickel_ebsd_master_pattern_uint8()
         assert mp.data.shape == (401, 401)
 
     @pytest.mark.parametrize(
@@ -55,13 +57,13 @@ class TestData:
             ("spherical", "both", (2, 401, 401)),
         ],
     )
-    def test_load_nickel_master_pattern_kwargs(
+    def test_load_nickel_ebsd_master_pattern_uint8_kwargs(
         self, projection, hemisphere, desired_shape
     ):
         """Master patterns in both spherical and Lambert projections
         can be loaded as expected.
         """
-        mp = data.nickel_master_pattern(
+        mp = data.nickel_ebsd_master_pattern_uint8(
             projection=projection, hemisphere=hemisphere,
         )
 
@@ -81,7 +83,24 @@ class TestData:
             == hemisphere
         )
 
-        mp_lazy = data.nickel_master_pattern(lazy=True)
+        mp_lazy = data.nickel_ebsd_master_pattern_uint8(lazy=True)
 
         assert isinstance(mp_lazy, LazyEBSDMasterPattern)
         assert isinstance(mp_lazy.data, Array)
+
+    def test_load_nickel_ebsd_large_raises(self):
+        """Raises desired error message."""
+        file = data.cache_data_path.joinpath("nickel_ebsd_large/patterns.h5")
+        if file.exists():
+            os.remove(file)
+            os.rmdir(file.parent)
+        with pytest.raises(ValueError, match="The dataset must be"):
+            _ = data.nickel_ebsd_large(allow_download=False)
+
+    def test_load_nickel_ebsd_large_allow(self):
+        """Download from external."""
+        s = data.nickel_ebsd_large(allow_download=True)
+
+        assert isinstance(s, EBSD)
+        assert s.data.shape == (55, 75, 60, 60)
+        assert np.issubdtype(s.data.dtype, np.uint8)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 from itertools import chain
 from setuptools import setup, find_packages
 
-# Get release information without importing anything from the projections
+# Get release information without importing anything from the project
 with open("kikuchipy/release.py") as fid:
     for line in fid:
         if line.startswith("author"):
@@ -42,18 +42,18 @@ with open("kikuchipy/release.py") as fid:
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
 extra_feature_requirements = {
     "doc": [
+        "nbsphinx >= 0.7",
         "sphinx >= 3.0.2",
         "sphinx-rtd-theme >= 0.4.3",
         "sphinx-copybutton >= 0.2.5",
         "sphinx-autodoc-typehints >= 1.10.3",
-        "nbsphinx >= 0.7",
         "sphinxcontrib-bibtex >= 1.0",
     ],
     # Update in .travis.yml if this list is updated!
-    "tests": ["pytest >= 5.4", "pytest-cov >= 2.8.1", "coverage >= 5.0",],
+    "tests": ["coverage >= 5.0", "pytest >= 5.4", "pytest-cov >= 2.8.1"],
 }
 
-# Create a development projections, including both the doc and tests projects
+# Create a development project, including both the doc and tests projects
 extra_feature_requirements["dev"] = [
     "black >= 19.3b0",
     "pre-commit >= 1.16",
@@ -123,6 +123,8 @@ setup(
         "numpy >= 1.18",
         "numba >= 0.48",
         "orix >= 0.5",
+        "pooch",
+        "tqdm >= 0.5.2",
         "scikit-image >= 0.16",
         "scikit-learn",
         "scipy",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

- Set up a framework for downloading datasets outside of the package via the package API:
  - If a dataset is asked for and it is not in the `kikuchipy.data` module, it is downloaded from the https://github.com/pyxem/kikuchipy-data repository, given that the user allows this by passing `allow_download=True` to `kikuchipy.data.nickel_ebsd_large()`, e.g.
  - The dataset is downloaded to a local cache (on my machine the default is `/home/hakon/.cache/kikuchipy/`). The `pooch` package handles download, caching, version control etc. Every file in a registry (`kikuchipy.data._registry.py`) has a SHA256 label that pooch checks against. If we have updated the SHA256 of the file, pooch will redownload the file (given the user allows this).
  - When the file is available in the cache, the user can just download it as the other files in the `kikuchipy.data` module.
- The user can specify the desired data cache directory by setting a global `KIKUCHIPY_DATA_DIR` variable on their system. On my Ubuntu I tested setting this in `~/.bashrc` to `export KIKUCHIPY_DATA_DIR=~/kikuchipy_data`, which worked fine.
- A `tqdm` dependency is introduced to get a nice progressbar for the external dataset download (already a HyperSpy dependency, thus it doesn't cost us anything).
- The tests are updated. Luckily, "d" is early in the alphabet, so the `kikuchipy.data` module tests run early in the test suit, allowing us to test the lines where the external dataset is not downloaded and the user has not set `allow_download=True`. This might become an issue later...
- Rename `kikuchipy.data.nickel_ebsd()` to `kikuchipy.data.nickel_ebsd_small()` and `kikuchipy.data.nickel_master_pattern()` to `kikuchipy.data.nickel_ebsd_master_pattern_small()`.
- Add `kikuchipy.data.nickel_ebsd_large()` (https://github.com/pyxem/kikuchipy-data/tree/master/nickel_ebsd_large) to data module

@friedkitteh: This should allow for us uploading a couple of larger master pattern files (like two-three beam energies and 501^2 pixels, I think) to the kikuchipy-data repository.

@onatlandsmyr: I plan to upload a ~15 MB part of the SDSS data set you've been testing on. You've been looking at this dataset for a while... Any particular 15 MB part of it that is the most interesting? Number of MB can easily be checked by `s.data.nbytes / 1e6`.

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### Minimal example of the bug fix or new feature

```python
>>> import kikuchipy as kp
>>> ni_small = kp.data.nickel_ebsd_small()  # Part of the package distribution
>>> ni_small
<EBSD, title: patterns My awes0m4 ..., dimensions: (3, 3|60, 60)>
>>> ni_large = kp.data.nickel_ebsd_large()  # Not part of the package distribution
ValueError: The dataset must be (re)downloaded from the kikuchipy-data repository on GitHub (https://github.com/pyxem
/kikuchipy-data) to your local cache with the pooch Python package. Pass `allow_download=True` to allow this download.
>>> ni_large = kp.data.nickel_ebsd_large(allow_download=True)
Downloading file 'data/nickel_ebsd_large/patterns.h5' from 'https://github.com/pyxem/kikuchipy-data/raw/master
/nickel_ebsd_large/patterns.h5' to '/home/hakon/.cache/kikuchipy/master'.
100%|█████████████████████████████████████| 13.0M/13.0M [00:00<00:00, 4.87GB/s]
>>> ni_large
<EBSD, title: patterns Scan 1, dimensions: (75, 55|60, 60)>
>>> ni_large2 = kp.data.nickel_ebsd_large()  # Now part of cache, don't have to redownload, even after restarting Python
```

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.