### PR TITLE
Write/read support for EBSD signal with 0/1 navigation dimension in kikuchipy's h5ebsd format

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,7 +24,7 @@ Contributors
 Added
 -----
 - Support for writing/reading an EBSD signal with 1 or 0 navigation axes to/from
-  an h5ebsd file in the kikuchipy format.
+  a kikuchipy h5ebsd file.
   (`#276 <https://github.com/pyxem/kikuchipy/pull/276>`_)
 - User guide notebook showing basic pattern matching.
   (`#263 <https://github.com/pyxem/kikuchipy/pull/263>`_)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,9 @@ Contributors
 
 Added
 -----
+- Support for writing/reading an EBSD signal with 1 or 0 navigation axes to/from
+  an h5ebsd file in the kikuchipy format.
+  (`#276 <https://github.com/pyxem/kikuchipy/pull/276>`_)
 - User guide notebook showing basic pattern matching.
   (`#263 <https://github.com/pyxem/kikuchipy/pull/263>`_)
 - EBSD.detector property storing an EBSDDetector.

--- a/kikuchipy/io/plugins/nordif.py
+++ b/kikuchipy/io/plugins/nordif.py
@@ -44,7 +44,7 @@ full_support = False
 # Recognised file extension
 file_extensions = ["dat"]
 default_extension = 0
-# Writing capabilities
+# Writing capabilities (signal dimensions, navigation dimensions)
 writes = [(2, 2), (2, 1), (2, 0)]
 
 

--- a/kikuchipy/io/plugins/tests/test_h5ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_h5ebsd.py
@@ -362,10 +362,12 @@ class Testh5ebsd:
             _ = hdf5group2dict(group=f["/"], lazy=True)
 
     def test_save_load_1d_nav(self, save_path_hdf5):
+        """Save-load cycle of signals with one navigation dimension."""
         desired_shape = (3, 60, 60)
         desired_nav_extent = (0, 3)
-
         s = nickel_ebsd_small()
+
+        # One column of patterns
         s_y_only = s.inav[0]
         s_y_only.save(save_path_hdf5)
         s_y_only2 = load(save_path_hdf5)
@@ -373,6 +375,7 @@ class Testh5ebsd:
         assert s_y_only2.axes_manager.navigation_axes[0].name == "y"
         assert s_y_only2.axes_manager.navigation_extent == desired_nav_extent
 
+        # One row of patterns
         s_x_only = s.inav[:, 0]
         s_x_only.save(save_path_hdf5, overwrite=True)
         s_x_only2 = load(save_path_hdf5)
@@ -380,6 +383,7 @@ class Testh5ebsd:
         assert s_x_only2.axes_manager.navigation_axes[0].name == "x"
         assert s_x_only2.axes_manager.navigation_extent == desired_nav_extent
 
+        # Maintain axis name
         s_y_only2.axes_manager["y"].name = "x"
         s_y_only2.save(save_path_hdf5, overwrite=True)
         s_x_only3 = load(save_path_hdf5)
@@ -388,6 +392,7 @@ class Testh5ebsd:
         assert s_x_only3.axes_manager.navigation_extent == desired_nav_extent
 
     def test_save_load_0d_nav(self, save_path_hdf5):
+        """Save-load cycle of a signal with no navigation dimension."""
         s = nickel_ebsd_small()
         s0 = s.inav[0, 0]
         s0.save(save_path_hdf5)

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -89,6 +89,8 @@ class EBSD(CommonImage, Signal2D):
     def __init__(self, *args, **kwargs):
         """Create an :class:`~kikuchipy.signals.EBSD` object from a
         :class:`hyperspy.signals.Signal2D` or a :class:`numpy.ndarray`.
+        See the docstring of :class:`hyperspy.signal.BaseSignal` for
+        optional input parameters.
         """
         Signal2D.__init__(self, *args, **kwargs)
 


### PR DESCRIPTION
#### Description of the change
Write/read support for EBSD signal with 0/1 navigation dimension in kikuchipy's h5ebsd format.

Close #269.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()
>>> s
<EBSD, title: , (3, 3|60, 60)>
>>> s.inav[0].save("filename.h5")
>>> s2 = kp.load("filename.h5")
>>> s2
<EBSD, title: , (3|60, 60)>
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
