### PR TITLE
Overwrite HyperSpy's compute() w/ EBSD.xmap carried over

### DIFF
--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -1525,7 +1525,7 @@ class EBSD(CommonImage, Signal2D):
             return s_out
 
 
-class LazyEBSD(EBSD, LazySignal2D):
+class LazyEBSD(LazySignal2D, EBSD):
     """Lazy implementation of the :class:`EBSD` class.
 
     This class extends HyperSpy's LazySignal2D class for EBSD patterns.
@@ -1536,10 +1536,13 @@ class LazyEBSD(EBSD, LazySignal2D):
     See docstring of :class:`EBSD` for attributes and methods.
     """
 
-    _lazy = True
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def compute(self, *args, **kwargs):
+        xmap = self.xmap
+        super().compute(*args, **kwargs)
+        self._xmap = xmap
 
     def get_decomposition_model_write(
         self,

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -1208,11 +1208,17 @@ class TestEBSDxmapProperty:
         assert isinstance(xmap, CrystalMap)
         assert xmap.phases[0].name == "ni"
 
+    def test_attribute_carry_over_from_lazy(self, dummy_signal):
+        ssim = load(EMSOFT_FILE, lazy=True)
+        xmap_lazy = ssim.xmap.deepcopy()
+        assert isinstance(xmap_lazy, CrystalMap)
+        assert xmap_lazy.phases[0].name == "ni"
 
-class TestEBSDdetectorProperty:
-    def test_init_detector(self):
-        """The attribute is set correctly."""
-        pass
+        ssim.compute()
+        xmap = ssim.xmap
+        assert isinstance(xmap, CrystalMap)
+        assert xmap.phases[0].name == "ni"
+        assert np.allclose(xmap.rotations.data, xmap_lazy.rotations.data)
 
 
 class TestPatternMatching:


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
`LazyEBSD.compute()` is overwritten so the `xmap` attribute is carried over to an `EBSD` signal upon a call to `LazyEBSD.compute()`.

Close #264.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> from orix import io
>>> s = kp.load("pattern.h5", lazy=True)
>>> s._xmap = io.load("crystalmap.ang")
>>> s.xmap
Phase  Orientations                 Name  Space group  Point group  Proper point group       Color
    1  6043 (51.6%)      ferrite/ferrite         None          432                 432    tab:blue
    2  5657 (48.4%)  austenite/austenite         None          432                 432  tab:orange
Properties: iq, dp
Scan unit: um
>>> s.compute()
>>> s.xmap  # None before
Phase  Orientations                 Name  Space group  Point group  Proper point group       Color
    1  6043 (51.6%)      ferrite/ferrite         None          432                 432    tab:blue
    2  5657 (48.4%)  austenite/austenite         None          432                 432  tab:orange
Properties: iq, dp
Scan unit: um
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.
