### PR TITLE
Increment version to 0.4.dev0, update release guide

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -9,11 +9,9 @@ How to make a new release of ``kikuchipy``
   contributors and reviewers are acknowledged. Increment the version number in
   `release.py`. Make a PR to the release branch.
 - Create a PR from the release branch to master. Discuss the changelog with
-  others, and make the changes *directly* to the release branch. After all
-  checks pass the PR is merged, cherry-pick any resulting changes to the release
-  branch.
+  others, and make any changes *directly* to the release branch.
 - On the master branch, increment the version number in `release.py` to the next
-  `.dev0`.
+  v<major>.<minor>.dev0.
 - If a release candidate (RC) is to be made, make a PR to the release branch
   with `-rc.1` added to the version name, like v0.42.0-rc.1, merge the PR after
   all checks pass, and publish an RC release off of the release branch. See that
@@ -22,12 +20,14 @@ How to make a new release of ``kikuchipy``
   Binder can build the repository successfully by going to the Read the Docs PR
   check in the RC PR above after the RC release.
 - Create a release draft (tag) via the GitHub repo from the release branch with
-  the correct tag version name, e.g. v0.42.x and release title (see previous
-  releases). Add the new release notes from the changelog. Publish the release.
+  the correct tag version name, e.g. v0.42.0, and release title
+  "kikuchipy 0.42.0". Add the new release notes from the changelog, and convert
+  any reStructuredText formatting to Markdown by hand. Publish the release.
 - Monitor the publish GitHub Action to ensure the release is successfully
   published to PyPI.
-- Download the new version from PyPI with the `dev` dependencies locally and run
-  the tests to make sure everything is as it should be.
+- Download the new version from PyPI with the `dev` dependencies with
+  `pip install kikuchipy[dev]==0.42.0` locally and run the tests with
+  `pytest --pyargs kikuchipy` to make sure everything is as it should be.
 - Make a PR to master with any updates to this guide if necessary.
 
 conda-forge
@@ -36,13 +36,24 @@ A kikuchipy build recipe is available at
 https://github.com/conda-forge/kikuchipy-feedstock. conda-forge documentation is
 available at https://conda-forge.org/docs/index.html.
 
+- Normally, a conda-forge bot will make a PR to the feedstock with the necessary
+  changes within a day of a new PyPI release, to our great convenience!
+- Proceed with the last steps below.
+
+If the bot for some reason does not make this PR:
+
 - Fork the feedstock.
-- Create a new release branch named v<major>.<minor>.x off of master.
+- Create a *local* release branch named v<major>.<minor>.x off of master.
 - Increment the version number in `recipe/meta.yml`. Get the SHA256 for the
   package distribution (`.tar.gz`) from PyPI
   https://pypi.org/project/kikuchipy/.
-- Make a PR to master from the release branch. Follow the relevant instructions
-  from the conda-forge documentation on updating packages. Merge the PR after
+- Make a PR to master from your release branch.
+- Proceed with the last steps below.
+
+Last steps:
+
+- Follow the relevant instructions from the conda-forge documentation on
+  updating packages, as well as the instructions in the PR, and merge it after
   all checks are green.
 - Monitor the Azure pipeline CI to ensure the release is successfully published
   to conda-forge.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,9 @@ project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. 
 List entries are sorted in descending chronological order.
 
+Unreleased
+==========
+
 0.3.2 (2021-02-01)
 ==================
 

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -34,4 +34,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.3.2"
+version = "0.4.dev0"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Update release guide
* Increment version in release.py to 0.4.dev0
* Add "Unreleased" to changelog

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
