### PR TITLE
Ensure use of Rotation.size gives int in master pattern sampling

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,6 +154,9 @@ nbsphinx_prolog = (
 # https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
 nbsphinx_execute = "always"  # auto, always, never
 
+# sphinxcontrib-bibtex configuration
+bibtex_bibfiles = ["bibliography.bib"]
+
 
 def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object.

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -163,7 +163,7 @@ class EBSDMasterPattern(CommonImage, Signal2D):
 
         npx, npy = self.axes_manager.signal_shape
         dc = _get_direction_cosines(detector)
-        n = rotations.size
+        n = int(rotations.size)
         det_y, det_x = detector.shape
         dtype_out = dtype_out
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change


* Ensure use of Rotation.size gives int in master pattern sampling.
* Add `sphinxcontrib-bibtex` config parameter in the Sphinx configuration file

This adddresses an overflow warning @friedkitteh discovered when sampling EBSD patterns from a master pattern. I haven't experienced it myself, but I believe the reason for the warning comes from the `orix.base.Object3d.size` attribute not always returning an integer, since it uses `np.prod(self.shape)`, which in my experience doesn't always return an integer even though the `np.ndarray.shape` attribute is a tuple of integers...

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
