### PR TITLE
Increment version again from 0.3.1 in release.py

### DIFF
--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -34,4 +34,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.3.1"
+version = "0.4.0dev"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Increment version again from 0.3.1 in release.py

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
