### PR TITLE
Point Binder and nbviewer to GitHub master links when built from dev versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,3 @@ jobs:
       - name: Upload coverage to Coveralls
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel: true
-
-  coveralls-finish:
-    needs: build-with-pip
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls finished
-      uses: AndreMiras/coveralls-python-action@develop
-      with:
-        parallel-finished: true

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@
     :target: https://pypi.python.org/pypi/kikuchipy
     :alt: PyPI version
 
-.. Total downloads
-.. image:: https://static.pepy.tech/personalized-badge/kikuchipy?&left_color=grey&right_color=yellow&left_text=downloads
-    :target: https://github.com/pyxem/kikuchipy
-    :alt: Total downloads
+.. Downloads per month
+.. image:: https://static.pepy.tech/personalized-badge/kikuchipy?period=month&left_color=grey&right_color=yellow&left_text=downloads/month
+    :target: https://pepy.tech/project/kikuchipy
+    :alt: Downloads per month
 
 .. Zenodo DOI
 .. image:: https://zenodo.org/badge/doi/10.5281/zenodo.3597646.svg

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -152,7 +152,7 @@ nbsphinx_prolog = (
 """
 )
 # https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
-nbsphinx_execute = "auto"  # auto, always, never
+nbsphinx_execute = "always"  # auto, always, never
 
 
 def linkcode_resolve(domain, info):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -104,9 +104,17 @@ html_theme_options = {
 numfig = True
 
 # nbsphinx configuration
-# Taken from nbsphinx' own nbsphinx configuration file.
+# Taken from nbsphinx' own nbsphinx configuration file, with slight
+# modification to point nbviewer and Binder to the GitHub master links
+# when the documentation is launched from a kikuchipy version with
+# "dev" in the version.
+if "dev" in version:
+    release_version = "master"
+else:
+    release_verision = version
 # This is processed by Jinja2 and inserted before each notebook
-nbsphinx_prolog = r"""
+nbsphinx_prolog = (
+    r"""
 {% set docname = 'doc/' + env.doc2path(env.docname, base=None) %}
 
 .. raw:: html
@@ -115,9 +123,13 @@ nbsphinx_prolog = r"""
 
     <div class="admonition note">
       This page was generated from
-      <a class="reference external" href="https://github.com/pyxem/kikuchipy/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
+      <a class="reference external" href="https://github.com/pyxem/kikuchipy/blob/"""
+    + f"{release_version}"
+    + r"""/{{ docname|e }}">{{ docname|e }}</a>.
       Interactive online version:
-      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/pyxem/kikuchipy/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/pyxem/kikuchipy/"""
+    + f"{release_version}"
+    + r"""?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
       <script>
         if (document.location.host) {
           $(document.currentScript).replaceWith(
@@ -138,8 +150,9 @@ nbsphinx_prolog = r"""
     \textcolor{gray}{The following section was generated from
     \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
 """
+)
 # https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
-nbsphinx_execute = "always"  # auto, always, never
+nbsphinx_execute = "auto"  # auto, always, never
 
 
 def linkcode_resolve(domain, info):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [tool:pytest]
-filterwarnings =
-    ignore::DeprecationWarning
+addopts = -ra
 
 [coverage:run]
 source = kikuchipy
@@ -8,5 +7,8 @@ omit =
     setup.py
     kikuchipy/release.py
 relative_files = True
+
+[coverage:report]
+precision = 2
 
 # Note that Black does not support setup.cfg


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change

* Fix #258.
* In user guide pages built from Jupyter Notebooks on development versions (with `dev` in `kikuchipy.version`), point Binder and nbviewer to the `master` branch links instead of e.g. `0.3.dev0`, which points nowhere.
* Try to simplify Coveralls GitHub Action...

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
