### PR TITLE
Fix release version links used by Binder and nbsphinx

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -18,7 +18,9 @@ How to make a new release of ``kikuchipy``
   with `-rc.1` added to the version name, like v0.42.0-rc.1, merge the PR after
   all checks pass, and publish an RC release off of the release branch. See that
   it is made available via PyPI, download it with the `dev` dependencies, and
-  run the tests to make sure everything is as it should be.
+  run the tests to make sure everything is as it should be. Also check that
+  Binder can build the repository successfully by going to the Read the Docs PR
+  check in the RC PR above after the RC release.
 - Create a release draft (tag) via the GitHub repo from the release branch with
   the correct tag version name, e.g. v0.42.x and release title (see previous
   releases). Add the new release notes from the changelog. Publish the release.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,18 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. 
 List entries are sorted in descending chronological order.
 
+Unreleased
+==========
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Fixed
+-----
+- Version link Binder uses to make the Jupyter Notebooks run in the browser.
+  (`#301 <https://github.com/pyxem/kikuchipy/pull/300>`_)
+
 0.3.0 (2021-01-22)
 ==================
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,8 +12,8 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. 
 List entries are sorted in descending chronological order.
 
-Unreleased
-==========
+0.3.1 (2021-01-22)
+==================
 
 Contributors
 ------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,7 +113,7 @@ numfig = True
 if "dev" in version:
     release_version = "master"
 else:
-    release_version = version
+    release_version = "v" + version
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = (
     r"""

--- a/doc/pattern_matching.ipynb
+++ b/doc/pattern_matching.ipynb
@@ -69,7 +69,8 @@
     "import kikuchipy as kp\n",
     "\n",
     "\n",
-    "s = kp.data.nickel_ebsd_large()  # Use kp.load(\"data.h5\") to load your own data\n",
+    "# Use kp.load(\"data.h5\") to load your own data\n",
+    "s = kp.data.nickel_ebsd_large(allow_download=True)  # External download\n",
     "s"
    ]
   },

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -34,4 +34,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.4.0dev"
+version = "0.3.1"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Fix #300.
* Add ~an "Unreleased"~ a "0.3.1" section to the changelog, with this fix mentioned.
* Clarify external download in pattern matching notebook
* Change release version to 0.3.1 in release.py
* Add note about checking that Binder can build the GitHub repository in the release guide

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
