### PR TITLE
Remove master pattern metadata, add projection, hemisphere and phase attributes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -55,9 +55,8 @@ Added
 
 Changed
 -------
-- EBSDMasterPattern class exposes metadata as properties (some are settable),
-  replacing the set_simulation_parameters() and set_phase_parameters() methods.
-  (`#246 <https://github.com/pyxem/kikuchipy/pull/246>`_)
+- The EBSDMasterPattern gets unsettable phase, hemisphere and projection
+  properties. (`#246 <https://github.com/pyxem/kikuchipy/pull/246>`_)
 - EMsoft EBSD master pattern plugin can read a single energy pattern. Parameter
   `energy_range`  changed to `energy`.
   (`240 <https://github.com/pyxem/kikuchipy/pull/240>`_)
@@ -72,6 +71,13 @@ Changed
   (`#196 <https://github.com/pyxem/kikuchipy/pull/196>`_)
 - Remove language_version in pre-commit config file.
   (`#195 <https://github.com/pyxem/kikuchipy/pull/195>`_)
+
+Removed
+-------
+- The EBSDMasterPattern and EBSD metadata node Sample.Phases, to be replaced
+  by class attributes. The set_phase_parameters() method is removed from both
+  classes, and the set_simulation_parameters() is removed from the former class.
+  (`#246 <https://github.com/pyxem/kikuchipy/pull/246>`_)
 
 Fixed
 -----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -55,6 +55,9 @@ Added
 
 Changed
 -------
+- EBSDMasterPattern class exposes metadata as properties (some are settable),
+  replacing the set_simulation_parameters() and set_phase_parameters() methods.
+  (`#246 <https://github.com/pyxem/kikuchipy/pull/246>`_)
 - EMsoft EBSD master pattern plugin can read a single energy pattern. Parameter
   `energy_range`  changed to `energy`.
   (`240 <https://github.com/pyxem/kikuchipy/pull/240>`_)

--- a/doc/load_save_data.ipynb
+++ b/doc/load_save_data.ipynb
@@ -226,10 +226,7 @@
     "[set_experimental_parameters()](reference.rst#kikuchipy.signals.EBSD.set_experimental_parameters),\n",
     "[set_phase_parameters()](reference.rst#kikuchipy.signals.EBSD.set_phase_parameters),\n",
     "[set_scan_calibration()](reference.rst#kikuchipy.signals.EBSD.set_scan_calibration) and\n",
-    "[set_detector_calibration()](reference.rst#kikuchipy.signals.EBSD.set_detector_calibration),\n",
-    "or the [EBSDMasterPattern](reference.rst#kikuchipy.signals.EBSDMasterPattern)\n",
-    "class methods [set_simulation_parameters()](reference.rst#kikuchipy.signals.EBSDMasterPattern.set_simulation_parameters) or\n",
-    "[set_phase_parameters()](reference.rst#kikuchipy.signals.EBSDMasterPattern.set_phase_parameters).\n",
+    "[set_detector_calibration()](reference.rst#kikuchipy.signals.EBSD.set_detector_calibration).\n",
     "For example, to set or change the accelerating voltage, horizontal pattern\n",
     "centre coordinate and static background pattern (stored as a `numpy.ndarray`):"
    ]
@@ -768,14 +765,9 @@
     "s_mp = kp.load(filename=datadir + emsoft_master_pattern)\n",
     "\n",
     "print(s_mp)\n",
-    "print(\n",
-    "    s_mp.metadata.get_item(\n",
-    "        \"Simulation.EBSD_master_pattern.Master_pattern.projection\"\n",
-    "    ),\n",
-    "    s_mp.metadata.get_item(\n",
-    "        \"Simulation.EBSD_master_pattern.Master_pattern.hemisphere\"\n",
-    "    )\n",
-    ")"
+    "print(s_mp.projection)\n",
+    "print(s_mp.hemisphere)\n",
+    "print(s_mp.phase)"
    ]
   },
   {
@@ -808,14 +800,8 @@
     ")\n",
     "\n",
     "print(s_mp)\n",
-    "print(\n",
-    "    s_mp.metadata.get_item(\n",
-    "        \"Simulation.EBSD_master_pattern.Master_pattern.projection\"\n",
-    "    ),\n",
-    "    s_mp.metadata.get_item(\n",
-    "        \"Simulation.EBSD_master_pattern.Master_pattern.hemisphere\"\n",
-    "    )\n",
-    ")"
+    "print(s_mp.projection)\n",
+    "print(s_mp.hemisphere)"
    ]
   },
   {

--- a/doc/metadata.rst
+++ b/doc/metadata.rst
@@ -2,20 +2,16 @@
 Metadata structure
 ==================
 
-The :class:`~kikuchipy.signals.EBSD` and
-:class:`~kikuchipy.signals.EBSDMasterPattern` classes store metadata in the
+The :class:`~kikuchipy.signals.EBSD` class stores metadata in the
 ``metadata`` attribute provided by HyperSpy. While kikuchipy's EBSD
-(:func:`~kikuchipy.signals.util.ebsd_metadata`) and EBSDMasterPattern
-(:func:`~kikuchipy.signals.util.ebsd_master_pattern_metadata`) metadata
-structures are based on `HyperSpy's metadata structure
+(:func:`~kikuchipy.signals.util.ebsd_metadata`) metadata structure is based on
+`HyperSpy's metadata structure
 <http://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_,
-they each include a node ``Acquisition_instrument.Sample.Phases`` to store
-phase information, and ``Acquisition_instrument.SEM.Detector.EBSD`` or
-``Simulation.EBSD_master_pattern``, respectively. The information in these nodes
-are written, along with the patterns, to file when saving an EBSD object in the
-`kikuchipy h5ebsd format <load_save_data.ipynb#h5ebsd>`_ 
-or an EBSDMasterPattern object in `the HyperSpy HDF5 format
-<http://hyperspy.org/hyperspy-doc/current/user_guide/io.html#hspy-hyperspy-s-hdf5-specification>`_.
+it includes the nodes ``Acquisition_instrument.Sample.Phases`` to store
+phase information and ``Acquisition_instrument.SEM.Detector.EBSD`` for
+acquisition information. The information in these nodes are written, along with
+the patterns, to file when saving an EBSD signal in the
+`kikuchipy h5ebsd format <load_save_data.ipynb#h5ebsd>`_.
 
 ::
 
@@ -44,49 +40,28 @@ or an EBSDMasterPattern object in `the HyperSpy HDF5 format
     │       ├── magnification
     │       ├── microscope
     │       └── working_distance [mm]
-    ├── Sample
-    │   └── Phases
-    │       └── 1
-    │           ├── atom_coordinates
-    │           │   └── 1
-    │           │       ├── atom
-    │           │       ├── coordinates (x0, y0, z0)
-    │           │       ├── debye_waller_factor [nm^2]
-    │           │       └── site_occupation
-    │           ├── formula
-    │           ├── info
-    │           ├── lattice_constants (a, b, c and alfa, beta, gamma) [nm and º]
-    │           ├── laue_group
-    │           ├── material_name
-    │           ├── point_group
-    │           ├── setting
-    │           ├── source
-    │           ├── space_group
-    │           └── symmetry
-    └── Simulation
-        └── EBSD_master_pattern
-            ├── BSE_simulation
-            │   ├── depth_step [nm]
-            │   ├── energy_step [keV]
-            │   ├── incident_beam_energy [keV]
-            │   ├── max_depth [nm]
-            │   ├── min_beam_energy [keV]
-            │   ├── mode
-            │   ├── number_of_electrons
-            │   ├── pixels_along_x
-            │   └── sample_tilt [º]
-            └── Master_pattern
-                ├── Bethe_parameters
-                │   ├── complete_cutoff
-                │   ├── strong_beam_cutoff
-                │   └── weak_beam_cutoff
-                ├── projection
-                ├── hemisphere
-                └── smallest_interplanar_spacing [nm]
+    └── Sample
+        └── Phases
+            └── 1
+                ├── atom_coordinates
+                │   └── 1
+                │       ├── atom
+                │       ├── coordinates (x0, y0, z0)
+                │       ├── debye_waller_factor [nm^2]
+                │       └── site_occupation
+                ├── formula
+                ├── info
+                ├── lattice_constants (a, b, c and alfa, beta, gamma) [nm and º]
+                ├── laue_group
+                ├── material_name
+                ├── point_group
+                ├── setting
+                ├── source
+                ├── space_group
+                └── symmetry
 
 The utility function :func:`~kikuchipy.signals.util.metadata_nodes` returns the
-node strings for the ``SEM``, ``EBSD`` and ``EBSD_master_pattern`` nodes for
-convenience.
+node strings for the ``SEM`` and ``EBSD`` nodes for convenience.
 
 .. note::
 
@@ -101,20 +76,10 @@ This node contains information relevant for EBSD data. All parameters can be
 set with the method :meth:`~kikuchipy.signals.EBSD.set_experimental_parameters`.
 An explanation of each parameter is given in the method's docstring.
 
-EBSD master pattern
-===================
-
-This node contains information relevant for simulated EBSD master patterns. All
-parameters can be set with the method
-:meth:`~kikuchipy.signals.EBSDMasterPattern.set_simulation_parameters`. An
-explanation of each parameter is given in the method's docstring.
-
 Phases
 ======
 
 This node contains information relevant for EBSD scans or simulated patterns'
 phases. All parameters can be set with the :class:`~kikuchipy.signals.EBSD`
-method :meth:`~kikuchipy.signals.EBSD.set_phase_parameters` or the
-:class:`~kikuchipy.signals.EBSDMasterPattern` method
-:meth:`~kikuchipy.signals.EBSDMasterPattern.set_phase_parameters`.
-An explanation of each parameter is given in the methods' docstring.
+method :meth:`~kikuchipy.signals.EBSD.set_phase_parameters`. An explanation of
+each parameter is given in the methods' docstring.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -503,12 +503,9 @@ All methods listed here are also available to
 .. autosummary::
     normalize_intensity
     rescale_intensity
-    set_simulation_parameters
-    set_phase_parameters
 
 .. autoclass:: kikuchipy.signals.EBSDMasterPattern
     :members:
-    :undoc-members:
     :inherited-members: Signal2D
     :show-inheritance:
 
@@ -539,7 +536,6 @@ util
 .. currentmodule:: kikuchipy.signals.util
 
 .. autosummary::
-    ebsd_master_pattern_metadata
     ebsd_metadata
     metadata_nodes
 

--- a/kikuchipy/data/tests/test_data.py
+++ b/kikuchipy/data/tests/test_data.py
@@ -70,18 +70,8 @@ class TestData:
         assert isinstance(mp, EBSDMasterPattern)
         assert mp.data.shape == desired_shape
         assert np.issubdtype(mp.data.dtype, np.uint8)
-        assert (
-            mp.metadata.get_item(
-                "Simulation.EBSD_master_pattern.Master_pattern.projection"
-            )
-            == projection
-        )
-        assert (
-            mp.metadata.get_item(
-                "Simulation.EBSD_master_pattern.Master_pattern.hemisphere"
-            )
-            == hemisphere
-        )
+        assert mp.projection == projection
+        assert mp.hemisphere == hemisphere
 
         mp_lazy = data.nickel_ebsd_master_pattern_small(lazy=True)
 

--- a/kikuchipy/io/plugins/emsoft_ebsd.py
+++ b/kikuchipy/io/plugins/emsoft_ebsd.py
@@ -29,9 +29,6 @@ from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.quaternion import Rotation
 
 from kikuchipy.io.plugins.h5ebsd import hdf5group2dict
-from kikuchipy.io.plugins.emsoft_ebsd_master_pattern import (
-    _crystal_data_2_metadata,
-)
 from kikuchipy.signals.util._metadata import (
     ebsd_metadata,
     metadata_nodes,
@@ -103,13 +100,6 @@ def file_reader(
             "General": {
                 "title": f.filename.split("/")[-1].split(".")[0],
                 "original_filename": f.filename.split("/")[-1],
-            },
-            "Sample": {
-                "Phases": {
-                    "1": _crystal_data_2_metadata(
-                        hdf5group2dict(f["CrystalData"])
-                    )
-                }
             },
         }
     )

--- a/kikuchipy/io/plugins/tests/test_emsoft_ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_emsoft_ebsd.py
@@ -30,7 +30,6 @@ from kikuchipy.io.plugins.emsoft_ebsd import (
     _crystaldata2phase,
 )
 from kikuchipy.io.plugins.h5ebsd import hdf5group2dict
-from kikuchipy.signals.util._metadata import metadata_nodes
 
 DIR_PATH = os.path.dirname(__file__)
 EMSOFT_FILE = os.path.join(
@@ -44,24 +43,10 @@ class TestEMsoftEBSDReader:
         s = load(EMSOFT_FILE)
 
         assert isinstance(s.xmap, CrystalMap)
-
         assert s.data.shape == (10, 10, 10)
-
         assert s.axes_manager["dx"].scale == 70
         assert s.axes_manager["dx"].units == "um"
         assert s.axes_manager["x"].units == "px"
-
-        sem_node, ebsd_node = metadata_nodes(["sem", "ebsd"])
-        phase_node = "Sample.Phases.1"
-        desired_dict = {
-            f"{sem_node}.beam_energy": 20,
-            f"{ebsd_node}.manufacturer": "EMsoft",
-            f"{ebsd_node}.xpc": 4.86,
-            f"{phase_node}.space_group": 140,
-            f"{phase_node}.atom_coordinates.1.atom": 13,
-        }
-        for key, value in desired_dict.items():
-            assert s.metadata.get_item(key) == value
 
     @pytest.mark.parametrize("scan_size", [10, (1, 10), (5, 2)])
     def test_scan_size(self, scan_size):

--- a/kikuchipy/io/plugins/tests/test_emsoft_ebsd_masterpattern.py
+++ b/kikuchipy/io/plugins/tests/test_emsoft_ebsd_masterpattern.py
@@ -22,11 +22,9 @@ from h5py import File
 import numpy as np
 import pytest
 
-from kikuchipy.io._io import load
+from kikuchipy import load
 from kikuchipy.io.plugins.emsoft_ebsd_master_pattern import (
     _check_file_format,
-    _crystal_data_2_metadata,
-    _dict2dict_via_mapping,
     _get_data_shape_slices,
     _get_datasets,
 )
@@ -42,64 +40,12 @@ EMSOFT_FILE = os.path.join(
     DIR_PATH, "../../../data/emsoft_ebsd_master_pattern/master_patterns.h5"
 )
 
-# Settings content
 METADATA = {
     "General": {
         "original_filename": "master_patterns.h5",
         "title": "master_patterns",
     },
-    "Sample": {
-        "Phases": {
-            "1": {
-                "atom_coordinates": {
-                    "1": {
-                        "atom": 13,
-                        "coordinates": np.array([0.1587, 0.6587, 0]),
-                        "site_occupation": 1.0,
-                        "debye_waller_factor": 0.005,
-                    },
-                    "2": {
-                        "atom": 29,
-                        "coordinates": np.array([0, 0, 0.25]),
-                        "site_occupation": 1.0,
-                        "debye_waller_factor": 0.005,
-                    },
-                },
-                "lattice_constants": np.array(
-                    [0.5949, 0.5949, 0.5821, 90, 90, 90]
-                ),
-                "setting": 1,
-                "source": "Su Y.C., Yan J., Lu P.T., Su J.T.: Thermodynamic...",
-                "space_group": 140,
-            }
-        }
-    },
     "Signal": {"binned": False, "signal_type": "EBSDMasterPattern"},
-    "Simulation": {
-        "EBSD_master_pattern": {
-            "BSE_simulation": {
-                "depth_step": 1.0,
-                "energy_step": 1.0,
-                "incident_beam_energy": 20.0,
-                "max_depth": 100.0,
-                "min_beam_energy": 10.0,
-                "mode": "CSDA",
-                "number_of_electrons": 2000000000,
-                "pixels_along_x": 6,
-                "sample_tilt": 70,
-            },
-            "Master_pattern": {
-                "Bethe_parameters": {
-                    "complete_cutoff": 50.0,
-                    "strong_beam_cutoff": 4.0,
-                    "weak_beam_cutoff": 8.0,
-                },
-                "hemisphere": "north",
-                "projection": "spherical",
-                "smallest_interplanar_spacing": 0.05,
-            },
-        }
-    },
 }
 
 
@@ -292,63 +238,11 @@ class TestEMsoftEBSDMasterPatternReader:
                     hemisphere=hemisphere,
                 )
 
-    def test_dict2dict_via_mapping(self):
-        with File(EMSOFT_FILE, mode="r") as f:
-            mc_mapping = [
-                ("MCmode", "mode"),
-                ("sig", "sample_tilt"),
-                ("numsx", "pixels_along_x"),
-                ("totnum_el", "number_of_electrons"),
-                ("EkeV", "incident_beam_energy"),
-                ("Ehistmin", "min_beam_energy"),
-                ("Ebinsize", "energy_step"),
-                ("depthmax", "max_depth"),
-                ("depthstep", "depth_step"),
-            ]
-            d = _dict2dict_via_mapping(
-                dict_in=f["NMLparameters/MCCLNameList"], mapping=mc_mapping,
-            )
-
-        actual_keys = list(d.keys())
-        actual_keys.sort()
-        expected_keys = [j for _, j in mc_mapping]
-        expected_keys.sort()
-        assert actual_keys == expected_keys
-
-    def test_crystal_data_2_metadata(self):
-        group_dict = {
-            "Natomtypes": 1,
-            "Atomtypes": 13,
-            "AtomData": np.array([[0.1587], [0.6587], [0], [1], [0.005]]),
-            "CrystalSystem": 2,
-            "LatticeParameters": np.array([0.5949, 0.5949, 0.5821, 90, 90, 90]),
-            "SpaceGroupNumber": 140,
-            "SpaceGroupSetting": 1,
-            "Source": "A paper.",
-        }
-        actual_d = _crystal_data_2_metadata(group_dict)
-        desired_d = {
-            "atom_coordinates": {
-                "1": {
-                    "atom": group_dict["Atomtypes"],
-                    "coordinates": group_dict["AtomData"][:3, 0],
-                    "site_occupation": group_dict["AtomData"][3, 0],
-                    "debye_waller_factor": group_dict["AtomData"][4, 0],
-                }
-            },
-            "lattice_constants": group_dict["LatticeParameters"],
-            "setting": group_dict["SpaceGroupSetting"],
-            "space_group": group_dict["SpaceGroupNumber"],
-            "source": group_dict["Source"],
-        }
-
-        assert_dictionary(actual_d, desired_d)
-
     @pytest.mark.parametrize(
         "energy, energy_slice, desired_shape, desired_mean_energies",
         [
-            (20, slice(10, None), (2, 13, 13), [20,]),
-            (15, slice(5, 6), (2, 13, 13), [15,]),
+            (20, slice(10, None), (2, 13, 13), [20]),
+            (15, slice(5, 6), (2, 13, 13), [15]),
             ((15, 20), slice(5, None), (2, 6, 13, 13), np.linspace(15, 20, 6)),
             ((19, 20), slice(9, None), (2, 2, 13, 13), np.linspace(19, 20, 2)),
         ],

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -98,10 +98,7 @@ class EBSD(CommonImage, Signal2D):
             px_size=self.axes_manager.signal_axes[0].scale,
         )
 
-        if "xmap" in kwargs:
-            self._xmap = kwargs.pop("xmap")
-        else:
-            self._xmap = None
+        self._xmap = kwargs.pop("xmap", None)
 
         # Update metadata if object is initialised from numpy array
         if not self.metadata.has_item(metadata_nodes("ebsd")):

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -16,19 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union, List
-
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy._lazy_signals import LazySignal2D
-from hyperspy.misc.utils import DictionaryTreeBrowser
-import numpy as np
+from orix.crystal_map import Phase
 
-from kikuchipy.signals.util._metadata import (
-    ebsd_master_pattern_metadata,
-    metadata_nodes,
-    _update_phase_info,
-    _write_parameters_to_dictionary,
-)
 from kikuchipy.signals._common_image import CommonImage
 
 
@@ -36,253 +27,48 @@ class EBSDMasterPattern(CommonImage, Signal2D):
     """Simulated Electron Backscatter Diffraction (EBSD) master pattern.
 
     This class extends HyperSpy's Signal2D class for EBSD master
-    patterns.
+    patterns. Methods inherited from HyperSpy can be found in the
+    HyperSpy user guide. See the docstring of
+    :class:`hyperspy.signal.BaseSignal` for a list of additional
+    attributes.
 
-    Methods inherited from HyperSpy can be found in the HyperSpy user
-    guide.
-
-    See the docstring of :class:`hyperspy.signal.BaseSignal` for a list
-    of attributes.
-
+    Attributes
+    ----------
+    projection : str
+        Which projection the pattern is in: "spherical" or "lambert".
+    hemisphere : str
+        Which hemisphere the data contains: "north", "south" or "both".
+    phase : orix.crystal_map.phase_list.Phase
+        Phase describing the crystal structure used in the master
+        pattern simulation.
     """
 
     _signal_type = "EBSDMasterPattern"
     _alias_signal_types = ["ebsd_master_pattern", "master_pattern"]
     _lazy = False
 
+    phase = Phase()
+    projection = None
+    hemisphere = None
+
     def __init__(self, *args, **kwargs):
         """Create an :class:`~kikuchipy.signals.EBSDMasterPattern`
         object from a :class:`hyperspy.signals.Signal2D` or a
         :class:`numpy.ndarray`.
-
         """
-
         Signal2D.__init__(self, *args, **kwargs)
-
-        # Update metadata if object is initialized from numpy array or
-        # with set_signal_type()
-        if not self.metadata.has_item(metadata_nodes("ebsd_master_pattern")):
-            md = self.metadata.as_dictionary()
-            md.update(ebsd_master_pattern_metadata().as_dictionary())
-            self.metadata = DictionaryTreeBrowser(md)
-        if not self.metadata.has_item("Sample.Phases"):
-            self.set_phase_parameters()
-
-    def set_simulation_parameters(
-        self,
-        complete_cutoff: Union[None, int, float] = None,
-        depth_step: Union[None, int, float] = None,
-        energy_step: Union[None, int, float] = None,
-        hemisphere: Union[None, str] = None,
-        incident_beam_energy: Union[None, int, float] = None,
-        max_depth: Union[None, int, float] = None,
-        min_beam_energy: Union[None, int, float] = None,
-        mode: Optional[str] = None,
-        number_of_electrons: Optional[int] = None,
-        pixels_along_x: Optional[int] = None,
-        projection: Union[None, str] = None,
-        sample_tilt: Union[None, int, float] = None,
-        smallest_interplanar_spacing: Union[None, int, float] = None,
-        strong_beam_cutoff: Union[None, int, float] = None,
-        weak_beam_cutoff: Union[None, int, float] = None,
-    ):
-        """Set simulated parameters in signal metadata.
-
-        Parameters
-        ----------
-        complete_cutoff
-            Bethe parameter c3.
-        depth_step
-            Material penetration depth step size, in nm.
-        energy_step
-            Energy bin size, in keV.
-        hemisphere
-            Which hemisphere(s) the data contains.
-        incident_beam_energy
-            Incident beam energy, in keV.
-        max_depth
-            Maximum material penetration depth, in nm.
-        min_beam_energy
-            Minimum electron energy to consider, in keV.
-        mode
-            Simulation mode, e.g. Continuous slowing down
-            approximation (CSDA) used by EMsoft.
-        number_of_electrons
-            Total number of incident electrons.
-        pixels_along_x
-            Pixels along horizontal direction.
-        projection
-            Which projection the pattern is in.
-        sample_tilt
-            Sample tilte angle from horizontal, in degrees.
-        smallest_interplanar_spacing
-            Smallest interplanar spacing, d-spacing, taken into account
-            in the computation of the electrostatic lattice potential,
-            in nm.
-        strong_beam_cutoff
-            Bethe parameter c1.
-        weak_beam_cutoff
-            Bethe parameter c2.
-
-        See Also
-        --------
-        set_phase_parameters
-
-        Examples
-        --------
-        >>> import kikuchipy as kp
-        >>> ebsd_mp_node = kp.signals.util.metadata_nodes(
-        ...     "ebsd_master_pattern")
-        >>> s.metadata.get_item(ebsd_mp_node + '.incident_beam_energy')
-        15.0
-        >>> s.set_simulated_parameters(incident_beam_energy=20.5)
-        >>> s.metadata.get_item(ebsd_mp_node + '.incident_beam_energy')
-        20.5
-        """
-        md = self.metadata
-        ebsd_mp_node = metadata_nodes("ebsd_master_pattern")
-        _write_parameters_to_dictionary(
-            {
-                "BSE_simulation": {
-                    "depth_step": depth_step,
-                    "energy_step": energy_step,
-                    "incident_beam_energy": incident_beam_energy,
-                    "max_depth": max_depth,
-                    "min_beam_energy": min_beam_energy,
-                    "mode": mode,
-                    "number_of_electrons": number_of_electrons,
-                    "pixels_along_x": pixels_along_x,
-                    "sample_tilt": sample_tilt,
-                },
-                "Master_pattern": {
-                    "Bethe_parameters": {
-                        "complete_cutoff": complete_cutoff,
-                        "strong_beam_cutoff": strong_beam_cutoff,
-                        "weak_beam_cutoff": weak_beam_cutoff,
-                    },
-                    "smallest_interplanar_spacing": smallest_interplanar_spacing,
-                    "projection": projection,
-                    "hemisphere": hemisphere,
-                },
-            },
-            md,
-            ebsd_mp_node,
-        )
-
-    def set_phase_parameters(
-        self,
-        number: int = 1,
-        atom_coordinates: Optional[dict] = None,
-        formula: Optional[str] = None,
-        info: Optional[str] = None,
-        lattice_constants: Union[
-            None, np.ndarray, List[float], List[int]
-        ] = None,
-        laue_group: Optional[str] = None,
-        material_name: Optional[str] = None,
-        point_group: Optional[str] = None,
-        setting: Optional[int] = None,
-        source: Optional[str] = None,
-        space_group: Optional[int] = None,
-        symmetry: Optional[int] = None,
-    ):
-        """Set parameters for one phase in signal metadata.
-
-        A phase node with default values is created if none is present
-        in the metadata when this method is called.
-
-        Parameters
-        ----------
-        number
-            Phase number.
-        atom_coordinates
-            Dictionary of dictionaries with one or more of the atoms in
-            the unit cell, on the form `{'1': {'atom': 'Ni',
-            'coordinates': [0, 0, 0], 'site_occupation': 1,
-            'debye_waller_factor': 0}, '2': {'atom': 'O',... etc.`
-            `debye_waller_factor` in units of nm^2, and
-            `site_occupation` in range [0, 1].
-        formula
-            Phase formula, e.g. 'Fe2' or 'Ni'.
-        info
-            Whatever phase info the user finds relevant.
-        lattice_constants
-            Six lattice constants a, b, c, alpha, beta, gamma.
-        laue_group
-            Phase Laue group.
-        material_name
-            Name of material.
-        point_group
-            Phase point group.
-        setting
-            Space group's origin setting.
-        source
-            Literature reference for phase data.
-        space_group
-            Number between 1 and 230.
-        symmetry
-            Phase symmetry.
-
-        See Also
-        --------
-        set_simulation_parameters
-
-        Examples
-        --------
-        >>> s.metadata.Sample.Phases.Number_1.atom_coordinates.Number_1
-        ├── atom =
-        ├── coordinates = array([0., 0., 0.])
-        ├── debye_waller_factor = 0.0
-        └── site_occupation = 0.0
-        >>> s.set_phase_parameters(
-        ...     number=1, atom_coordinates={
-        ...         '1': {'atom': 'Ni', 'coordinates': [0, 0, 0],
-        ...         'site_occupation': 1,
-        ...         'debye_waller_factor': 0.0035}})
-        >>> s.metadata.Sample.Phases.Number_1.atom_coordinates.Number_1
-        ├── atom = Ni
-        ├── coordinates = array([0., 0., 0.])
-        ├── debye_waller_factor = 0.0035
-        └── site_occupation = 1
-        """
-        # Ensure atom coordinates are numpy arrays
-        if atom_coordinates is not None:
-            for phase, val in atom_coordinates.items():
-                atom_coordinates[phase]["coordinates"] = np.array(
-                    atom_coordinates[phase]["coordinates"]
-                )
-
-        inputs = {
-            "atom_coordinates": atom_coordinates,
-            "formula": formula,
-            "info": info,
-            "lattice_constants": lattice_constants,
-            "laue_group": laue_group,
-            "material_name": material_name,
-            "point_group": point_group,
-            "setting": setting,
-            "source": source,
-            "space_group": space_group,
-            "symmetry": symmetry,
-        }
-
-        # Remove None values
-        phase = {k: v for k, v in inputs.items() if v is not None}
-        _update_phase_info(self.metadata, phase, number)
+        self.phase = kwargs.pop("phase", Phase())
+        self.projection = kwargs.pop("projection", None)
+        self.hemisphere = kwargs.pop("hemisphere", None)
 
 
 class LazyEBSDMasterPattern(EBSDMasterPattern, LazySignal2D):
     """Lazy implementation of the :class:`EBSDMasterPattern` class.
 
     This class extends HyperSpy's LazySignal2D class for EBSD master
-    patterns.
-
-    Methods inherited from HyperSpy can be found in the HyperSpy user
-    guide.
-
-    See docstring of :class:`EBSDMasterPattern` for attributes and
-    methods.
-
+    patterns. Methods inherited from HyperSpy can be found in the
+    HyperSpy user guide. See docstring of :class:`EBSDMasterPattern`
+    for attributes and methods.
     """
 
     _lazy = True

--- a/kikuchipy/signals/tests/test_ebsd_masterpattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_masterpattern.py
@@ -98,6 +98,9 @@ class TestIO:
         assert s3.axes_manager.as_dictionary() == axes_manager
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
+    @pytest.mark.parametrize(
+        "save_path_hdf5", ["hspy"], indirect=["save_path_hdf5"]
+    )
     def test_original_metadata_save_load_cycle(self, save_path_hdf5):
         s = nickel_ebsd_master_pattern_small()
 

--- a/kikuchipy/signals/tests/test_ebsd_masterpattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_masterpattern.py
@@ -90,6 +90,12 @@ class TestIO:
         assert s3.axes_manager.as_dictionary() == axes_manager
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
+    def test_property_handling_load_save_cycle(self):
+        """A set property is nicely saved to and subsequently loaded from a
+        HDF5 file in the HyperSpy format (HSPY).
+        """
+        pass
+
 
 class TestMetadata:
     def test_set_simulation_parameters(self):
@@ -166,3 +172,13 @@ class TestMetadata:
         md_dict = s.metadata.get_item("Sample.Phases.1").as_dictionary()
         p.pop("number")
         assert_dictionary(p, md_dict)
+
+    # @pytest.mark.parametrize("parameter, value")
+    def test_setting_property_updates_metadata(self):
+        """Setting a property updates the corresponding metadata parameter."""
+        pass
+
+    # @pytest.mark.parametrize("parameter, value")
+    def test_setting_metadata_updates_property(self):
+        """Setting a metadata parameter updates the corresponding property."""
+        pass

--- a/kikuchipy/signals/util/__init__.py
+++ b/kikuchipy/signals/util/__init__.py
@@ -18,14 +18,9 @@
 
 """Signal utilities, mostly for handling signal metadata and attributes."""
 
-from kikuchipy.signals.util._metadata import (
-    ebsd_master_pattern_metadata,
-    ebsd_metadata,
-    metadata_nodes,
-)
+from kikuchipy.signals.util._metadata import ebsd_metadata, metadata_nodes
 
 __all__ = [
-    "ebsd_master_pattern_metadata",
     "ebsd_metadata",
     "metadata_nodes",
 ]

--- a/kikuchipy/signals/util/_metadata.py
+++ b/kikuchipy/signals/util/_metadata.py
@@ -67,55 +67,10 @@ def ebsd_metadata() -> DictionaryTreeBrowser:
     return md
 
 
-def ebsd_master_pattern_metadata() -> DictionaryTreeBrowser:
-    """Return a dictionary in HyperSpy's DictionaryTreeBrowser format
-    with the default kikuchipy EBSD master pattern metadata.
-
-    The parameters are chosen based on the contents in EMsoft's EBSD
-    master pattern HDF5 file.
-
-    See
-    :meth:`~kikuchipy.signals.EBSDMasterPattern.set_simulation_parameters`
-    for an explanation of the parameters.
-
-    Returns
-    -------
-    md : hyperspy.misc.utils.DictionaryTreeBrowser
-    """
-    ebsd_master_pattern = {
-        "BSE_simulation": {
-            "depth_step": -1.0,
-            "energy_step": -1.0,
-            "incident_beam_energy": -1.0,
-            "max_depth": -1.0,
-            "min_beam_energy": -1.0,
-            "mode": "",
-            "number_of_electrons": -1,
-            "pixels_along_x": -1,
-            "sample_tilt": -1.0,
-        },
-        "Master_pattern": {
-            "Bethe_parameters": {
-                "complete_cutoff": -1.0,
-                "strong_beam_cutoff": -1.0,
-                "weak_beam_cutoff": -1.0,
-            },
-            "smallest_interplanar_spacing": -1.0,
-            "projection": "",
-            "hemisphere": "",
-        },
-    }
-
-    md = DictionaryTreeBrowser()
-    md.set_item(metadata_nodes("ebsd_master_pattern"), ebsd_master_pattern)
-
-    return md
-
-
 def metadata_nodes(
     nodes: Union[None, str, List[str]] = None
 ) -> Union[List[str], str, List]:
-    """Return SEM, EBSD and/or EBSD master pattern metadata nodes.
+    """Return SEM and/or EBSD metadata nodes.
 
     This is a convenience function so that we only have to define these
     node strings here.
@@ -123,9 +78,8 @@ def metadata_nodes(
     Parameters
     ----------
     nodes
-        Metadata nodes to return. Options are "sem", "ebsd",
-        "ebsd_master_pattern" or None. If None (default) is passed, all
-        nodes are returned.
+        Metadata nodes to return. Options are "sem", "ebsd", or None.
+        If None (default) is passed, all nodes are returned.
 
     Returns
     -------
@@ -134,7 +88,6 @@ def metadata_nodes(
     available_nodes = {
         "sem": "Acquisition_instrument.SEM",
         "ebsd": "Acquisition_instrument.SEM.Detector.EBSD",
-        "ebsd_master_pattern": "Simulation.EBSD_master_pattern",
     }
 
     if nodes is None:

--- a/kikuchipy/signals/util/tests/test_metadata.py
+++ b/kikuchipy/signals/util/tests/test_metadata.py
@@ -20,7 +20,6 @@ import pytest
 
 from kikuchipy.signals.util._metadata import (
     ebsd_metadata,
-    ebsd_master_pattern_metadata,
     metadata_nodes,
     _set_metadata_from_mapping,
 )
@@ -36,36 +35,11 @@ class TestMetadata:
     def test_metadata_nodes(self):
         sem_node = "Acquisition_instrument.SEM"
         ebsd_node = sem_node + ".Detector.EBSD"
-        simulation_node = "Simulation"
-        ebsd_master_pattern_node = simulation_node + ".EBSD_master_pattern"
 
         assert metadata_nodes("sem") == sem_node
         assert metadata_nodes("ebsd") == ebsd_node
-        assert metadata_nodes() == [
-            sem_node,
-            ebsd_node,
-            ebsd_master_pattern_node,
-        ]
-        assert metadata_nodes(["ebsd", "sem"]) == [
-            ebsd_node,
-            sem_node,
-        ]
-        assert metadata_nodes(["sem", "ebsd_master_pattern"]) == [
-            sem_node,
-            ebsd_master_pattern_node,
-        ]
-
-    def test_ebsd_masterpattern_metadata(self):
-        ebsd_mp_node = metadata_nodes("ebsd_master_pattern")
-        md = ebsd_master_pattern_metadata()
-
-        assert md.get_item(ebsd_mp_node + ".BSE_simulation.mode") == ""
-        assert (
-            md.get_item(
-                ebsd_mp_node + ".Master_pattern.smallest_interplanar_spacing"
-            )
-            == -1.0
-        )
+        assert metadata_nodes() == [sem_node, ebsd_node]
+        assert metadata_nodes(["ebsd", "sem"]) == [ebsd_node, sem_node]
 
     def test_set_metadata_from_mapping(self):
         """Updating DictionaryTreeBrowser with values from a dictionary


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Remove the EBSDMasterPattern metadata Simulation node, since it is unused by the class.
* Instead, we add three settable attributes projection (str), hemisphere (str) and phase (orix Phase), which WILL be used in the class (#239). These can also be used when creating a master pattern class via init (see example below).
* Remove the `EBSDMasterPattern.set_simulation_parameters()` and `EBSDMasterPattern.set_phase_parameters()` methods.
* All parameter info from EMsoft's master pattern HDF5 file is stored in the original_metadata property, which carries over when saving and loading HDF5 files in the HyperSpy format. The three added properties above DOES NOT carry over in a save/load with ANY format supported by kikuchipy or HyperSpy... We will address this in the future if necessary.
* The EBSD master pattern metadata and Sample.Phases node is removed from the user guide page.

I hope to adopt this approach for the EBSD class as well, removing various metadata setting methods, so that all relevant parameters are available via e.g. `EBSD.acceleration_voltage` etc. (talking to the metadata, of course).

#### Progress of the PR

- [x] Add properties
- [x] Remove (old) metadata setting methods
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### Minimal example of the bug fix or new feature

```python
>>> import kikuchipy as kp
>>> from orix.crystal_map import Phase
>>> s_mp = kp.data.nickel_ebsd_master_pattern_small(projection="lambert")
>>> s_mp.projection
lambert
>>> s_mp.phase.point_group.contains_inversion
True
>>> s_mp2 = kp.signals.EBSDMasterPattern(
...     np.zeros((2, 10, 11, 11)), hemisphere="both", projection="lambert", phase=Phase("a")
... )
>>> s_mp2.phase.name
a
```

#### For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
