### PR TITLE
Update diffsims dependency and getting hkl data from ReciprocalLatticePoint

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,8 @@ Added
 
 Changed
 -------
+- Dependency requirement of diffsims from >= 0.3 to >= 0.4
+  (`#282 <https://github.com/pyxem/kikuchipy/pull/282>`_)
 - Name of hemisphere axis in EBSDMasterPattern from "y" to "hemisphere".
   (`#275 <https://github.com/pyxem/kikuchipy/pull/275>`_)
 - Replace Travis CI with GitHub Actions.
@@ -88,7 +90,6 @@ Changed
   `#244 <https://github.com/pyxem/kikuchipy/pull/244>`_,
   `#245 <https://github.com/pyxem/kikuchipy/pull/245>`_
   `#279 <https://github.com/pyxem/kikuchipy/pull/279>`_)
-
 - Move GitHub repository to the pyxem organization. Update relevant URLs.
   (`#198 <https://github.com/pyxem/kikuchipy/pull/198>`_)
 - Allow scikit-image >= 0.16.

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -195,7 +195,7 @@ def nickel_kikuchi_band(nickel_rlp, nickel_rotations, pc1):
     rlp = nickel_rlp.symmetrise()
 
     phase = rlp.phase
-    hkl = rlp._hkldata
+    hkl = rlp.hkl.data
 
     nav_shape = (5, 5)
 
@@ -245,7 +245,7 @@ def nickel_kikuchi_band(nickel_rlp, nickel_rotations, pc1):
 @pytest.fixture
 def nickel_zone_axes(nickel_kikuchi_band, nickel_rotations, pc1):
     bands = nickel_kikuchi_band
-    hkl = bands._hkldata
+    hkl = bands.hkl.data
     phase = bands.phase
 
     nav_shape = (5, 5)

--- a/kikuchipy/crystallography/_computations.py
+++ b/kikuchipy/crystallography/_computations.py
@@ -135,9 +135,9 @@ def _get_colors_for_allowed_bands(
     # TODO: Replace this ordering with future ordering method in
     #  diffsims
     g_order = np.argsort(rlp2.gspacing)
-    new_hkl = np.atleast_2d(rlp2._hkldata)[g_order]
+    new_hkl = np.atleast_2d(rlp2.hkl.data)[g_order]
     rlp3 = ReciprocalLatticePoint(phase=rlp.phase, hkl=new_hkl)
-    hkl = np.atleast_2d(rlp3._hkldata)
+    hkl = np.atleast_2d(rlp3.hkl.data)
     families, families_idx = _get_hkl_family(hkl=hkl, reduce=True)
 
     if color_cycle is None:

--- a/kikuchipy/crystallography/tests/test_crystallographic_computations.py
+++ b/kikuchipy/crystallography/tests/test_crystallographic_computations.py
@@ -62,7 +62,7 @@ class TestCrystallographicComputations:
                     phase=Phase(space_group=225), hkl=[1, 1, 1]
                 )
                 .symmetrise()
-                ._hkldata,
+                .hkl.data,
                 [1, 1, 1],
                 [
                     [
@@ -84,7 +84,7 @@ class TestCrystallographicComputations:
                     phase=Phase(space_group=225), hkl=[[1, 1, 1], [2, 0, 0]]
                 )
                 .symmetrise()
-                ._hkldata,
+                .hkl.data,
                 [[1, 1, 1], [2, 0, 0]],
                 [
                     [
@@ -114,7 +114,7 @@ class TestCrystallographicComputations:
                     phase=Phase(space_group=225), hkl=[[1, 1, 1], [2, 2, 2]]
                 )
                 .symmetrise()
-                ._hkldata,
+                .hkl.data,
                 [1, 1, 1],
                 [
                     [

--- a/kikuchipy/detectors/ebsd_detector.py
+++ b/kikuchipy/detectors/ebsd_detector.py
@@ -349,7 +349,7 @@ class EBSDDetector:
         return y_scale.reshape(self.navigation_shape)
 
     @property
-    def r_max(self):
+    def r_max(self) -> np.ndarray:
         """Maximum distance from PC to detector edge in gnomonic
         coordinates.
         """
@@ -562,19 +562,19 @@ class EBSDDetector:
             pcx *= sx
             bounds = self.bounds
             bounds[2:] = bounds[2:][::-1]
-            x_label = r"$x_{\mathrm{detector}}$"
-            y_label = r"$y_{\mathrm{detector}}$"
+            x_label = "x detector"
+            y_label = "y detector"
         else:
             pcy, pcx = (0, 0)
             bounds = self._average_gnomonic_bounds
-            x_label = r"$x_{\mathrm{gnomonic}}$"
-            y_label = r"$y_{\mathrm{gnomonic}}$"
+            x_label = "x gnomonic"
+            y_label = "y gnomonic"
 
         fig, ax = plt.subplots()
         ax.axis(zoom * bounds)
         ax.set_aspect(self.aspect_ratio)
-        ax.set_xlabel(x_label, fontsize=18)
-        ax.set_ylabel(y_label, fontsize=18)
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
 
         # Plot a pattern on the detector
         if isinstance(pattern, np.ndarray):

--- a/kikuchipy/detectors/tests/test_ebsd_detector.py
+++ b/kikuchipy/detectors/tests/test_ebsd_detector.py
@@ -341,33 +341,15 @@ class TestEBSDDetector:
             _ = EBSDDetector(pc=pc1, convention="nordif")
 
     @pytest.mark.parametrize(
-        "coordinates, show_pc, pattern, zoom, desired_labels",
+        "coordinates, show_pc, pattern, zoom, desired_label",
         [
-            (
-                None,
-                False,
-                None,
-                1,
-                ["$x_{\mathrm{detector}}$", "$y_{\mathrm{detector}}$"],
-            ),
-            (
-                "detector",
-                True,
-                np.ones((60, 60)),
-                1,
-                ["$x_{\mathrm{detector}}$", "$y_{\mathrm{detector}}$"],
-            ),
-            (
-                "gnomonic",
-                True,
-                np.ones((60, 60)),
-                2,
-                ["$x_{\mathrm{gnomonic}}$", "$y_{\mathrm{gnomonic}}$"],
-            ),
+            (None, False, None, 1, "detector"),
+            ("detector", True, np.ones((60, 60)), 1, "detector"),
+            ("gnomonic", True, np.ones((60, 60)), 2, "gnomonic"),
         ],
     )
     def test_plot_detector(
-        self, detector, coordinates, show_pc, pattern, zoom, desired_labels
+        self, detector, coordinates, show_pc, pattern, zoom, desired_label
     ):
         """Plotting detector works, *not* checking whether Matplotlib
         displays the pattern correctly.
@@ -379,8 +361,8 @@ class TestEBSDDetector:
             zoom=zoom,
             return_fig_ax=True,
         )
-        assert ax.get_xlabel() == desired_labels[0]
-        assert ax.get_ylabel() == desired_labels[1]
+        assert ax.get_xlabel() == f"x {desired_label}"
+        assert ax.get_ylabel() == f"y {desired_label}"
         if isinstance(pattern, np.ndarray):
             assert np.allclose(ax.get_images()[0].get_array(), pattern)
         plt.close("all")

--- a/kikuchipy/generators/ebsd_simulation_generator.py
+++ b/kikuchipy/generators/ebsd_simulation_generator.py
@@ -196,7 +196,7 @@ class EBSDSimulationGenerator:
 
         # Unit cell parameters (called more than once)
         phase = rlp.phase
-        hkl = rlp._hkldata
+        hkl = rlp.hkl.data
 
         # Get number of navigation dimensions and navigation axes
         # indices

--- a/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
+++ b/kikuchipy/generators/tests/test_ebsd_simulation_generator.py
@@ -274,7 +274,7 @@ class TestEBSDSimulationGenerator:
 
         bands = sim.bands
         assert bands.size == 14
-        assert np.allclose(bands._hkldata[5:7], [[0, -2, 0], [0, 0, 2]])
+        assert np.allclose(bands.hkl.data[5:7], [[0, -2, 0], [0, 0, 2]])
         assert np.allclose(
             bands.hkl_detector[:, 5:7].data,
             np.array(

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -195,7 +195,7 @@ class GeometricalEBSDSimulation:
             family_colors = []
             colors = _get_colors_for_allowed_bands(
                 phase=self.bands.phase,
-                highest_hkl=np.max(np.abs(self.bands._hkldata), axis=0),
+                highest_hkl=np.max(np.abs(self.bands.hkl.data), axis=0),
             )
             for hkl in families.keys():
                 for table_hkl, color in colors:
@@ -275,7 +275,7 @@ class GeometricalEBSDSimulation:
                 category=UserWarning,
             )
         return get_text_list(
-            texts=sub("[][ ]", "", str(self.zone_axes._hkldata)).split("\n"),
+            texts=sub("[][ ]", "", str(self.zone_axes.hkl.data)).split("\n"),
             coordinates=self.zone_axes_label_detector_coordinates,
             color=kwargs.pop("color", "k"),
             zorder=kwargs.pop("zorder", 5),

--- a/kikuchipy/simulations/tests/test_features.py
+++ b/kikuchipy/simulations/tests/test_features.py
@@ -353,7 +353,7 @@ class TestKikuchiBand:
             # Slicing shape () with two keys
             _ = bands[0, 0][0, 0]
         # Slicing ndim == 1 with two keys
-        assert np.allclose(bands[0][0, :2]._hkldata, bands._hkldata[:2])
+        assert np.allclose(bands[0][0, :2].hkl.data, bands.hkl.data[:2])
         assert bands[0][0, :2].navigation_shape == ()
 
         # Three getitem keys
@@ -609,7 +609,7 @@ class TestZoneAxis:
             # Slicing shape () with two keys
             _ = za[0, 0][0, 0]
         # Slicing ndim == 1 with two keys
-        assert np.allclose(za[0][0, :2]._hkldata, za._hkldata[:2])
+        assert np.allclose(za[0][0, :2].hkl.data, za.hkl.data[:2])
         assert za[0][0, :2].navigation_shape == ()
 
         # Three getitem keys

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     extras_require=extra_feature_requirements,
     install_requires=[
         "dask[array] >= 2.14",
-        "diffsims >= 0.3",
+        "diffsims >= 0.4",
         "hyperspy >= 1.5.2",
         "h5py >= 2.10",
         "matplotlib >= 3.2",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Set hard diffsims >= 0.4 dependency
* Update use of hkl data from `diffsims.crystallography.ReciprocalLatticePoint` from `._hkldata` to `hkl.data`

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `doc/changelog.rst`.