### PR TITLE
Fix creation of spatial arrays for CrystalMap after pattern matching

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,7 +23,7 @@ Fixed
 -----
 - Pattern matching sometimes failing to generate a crystal map due to incorrect
   creation of spatial arrays
-  (`#306 <https://github.com/pyxem/kikuchipy/pull/306>`_)
+  (`#307 <https://github.com/pyxem/kikuchipy/pull/307>`_)
 
 0.3.1 (2021-01-22)
 ==================

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,19 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. 
 List entries are sorted in descending chronological order.
 
+Unreleased
+==========
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Fixed
+-----
+- Pattern matching sometimes failing to generate a crystal map due to incorrect
+  creation of spatial arrays
+  (`#306 <https://github.com/pyxem/kikuchipy/pull/306>`_)
+
 0.3.1 (2021-01-22)
 ==================
 

--- a/doc/pattern_matching.ipynb
+++ b/doc/pattern_matching.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "Before we can generate a dictionary of\n",
     "simulated patterns, we need a master pattern containing all possible scattering\n",
-    "vectors for a candidate phase. This can simulated done using EMsoft\n",
+    "vectors for a candidate phase. This can be simulated using EMsoft\n",
     "<cite data-cite=\"callahan2013dynamical\">Callahan and De Graef (2013)</cite>\n",
     "<cite data-cite=\"jackson2014h5ebsd\">Jackson et al. (2014)</cite>, and then read\n",
     "into kikuchipy."
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we import libraries and load the small experimental Nickel test data."
+    "First, we import libraries and load the small experimental Nickel test data"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "source": [
     "Next, we load a dynamically simulated Nickel master pattern generated with\n",
     "EMsoft, in the northern hemisphere projection of the square Lambert projection\n",
-    "for an accelerating voltage of 20 keV."
+    "for an accelerating voltage of 20 keV"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "source": [
     "The Nickel phase information, specifically the crystal symmetry, asymmetric atom\n",
     "positions, and crystal lattice, is conveniently stored in an\n",
-    "[orix.crystal_map.Phase](https://orix.readthedocs.io/en/stable/reference.html#orix.crystal_map.phase_list.Phase)."
+    "[orix.crystal_map.Phase](https://orix.readthedocs.io/en/stable/reference.html#orix.crystal_map.phase_list.Phase)"
    ]
   },
   {
@@ -171,7 +171,7 @@
     "4$^{\\circ}$ characteristic distance between orientations (we can either pass\n",
     "in the proper point group, or the space group, which is a subgroup of the proper\n",
     "point group) using\n",
-    "[orix.sampling.get_sample_fundamental()](https://orix.readthedocs.io/en/stable/reference.html#orix.sampling.sample_generators.get_sample_fundamental)."
+    "[orix.sampling.get_sample_fundamental()](https://orix.readthedocs.io/en/stable/reference.html#orix.sampling.sample_generators.get_sample_fundamental)"
    ]
   },
   {
@@ -197,7 +197,7 @@
     "Note\n",
     "\n",
     "A characteristic distance of 4$^{\\circ}$ results in a course sampling of\n",
-    "orientation space; a shorter distance should be used for real experimental work.\n",
+    "orientation space; a shorter distance should be used for experimental work.\n",
     "\n",
     "</div>"
    ]
@@ -235,7 +235,7 @@
    "source": [
     "Let's double check the projection/pattern center (PC) position on the detector\n",
     "using\n",
-    "[plot()](reference.rst#kikuchipy.detectors.ebsd_detector.EBSDDetector.plot)."
+    "[plot()](reference.rst#kikuchipy.detectors.ebsd_detector.EBSDDetector.plot)"
    ]
   },
   {
@@ -279,7 +279,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's inspect the three first of the 14423 simulated patterns."
+    "Let's inspect the three first of the 14423 simulated patterns"
    ]
   },
   {
@@ -332,7 +332,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The results can be exported to an HDF5 file re-readable by orix."
+    "The results can be exported to an HDF5 file re-readable by orix"
    ]
   },
   {
@@ -351,7 +351,7 @@
    "metadata": {},
    "source": [
     "Let's inspect our matching results by plotting a map of the highest $r$\n",
-    "(stored in the `scores` property)."
+    "(stored in the `scores` property)"
    ]
   },
   {
@@ -371,7 +371,7 @@
    "metadata": {},
    "source": [
     "We can use the crystal map property `simulation_indices` to get the best\n",
-    "matching simulated patterns from the dictionary of simulated patterns."
+    "matching simulated patterns from the dictionary of simulated patterns"
    ]
   },
   {
@@ -404,7 +404,7 @@
    "outputs": [],
    "source": [
     "ncc_navigator = hs.signals.Signal2D(xmap.get_map_data(xmap.scores[:, 0]))\n",
-    "hs.plot.plot_signals([s, s_best], navigator=hs.signals.Signal2D(ncc_navigator))"
+    "hs.plot.plot_signals([s, s_best], navigator=ncc_navigator)"
    ]
   },
   {

--- a/kikuchipy/indexing/_static_pattern_matching.py
+++ b/kikuchipy/indexing/_static_pattern_matching.py
@@ -141,7 +141,6 @@ class StaticPatternMatching:
         spatial_arrays = _get_spatial_arrays(
             shape=axes_manager.navigation_shape,
             extent=axes_manager.navigation_extent,
-            step_sizes=[i.scale for i in axes_manager.navigation_axes],
         )
         n_nav_dims = axes_manager.navigation_dimension
         if n_nav_dims == 0:
@@ -200,18 +199,16 @@ class StaticPatternMatching:
 
 
 def _get_spatial_arrays(
-    shape: tuple, extent: tuple, step_sizes: tuple
+    shape: tuple, extent: tuple
 ) -> Union[tuple, np.ndarray]:
     n_nav_dims = len(shape)
     if n_nav_dims == 0:
         return ()
     if n_nav_dims == 1:
         x0, x1 = extent
-        dx = step_sizes[0]
-        return np.arange(x0, x1 + dx, dx)
+        return np.linspace(x0, x1, shape[0])
     else:
         x0, x1, y0, y1 = extent
-        dx, dy = step_sizes
-        x = np.tile(np.arange(x0, x1 + dx, dx), shape[1])
-        y = np.tile(np.arange(y0, y1 + dy, dy), shape[0])
+        x = np.tile(np.linspace(x0, x1, shape[0]), shape[1])
+        y = np.tile(np.linspace(y0, y1, shape[1]), shape[0])
         return x, y

--- a/kikuchipy/indexing/tests/test_static_pattern_matching.py
+++ b/kikuchipy/indexing/tests/test_static_pattern_matching.py
@@ -143,45 +143,45 @@ class TestStaticPatternMatching:
         assert res.shape == desired_xmap_shape
 
     @pytest.mark.parametrize(
-        "nav_slice, step_sizes, desired_arrays",
+        "shape, extent, desired_arrays",
         [
             # 0d
-            ((0, 0), (1, 1), ()),
-            ((slice(0, 0), slice(0, 0)), (1, 1), (np.array([]),) * 2),
+            ((), (), ()),
+            ((0, 0), (0.0, 2.0, 0.0, 2.0), (np.array([]),) * 2),
             # 1d
-            ((0, slice(None)), (1, 1.5), np.tile(np.arange(0, 4.5, 1.5), 3)),
+            ((3,), (0.0, 3.0), np.tile(np.linspace(0, 4.5, 3), 3)),
             # 2d
             (
-                (slice(None), slice(0, 2)),
-                (2, 1.5),
+                (3, 2),
+                (0.0, 4.0, 0.0, 1.5),
                 (
-                    np.tile(np.arange(0, 6, 2), 2),
-                    np.tile(np.arange(0, 3, 1.5), 3),
+                    np.tile(np.linspace(0, 4, 3), 2),
+                    np.tile(np.linspace(0, 1.5, 2), 3),
                 ),
             ),
             (
-                (slice(None), slice(0, 2)),
-                (0.5, 1),
+                (3, 2),
+                (0.0, 1.0, 0.0, 1.0),
                 (
-                    np.tile(np.arange(0, 1.5, 0.5), 2),
-                    np.tile(np.arange(0, 2, 1), 3),
+                    np.tile(np.linspace(0, 1, 3), 2),
+                    np.tile(np.linspace(0, 1, 2), 3),
+                ),
+            ),
+            (
+                (136, 249),
+                (79.5, 99.75, 30.0, 67.2),
+                (
+                    np.tile(np.linspace(79.5, 99.75, 136), 249),
+                    np.tile(np.linspace(30.0, 67.2, 249), 136),
                 ),
             ),
         ],
     )
-    def test_get_spatial_arrays(self, nav_slice, step_sizes, desired_arrays):
+    def test_get_spatial_arrays(self, shape, extent, desired_arrays):
         """Ensure spatial arrays for 0d, 1d and 2d EBSD signals are
         returned correctly.
         """
-        s = nickel_ebsd_small()
-        s.axes_manager["x"].scale = step_sizes[0]
-        s.axes_manager["y"].scale = step_sizes[1]
-        axes_manager = s.inav[nav_slice].axes_manager
-        spatial_arrays = _get_spatial_arrays(
-            shape=axes_manager.navigation_shape,
-            extent=axes_manager.navigation_extent,
-            step_sizes=[i.scale for i in axes_manager.navigation_axes],
-        )
+        spatial_arrays = _get_spatial_arrays(shape, extent)
 
         if len(spatial_arrays) == 0:
             assert spatial_arrays == desired_arrays


### PR DESCRIPTION
#### Description of the change
* Fix #306 
* Simplify `_get_spatial_arrays()`, add appropriate test.
* Fix typos in pattern matching user guide.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.