### PR TITLE
Add crystal map for EBSD signal from master pattern

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@
     :alt: PyPI version
 
 .. Downloads per month
-.. image:: https://static.pepy.tech/personalized-badge/kikuchipy?period=month&left_color=grey&right_color=yellow&left_text=downloads/month
-    :target: https://pepy.tech/project/kikuchipy
+.. image:: https://img.shields.io/pypi/dm/kikuchipy.svg
+    :target: https://pypistats.org/packages/kikuchipy
     :alt: Downloads per month
 
 .. Zenodo DOI

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,8 @@ Contributors
 
 Added
 -----
+- EBSD.detector property storing an EBSDDetector.
+  (`#262 <https://github.com/pyxem/kikuchipy/pull/262>`_)
 - Link to Binder in README and in the notebooks for running them in the browser.
   (`#257 <https://github.com/pyxem/kikuchipy/pull/257>`_)
 - A data module with a small Nickel EBSD data set and master pattern, and a
@@ -65,7 +67,7 @@ Changed
 - The EBSDMasterPattern gets phase, hemisphere and projection properties.
   (`#246 <https://github.com/pyxem/kikuchipy/pull/246>`_)
 - EMsoft EBSD master pattern plugin can read a single energy pattern. Parameter
-  `energy_range`  changed to `energy`.
+  `energy_range` changed to `energy`.
   (`240 <https://github.com/pyxem/kikuchipy/pull/240>`_)
 - Migrate user guide from reST files to Jupyter Notebooks converted to HTML with
   the `nbsphinx` package.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,8 +39,7 @@ Added
   creation of similarity metrics used in pattern matching, (2) computation of an
   orientation similarity map from indexing results, and (3) creation of a multi
   phase crystal map from single phase maps from pattern matching.
-- EBSD.xmap property storing an orix CrystalMap object. So far only read from
-  a EMsoft simulated EBSD pattern file. Relevant documentation updated.
+- EBSD.xmap property storing an orix CrystalMap.
   (`#226 <https://github.com/pyxem/kikuchipy/pull/226>`_)
 - Dependency on the diffsims package for handling of electron scattering and
   diffraction. (`#220 <https://github.com/pyxem/kikuchipy/pull/220>`_)

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -83,9 +83,14 @@ ADAPT_EQ_UINT8_SKIMAGE16 = np.array(
 ADAPT_EQ_UINT8_SKIMAGE17 = np.array(
     [[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8
 )
+ADAPT_EQ_UINT8_SKIMAGE18 = np.array(
+    [[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8
+)
 ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE16
-if skimage_version[2:4] == str(17):
+if skimage_version[2:4] == str(17):  # pragma: no cover
     ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE17
+elif skimage_version[2:4] == str(18):  # pragma: no cover
+    ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE18
 
 
 class TestRescaleIntensityChunk:

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -198,11 +198,13 @@ class EBSDMasterPattern(CommonImage, Signal2D):
         names = ["x", "dy", "dx"]
         scales = np.ones(3)
 
-        # Create crystal map
-        xmap = CrystalMap(
-            phase_list=PhaseList(self.phase), rotations=rotations,
+        # Add crystal map and detector to keyword arguments
+        kwargs = dict(
+            xmap=CrystalMap(
+                phase_list=PhaseList(self.phase), rotations=rotations,
+            ),
+            detector=detector,
         )
-        kwargs = dict(xmap=xmap)
 
         # Create axis objects for each axis
         axes = [

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -23,7 +23,7 @@ import dask.array as da
 from hyperspy._lazy_signals import LazySignal2D
 from hyperspy._signals.signal2d import Signal2D
 import numpy as np
-from orix.crystal_map import Phase
+from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.vector import Vector3d
 from orix.quaternion import Rotation
 
@@ -81,36 +81,37 @@ class EBSDMasterPattern(CommonImage, Signal2D):
         dtype_out: type = np.float32,
         compute: bool = False,
     ) -> Union[EBSD, LazyEBSD]:
-        """Creates a dictionary of EBSD patterns for a sample in the
-        EDAX TSL (RD, TD, ND) reference frame, given a set of local
-        crystal lattice rotations and a detector model from a master
-        pattern in the Lambert projection.
+        """Return a dictionary of EBSD patterns projected onto a
+        detector from a master pattern in the Lambert projection, for a
+        set of crystal rotations relative to the EDAX TSL sample
+        reference frame (RD, TD, ND) and a fixed detector-sample
+        geometry.
 
         Parameters
         ----------
         rotations : Rotation
-            Set of unit cell rotations to get patterns from.
+            Set of crystal rotations to get patterns from.
         detector : EBSDDetector
-            EBSDDetector object describing the detector geometry with a
-            single, fixed projection/pattern center.
+            EBSD detector describing the detector dimensions and the
+            detector-sample geometry with a single, fixed
+            projection/pattern center.
         energy : int
-            The wanted energy in the master pattern.
+            Master pattern energy, in kV.
         n_chunk : int, optional
-            The number of chunks the data should be split up into. By
-            default, this is set so each chunk is around 100 MB.
+            Number of dask chunks the pattern projection computation
+            should be split into. By default, this is set so each chunk
+            is around a maximum of 100 MB.
         dtype_out : type, optional
             Data type of the returned patterns, by default np.float32.
         compute : bool, optional
-            Whether or not the dask.compute() function should be called
-            and read the patterns into memory, by default false.
-            For more information see: :func:`dask.array.Array.compute`.
+            Whether to return a lazy result, by default False. For more
+            information see :func:`~dask.array.Array.compute`.
 
         Returns
         -------
         EBSD or LazyEBSD
-            All the simulated EBSD patterns with the shape (number of
-            rotations, detector pixels in x direction, detector pixels
-            in y direction).
+            EBSD patterns with the shape
+            `(rotations.size,) + detector.shape`.
 
         Notes
         -----
@@ -122,12 +123,12 @@ class EBSDMasterPattern(CommonImage, Signal2D):
         """
         if self.projection != "lambert":
             raise NotImplementedError(
-                "Method only supports master patterns in Lambert projection!"
+                "Method only supports master patterns in Lambert projection"
             )
         pc = detector.pc_emsoft()
         if len(pc) > 1:
-            raise ValueError(
-                "Method only supports a single projection/pattern center!"
+            raise NotImplementedError(
+                "Method only supports a single projection/pattern center"
             )
 
         # 4 cases
@@ -141,8 +142,8 @@ class EBSDMasterPattern(CommonImage, Signal2D):
         elif len(self.axes_manager.shape) == 2:
             if not self.phase.point_group.contains_inversion:
                 raise AttributeError(
-                    "For phases without inversion symmetry, "
-                    "both hemispheres must be in master pattern!"
+                    "For phases without inversion symmetry, both hemispheres "
+                    "must be in the master pattern"
                 )
             mpn = self.data
             mps = mpn
@@ -151,8 +152,8 @@ class EBSDMasterPattern(CommonImage, Signal2D):
                 energies = self.axes_manager["energy"].axis
                 if not self.phase.point_group.contains_inversion:
                     raise AttributeError(
-                        "For phases without inversion symmetry, both"
-                        "hemispheres must be in master pattern!"
+                        "For phases without inversion symmetry, both "
+                        "hemispheres must be in the master pattern"
                     )
                 energy_index = (np.abs(energies - energy)).argmin()
                 mpn = self.data[energy_index]
@@ -197,6 +198,12 @@ class EBSDMasterPattern(CommonImage, Signal2D):
         names = ["x", "dy", "dx"]
         scales = np.ones(3)
 
+        # Create crystal map
+        xmap = CrystalMap(
+            phase_list=PhaseList(self.phase), rotations=rotations,
+        )
+        kwargs = dict(xmap=xmap)
+
         # Create axis objects for each axis
         axes = [
             {
@@ -210,8 +217,9 @@ class EBSDMasterPattern(CommonImage, Signal2D):
             for i in range(simulated.ndim)
         ]
         if compute:
-            return EBSD(simulated.compute(), axes=axes)
-        return LazyEBSD(simulated, axes=axes)
+            return EBSD(simulated.compute(), axes=axes, **kwargs)
+        else:
+            return LazyEBSD(simulated, axes=axes, **kwargs)
 
 
 class LazyEBSDMasterPattern(EBSDMasterPattern, LazySignal2D):
@@ -244,7 +252,6 @@ def _get_direction_cosines(detector: EBSDDetector) -> Vector3d:
     Vector3d
         Direction cosines for each detector pixel.
     """
-
     pc = detector.pc_emsoft()
     xpc = pc[..., 0]
     ypc = pc[..., 1]
@@ -372,7 +379,7 @@ def _get_patterns_chunk(
     Parameters
     ----------
     r : Rotation
-        Rotation object with all the rotations for a given chunk.
+        Rotations for a given chunk.
     dc : Vector3d
         Direction cosines unit vector between detector and sample.
     master_north : numpy.ndarray
@@ -453,8 +460,7 @@ def _min_number_of_chunks(
     Returns
     -------
     int
-       The minimum number of chunks required so each chunk is around
-       100 MB.
+       Minimum number of chunks required so each chunk is around 100 MB.
     """
     dy, dx = detector_shape
     nbytes = dy * dx * n_rotations * np.dtype(dtype_out).itemsize

--- a/kikuchipy/signals/tests/test_ebsd_masterpattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_masterpattern.py
@@ -320,21 +320,21 @@ class TestSimulatedPatternDictionary:
         n_chunks = _min_number_of_chunks(self.detector.shape, 117000, np.uint8)
         assert n_chunks == 360
 
-    def test_simulated_patterns_xmap(self):
+    def test_simulated_patterns_xmap_detector(self):
         mp = nickel_ebsd_master_pattern_small(projection="lambert")
         r = Rotation.from_euler([[0, 0, 0], [0, np.pi / 2, 0]])
-
-        s = mp.get_patterns(
-            rotations=r,
-            detector=EBSDDetector(
-                shape=(60, 60),
-                pc=[0.5, 0.5, 0.5],
-                sample_tilt=70,
-                convention="tsl",
-            ),
-            energy=20,
+        detector = EBSDDetector(
+            shape=(60, 60),
+            pc=[0.5, 0.5, 0.5],
+            sample_tilt=70,
+            convention="tsl",
         )
+        s = mp.get_patterns(rotations=r, detector=detector, energy=20)
 
         assert np.allclose(s.xmap.rotations.to_euler(), r.to_euler())
         assert s.xmap.phases.names == [mp.phase.name]
         assert s.xmap.phases[0].point_group.name == mp.phase.point_group.name
+
+        assert s.detector.shape == detector.shape
+        assert np.allclose(s.detector.pc, detector.pc)
+        assert s.detector.sample_tilt == detector.sample_tilt

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         "numpy >= 1.18",
         "numba >= 0.48",
         "orix >= 0.5",
-        "pooch",
+        "pooch >= 0.13",
         "psutil",
         "tqdm >= 0.5.2",
         "scikit-image >= 0.16",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Add crystal map for EBSD signal of projected patterns from master pattern
* Minor docstring changes to `EBSDMasterPattern.get_patterns()`

#### Progress of the PR

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean style in [as per black](https://black.readthedocs.io/en/stable/the_black_code_style.html)
- [x] Add detector as well

#### Minimal example of the bug fix or new feature

```python
>>> import numpy as np
>>> from orix.quaternion import Rotation
>>> import kikuchipy as kp
>>> mp = nickel_ebsd_master_pattern_small(projection="lambert")
>>> r = Rotation.from_euler([[0, 0, 0], [0, np.pi / 2, 0]])
>>> s = mp.get_patterns(
...     rotations=r,
...     detector=kp.detectors.EBSDDetector(
...         shape=(60, 60),
...         pc=[0.5, 0.5, 0.5],
...         sample_tilt=70,
...         convention="tsl",
....    ),
...     energy=20,
... )
>>> s.xmap
Phase  Orientations  Name  Space group  Point group  Proper point group     Color
    0    2 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue
Properties: 
Scan unit: px
```

#### For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.