### PR TITLE
Update README, add Binder badge, always build all notebooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,16 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: coverage report --show-missing
       - name: Upload coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: AndreMiras/coveralls-python-action@develop
-  
+        with:
+          parallel: true
+
+  coveralls-finish:
+    needs: build-with-pip
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls finished
+      uses: AndreMiras/coveralls-python-action@develop
+      with:
+        parallel-finished: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: coverage report --show-missing
       - name: Upload coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 }}
         uses: AndreMiras/coveralls-python-action@develop
   

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,7 @@
-.. GitHub Actions
-.. image:: https://github.com/pyxem/kikuchipy/workflows/build/badge.svg
-    :target: https://github.com/pyxem/kikuchipy/actions
-    :alt: Build status
-
-.. Coveralls
-.. image:: https://img.shields.io/coveralls/github/pyxem/kikuchipy.svg
-    :target: https://coveralls.io/github/pyxem/kikuchipy?branch=master
-    :alt: Coveralls status
+.. Launch binder
+.. image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/pyxem/kikuchipy/HEAD
+    :alt: Launch binder
 
 .. Read the Docs
 .. image:: https://readthedocs.org/projects/kikuchipy/badge/?version=latest
@@ -18,10 +13,15 @@
     :target: https://pypi.python.org/pypi/kikuchipy
     :alt: PyPI version
 
-.. Launch binder
-.. image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/pyxem/kikuchipy/HEAD
-    :alt: Launch binder
+.. GitHub Actions
+.. image:: https://github.com/pyxem/kikuchipy/workflows/build/badge.svg
+    :target: https://github.com/pyxem/kikuchipy/actions
+    :alt: Build status
+
+.. Coveralls
+.. image:: https://img.shields.io/coveralls/github/pyxem/kikuchipy.svg
+    :target: https://coveralls.io/github/pyxem/kikuchipy?branch=master
+    :alt: Coveralls status
 
 .. Total downloads
 .. image:: https://static.pepy.tech/personalized-badge/kikuchipy?&left_color=grey&right_color=yellow&left_text=downloads
@@ -40,12 +40,12 @@ The library builds on the tools for multi-dimensional data analysis provided
 by the HyperSpy library. An effort is made to keep memory usage in check and
 enable scalability by using the Dask library for pattern processing.
 
-The project is in an alpha stage, and there will likely be breaking changes with
-each release.
+The project is in an **alpha** stage, and there will likely be breaking changes
+with each release.
 
 kikuchipy is released under the GPLv3+ license.
 
-- User guide: https://kikuchipy.org
+- User guide: https://kikuchipy.org, or launch Binder and visit `doc/`
 - Contributing: https://kikuchipy.org/en/latest/contributing.html
 - Code of Conduct: https://kikuchipy.org/en/latest/code_of_conduct.html
 - Cite: If you find this project useful, please cite the DOI above.

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,8 @@ with each release...
 
 kikuchipy is released under the GPLv3+ license.
 
-- User guide: https://kikuchipy.org, or launch Binder and visit ``doc/``
+- User guide: https://kikuchipy.org, or launch Binder, visit ``doc/`` and run
+  the Jupyter Notebooks
 - Contributing: https://kikuchipy.org/en/latest/contributing.html
 - Code of Conduct: https://kikuchipy.org/en/latest/code_of_conduct.html
 - Cite: If you find this project useful, please cite the DOI above.

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,13 @@
     :target: https://pypi.python.org/pypi/kikuchipy
     :alt: PyPI version
 
+.. Launch binder
+.. image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/pyxem/kikuchipy/HEAD
+    :alt: Launch binder
+
 .. Total downloads
-.. image:: https://pepy.tech/badge/kikuchipy
+.. image:: https://static.pepy.tech/personalized-badge/kikuchipy?&left_color=grey&right_color=yellow&left_text=downloads
     :target: https://github.com/pyxem/kikuchipy
     :alt: Total downloads
 
@@ -40,29 +45,7 @@ each release.
 
 kikuchipy is released under the GPLv3+ license.
 
-User guide
-----------
-Installation instructions, a user guide and the full API reference are available
-from `our webpage <https://kikuchipy.org>`_.
-
-Tutorials and example workflows
--------------------------------
-Jupyter Notebooks that you can work through and modify to perform processing and
-analyses of EBSD patterns are available `here
-<https://github.com/pyxem/kikuchipy-demos>`_. For learning purposes, we
-recommend to use them alongside our user guide.
-
-Contributing
-------------
-Everyone is welcome to contribute. Please read our `contributor guide
-<https://kikuchipy.org/en/latest/contributing.html>`_ to get started!
-
-Code of Conduct
----------------
-kikuchipy has a `Code of Conduct
-<https://kikuchipy.org/en/latest/code_of_conduct.html>`_ that should be honoured
-by everyone who participates in the kikuchipy community.
-
-Cite
-----
-If you find this project useful, please cite the DOI above.
+- User guide: https://kikuchipy.org
+- Contributing: https://kikuchipy.org/en/latest/contributing.html
+- Code of Conduct: https://kikuchipy.org/en/latest/code_of_conduct.html
+- Cite: If you find this project useful, please cite the DOI above.

--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,6 @@
     :target: https://kikuchipy.org/en/latest/
     :alt: Documentation status
 
-.. PyPI version
-.. image:: https://img.shields.io/pypi/v/kikuchipy.svg
-    :target: https://pypi.python.org/pypi/kikuchipy
-    :alt: PyPI version
-
 .. GitHub Actions
 .. image:: https://github.com/pyxem/kikuchipy/workflows/build/badge.svg
     :target: https://github.com/pyxem/kikuchipy/actions
@@ -22,6 +17,11 @@
 .. image:: https://img.shields.io/coveralls/github/pyxem/kikuchipy.svg
     :target: https://coveralls.io/github/pyxem/kikuchipy?branch=master
     :alt: Coveralls status
+
+.. PyPI version
+.. image:: https://img.shields.io/pypi/v/kikuchipy.svg
+    :target: https://pypi.python.org/pypi/kikuchipy
+    :alt: PyPI version
 
 .. Total downloads
 .. image:: https://static.pepy.tech/personalized-badge/kikuchipy?&left_color=grey&right_color=yellow&left_text=downloads
@@ -40,12 +40,12 @@ The library builds on the tools for multi-dimensional data analysis provided
 by the HyperSpy library. An effort is made to keep memory usage in check and
 enable scalability by using the Dask library for pattern processing.
 
-The project is in an **alpha** stage, and there will likely be breaking changes
-with each release.
+The project is in an **alpha** stage, so there will likely be breaking changes
+with each release...
 
 kikuchipy is released under the GPLv3+ license.
 
-- User guide: https://kikuchipy.org, or launch Binder and visit `doc/`
+- User guide: https://kikuchipy.org, or launch Binder and visit ``doc/``
 - Contributing: https://kikuchipy.org/en/latest/contributing.html
 - Code of Conduct: https://kikuchipy.org/en/latest/code_of_conduct.html
 - Cite: If you find this project useful, please cite the DOI above.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,8 @@ Contributors
 
 Added
 -----
+- Link to Binder in README and in the notebooks for running them in the browser.
+  (`#257 <https://github.com/pyxem/kikuchipy/pull/257>`_)
 - A data module with a small Nickel EBSD data set and master pattern, and a
   larger EBSD data set downloadable via the module. Two dependencies, pooch and
   tqdm, are added along with this module.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,6 +116,8 @@ nbsphinx_prolog = r"""
     <div class="admonition note">
       This page was generated from
       <a class="reference external" href="https://github.com/pyxem/kikuchipy/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
+      Interactive online version:
+      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/pyxem/kikuchipy/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
       <script>
         if (document.location.host) {
           $(document.currentScript).replaceWith(

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,6 +136,8 @@ nbsphinx_prolog = r"""
     \textcolor{gray}{The following section was generated from
     \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
 """
+# https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
+nbsphinx_execute = "always"  # auto, always, never
 
 
 def linkcode_resolve(domain, info):


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Simplify README
* Tell nbsphinx to always build notebooks
* Add Binder launch badge

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)
- [x] Go over wording in readme again
- [x] See if launching of the Binder can be sped up
- [x] Improve use of Binder

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
