### PR TITLE
Add three Si single crystal EBSD patterns to data module, from external kikuchipy-data repo

### DIFF
--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -194,3 +194,16 @@
 	volume = {200},
 	year = {2019}
 }
+@article{hjelen1991electron,
+	author = {Hjelen, Jarle and Hoel, Eivind and Ørsund, Roar},
+	doi = {10.1016/0739-6260(91)90128-M},
+	journal = {Micron and Microscopica Acta},
+	keywords = {ebsd, indexing},
+	number = {1-2},
+	pages = {137–138},
+	publisher = {Pergamon},
+	title = {{Electron diffraction in the SEM}},
+	volume = {22},
+	year = {1991}
+}
+

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,9 @@ Contributors
 
 Added
 -----
+- Add three EBSD patterns from the same position of a single crystal Si sample
+  with varying sample-screen distances to the data module via external repo.
+  (`#318 <https://github.com/pyxem/kikuchipy/pull/318>`_)
 - Reading of NORDIF calibration patterns specified in a setting file into an
   EBSD signal. (`#317 <https://github.com/pyxem/kikuchipy/pull/317>`_)
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,9 +21,9 @@ Contributors
 
 Added
 -----
-- Add three EBSD patterns from the same position of a single crystal Si sample
-  with varying sample-screen distances to the data module via external repo.
-  (`#318 <https://github.com/pyxem/kikuchipy/pull/318>`_)
+- Three single crystal Si EBSD patterns, from the same sample position but with
+  varying sample-screen distances, to the data module (via external repo).
+  (`#320 <https://github.com/pyxem/kikuchipy/pull/320>`_)
 - Reading of NORDIF calibration patterns specified in a setting file into an
   EBSD signal. (`#317 <https://github.com/pyxem/kikuchipy/pull/317>`_)
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -188,6 +188,13 @@ Some useful `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_, like a
 dummy scan and corresponding background pattern, are available in the
 ``conftest.py`` file.
 
+.. note::
+
+   Some :mod:`kikuchipy.data` module tests check that data not part of the
+   package distribution can be downloaded from the `kikuchipy-data GitHub
+   repository <https://github.com/pyxem/kikuchipy-data>`_, thus downloading some
+   datasets of ~15 MB to your local cache.
+
 To run the tests::
 
    $ pytest --cov --pyargs kikuchipy
@@ -201,12 +208,31 @@ terminal. For an even nicer presentation, you can use ``coverage.py`` directly::
 Then, you can open the created ``htmlcov/index.html`` in the browser and inspect
 the coverage in more detail.
 
-.. note::
+Adding test data to the data module
+===================================
 
-   Some :mod:`kikuchipy.data` module tests check that data not part of the
-   package distribution can be downloaded from the `kikuchipy-data GitHub
-   repository <https://github.com/pyxem/kikuchipy-data>`_, thus downloading some
-   datasets of ~15 MB to your local cache.
+Test data sets used in user guides and tests are included in the
+:mod:`kikuchipy.data` module via the
+`pooch <https://www.fatiando.org/pooch/latest/>`_ Python library. These are
+listed in `kikuchipy.data._registry.py` with their file hash (SHA256, get with
+e.g. `sha256sum <file>`) and location, the latter potentially not within the
+package but from the
+`kikuchipy-data <https://github.com/pyxem/kikuchipy-data>`_ repository, since
+some files are considered too large to include.
+
+If a dataset is asked for and it is not in the package but in the registry, it
+can be downloaded from the repository, provided that the user allows this by
+passing `allow_download=True` to e.g. :func:`~kikuchipy.data.nickel_ebsd_large`.
+The dataset is then downloaded to a local cache, e.g.
+`/home/user/.cache/kikuchipy/`. Pooch handles download, caching, version control
+etc. Every file in the registry has a SHA256 label that pooch checks against. If
+we have updated the SHA256 of a file, pooch will redownload it. When the file is
+available in the cache, the user can just load it as the other files in the data
+module.
+
+The user can specify the desired data cache directory by setting a global
+`KIKUCHIPY_DATA_DIR` variable on their system, e.g. setting
+`export KIKUCHIPY_DATA_DIR=~/kikuchipy_data` in `~/.bashrc`.
 
 Continuous integration (CI)
 ===========================

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -211,28 +211,25 @@ the coverage in more detail.
 Adding test data to the data module
 ===================================
 
-Test data sets used in user guides and tests are included in the
-:mod:`kikuchipy.data` module via the
-`pooch <https://www.fatiando.org/pooch/latest/>`_ Python library. These are
-listed in `kikuchipy.data._registry.py` with their file hash (SHA256, get with
-e.g. `sha256sum <file>`) and location, the latter potentially not within the
-package but from the
+Test data for user guides and tests are included in the :mod:`kikuchipy.data`
+module via the `pooch <https://www.fatiando.org/pooch/latest/>`_ Python library.
+These are listed in `kikuchipy.data._registry.py` with their file verification
+string (hash, SHA256, obtain with e.g. `sha256sum <file>`) and location, the
+latter potentially not within the package but from the
 `kikuchipy-data <https://github.com/pyxem/kikuchipy-data>`_ repository, since
 some files are considered too large to include.
 
-If a dataset is asked for and it is not in the package but in the registry, it
-can be downloaded from the repository, provided that the user allows this by
-passing `allow_download=True` to e.g. :func:`~kikuchipy.data.nickel_ebsd_large`.
-The dataset is then downloaded to a local cache, e.g.
-`/home/user/.cache/kikuchipy/`. Pooch handles download, caching, version control
-etc. Every file in the registry has a SHA256 label that pooch checks against. If
-we have updated the SHA256 of a file, pooch will redownload it. When the file is
-available in the cache, the user can just load it as the other files in the data
-module.
+If required dataset isn't in the package, but is in the registry, it can be
+downloaded from the repository when the user passes `allow_download=True` to
+e.g. :func:`~kikuchipy.data.nickel_ebsd_large`. The dataset is then downloaded
+to a local cache, e.g. `/home/user/.cache/kikuchipy/`. Pooch handles
+downloading, caching, version control, file verification (against hash) etc. If
+we have updated the file hash, pooch will redownload it. If the file is
+available in the cache, it can be loaded as the other files in the data module.
 
-The user can specify the desired data cache directory by setting a global
-`KIKUCHIPY_DATA_DIR` variable on their system, e.g. setting
-`export KIKUCHIPY_DATA_DIR=~/kikuchipy_data` in `~/.bashrc`.
+The desired data cache directory by set with a global `KIKUCHIPY_DATA_DIR`
+variable locally, e.g. by setting `export KIKUCHIPY_DATA_DIR=~/kikuchipy_data`
+in `~/.bashrc`.
 
 Continuous integration (CI)
 ===========================

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -208,18 +208,18 @@ terminal. For an even nicer presentation, you can use ``coverage.py`` directly::
 Then, you can open the created ``htmlcov/index.html`` in the browser and inspect
 the coverage in more detail.
 
-Adding test data to the data module
-===================================
+Adding data to the data module
+==============================
 
 Test data for user guides and tests are included in the :mod:`kikuchipy.data`
 module via the `pooch <https://www.fatiando.org/pooch/latest/>`_ Python library.
-These are listed in `kikuchipy.data._registry.py` with their file verification
-string (hash, SHA256, obtain with e.g. `sha256sum <file>`) and location, the
-latter potentially not within the package but from the
+These are listed in a file registry (`kikuchipy.data._registry.py`) with their
+file verification string (hash, SHA256, obtain with e.g. `sha256sum <file>`) and
+location, the latter potentially not within the package but from the
 `kikuchipy-data <https://github.com/pyxem/kikuchipy-data>`_ repository, since
-some files are considered too large to include.
+some files are considered too large to include in the package.
 
-If required dataset isn't in the package, but is in the registry, it can be
+If a required dataset isn't in the package, but is in the registry, it can be
 downloaded from the repository when the user passes `allow_download=True` to
 e.g. :func:`~kikuchipy.data.nickel_ebsd_large`. The dataset is then downloaded
 to a local cache, e.g. `/home/user/.cache/kikuchipy/`. Pooch handles
@@ -227,9 +227,9 @@ downloading, caching, version control, file verification (against hash) etc. If
 we have updated the file hash, pooch will redownload it. If the file is
 available in the cache, it can be loaded as the other files in the data module.
 
-The desired data cache directory by set with a global `KIKUCHIPY_DATA_DIR`
-variable locally, e.g. by setting `export KIKUCHIPY_DATA_DIR=~/kikuchipy_data`
-in `~/.bashrc`.
+The desired data cache directory used by pooch can be set with a global
+`KIKUCHIPY_DATA_DIR` variable locally, e.g. by setting
+`export KIKUCHIPY_DATA_DIR=~/kikuchipy_data` in `~/.bashrc`.
 
 Continuous integration (CI)
 ===========================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -59,6 +59,9 @@ data
     nickel_ebsd_small
     nickel_ebsd_large
     nickel_ebsd_master_pattern_small
+    silicon_ebsd_moving_screen_in
+    silicon_ebsd_moving_screen_out5mm
+    silicon_ebsd_moving_screen_out10mm
 
 .. automodule:: kikuchipy.data
     :members:

--- a/kikuchipy/data/__init__.py
+++ b/kikuchipy/data/__init__.py
@@ -38,6 +38,9 @@ __all__ = [
     "nickel_ebsd_small",
     "nickel_ebsd_large",
     "nickel_ebsd_master_pattern_small",
+    "silicon_ebsd_moving_screen_in",
+    "silicon_ebsd_moving_screen_out5mm",
+    "silicon_ebsd_moving_screen_out10mm",
 ]
 
 
@@ -163,6 +166,119 @@ def nickel_ebsd_large(allow_download: bool = False, **kwargs) -> EBSD:
     """
     return _load(
         filename="data/nickel_ebsd_large/patterns.h5",
+        allow_download=allow_download,
+        **kwargs,
+    )
+
+
+def silicon_ebsd_moving_screen_in(
+    allow_download: bool = False, **kwargs
+) -> EBSD:
+    """One EBSD pattern of (480, 480) detector pixels from a single
+    crystal Silicon sample, acquired on a NORDIF UF-420 detector.
+
+    This pattern is used in combination with one of two other patterns
+    of the same region but with another specimen-screen-distance in the
+    moving-screen projection center calibration technique
+    :cite:`hjelen1991electron`.
+
+    Parameters
+    ----------
+    allow_download : bool
+        Whether to allow downloading the dataset from the kikuchipy-data
+        GitHub repository (https://github.com/pyxem/kikuchipy-data) to
+        the local cache with the pooch Python package. Default is False.
+    kwargs
+        Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
+
+    Returns
+    -------
+    signal : EBSD
+        EBSD signal.
+    
+    See Also
+    --------
+    silicon_ebsd_moving_screen_out5mm
+    silicon_ebsd_moving_screen_out10mm
+    """
+    return _load(
+        filename="data/silicon_ebsd_moving_screen/si_in.h5",
+        allow_download=allow_download,
+        **kwargs,
+    )
+
+
+def silicon_ebsd_moving_screen_out5mm(
+    allow_download: bool = False, **kwargs
+) -> EBSD:
+    """One EBSD pattern of (480, 480) detector pixels from a single
+    crystal Silicon sample, acquired on a NORDIF UF-420 detector.
+
+    This pattern is used in combination with one of two other patterns
+    of the same region but with another specimen-screen-distance (SSD)
+    in the moving-screen projection center calibration technique
+    :cite:`hjelen1991electron`. It has a 5 mm greater SSD compared to
+    :func:`silicon_ebsd_moving_screen_in`.
+
+    Parameters
+    ----------
+    allow_download : bool
+        Whether to allow downloading the dataset from the kikuchipy-data
+        GitHub repository (https://github.com/pyxem/kikuchipy-data) to
+        the local cache with the pooch Python package. Default is False.
+    kwargs
+        Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
+
+    Returns
+    -------
+    signal : EBSD
+        EBSD signal.
+    
+    See Also
+    --------
+    silicon_ebsd_moving_screen_in
+    silicon_ebsd_moving_screen_out10mm
+    """
+    return _load(
+        filename="data/silicon_ebsd_moving_screen/si_out5mm.h5",
+        allow_download=allow_download,
+        **kwargs,
+    )
+
+
+def silicon_ebsd_moving_screen_out10mm(
+    allow_download: bool = False, **kwargs
+) -> EBSD:
+    """One EBSD pattern of (480, 480) detector pixels from a single
+    crystal Silicon sample, acquired on a NORDIF UF-420 detector.
+
+    This pattern is used in combination with one of two other patterns
+    of the same region but with another specimen-screen-distance (SSD)
+    in the moving-screen projection center calibration technique
+    :cite:`hjelen1991electron`. It has a 10 mm greater SSD compared to
+    :func:`silicon_ebsd_moving_screen_in`.
+
+    Parameters
+    ----------
+    allow_download : bool
+        Whether to allow downloading the dataset from the kikuchipy-data
+        GitHub repository (https://github.com/pyxem/kikuchipy-data) to
+        the local cache with the pooch Python package. Default is False.
+    kwargs
+        Keyword arguments passed to :func:`~kikuchipy.io._io.load`.
+
+    Returns
+    -------
+    signal : EBSD
+        EBSD signal.
+    
+    See Also
+    --------
+    silicon_ebsd_moving_screen_in
+    silicon_ebsd_moving_screen_out5mm
+    """
+    return _load(
+        filename="data/silicon_ebsd_moving_screen/si_out10mm.h5",
         allow_download=allow_download,
         **kwargs,
     )

--- a/kikuchipy/data/__init__.py
+++ b/kikuchipy/data/__init__.py
@@ -177,10 +177,10 @@ def silicon_ebsd_moving_screen_in(
     """One EBSD pattern of (480, 480) detector pixels from a single
     crystal Silicon sample, acquired on a NORDIF UF-420 detector.
 
-    This pattern is used in combination with one of two other patterns
-    of the same region but with another specimen-screen-distance in the
-    moving-screen projection center calibration technique
-    :cite:`hjelen1991electron`.
+    This pattern and two other patterns from the same sample position
+    but with 5 mm and 10 mm greater sample-screen-distances were
+    acquired to test the moving-screen projection center estimation
+    technique :cite:`hjelen1991electron`.
 
     Parameters
     ----------
@@ -214,11 +214,12 @@ def silicon_ebsd_moving_screen_out5mm(
     """One EBSD pattern of (480, 480) detector pixels from a single
     crystal Silicon sample, acquired on a NORDIF UF-420 detector.
 
-    This pattern is used in combination with one of two other patterns
-    of the same region but with another specimen-screen-distance (SSD)
-    in the moving-screen projection center calibration technique
-    :cite:`hjelen1991electron`. It has a 5 mm greater SSD compared to
-    :func:`silicon_ebsd_moving_screen_in`.
+    This pattern and two other patterns from the same sample position
+    but with sample-screen-distances 5 mm shorter
+    (:func:`silicon_ebsd_moving_screen_in`) and 5 mm greater
+    (:func:`silicon_ebsd_moving_screen_out10mm`) were acquired to test
+    the moving-screen projection center estimation technique
+    :cite:`hjelen1991electron`.
 
     Parameters
     ----------
@@ -252,11 +253,12 @@ def silicon_ebsd_moving_screen_out10mm(
     """One EBSD pattern of (480, 480) detector pixels from a single
     crystal Silicon sample, acquired on a NORDIF UF-420 detector.
 
-    This pattern is used in combination with one of two other patterns
-    of the same region but with another specimen-screen-distance (SSD)
-    in the moving-screen projection center calibration technique
-    :cite:`hjelen1991electron`. It has a 10 mm greater SSD compared to
-    :func:`silicon_ebsd_moving_screen_in`.
+    This pattern and two other patterns from the same sample position
+    but with sample-screen-distances 10 mm shorter
+    (:func:`silicon_ebsd_moving_screen_in`) and 5 mm shorter
+    (:func:`silicon_ebsd_moving_screen_out5mm`) were acquired to test
+    the moving-screen projection center estimation technique
+    :cite:`hjelen1991electron`.
 
     Parameters
     ----------

--- a/kikuchipy/data/_registry.py
+++ b/kikuchipy/data/_registry.py
@@ -21,8 +21,14 @@ registry = {
     "data/kikuchipy/patterns.h5": "7a99ce88174c725f5407b6fcc1eab0c4255694ca8e6029fde7f372f3ab40897f",
     "data/emsoft_ebsd_master_pattern/ni_mc_mp_20kv_uint8_gzip_opts9.h5": "8a7c1fb471d9ce750f0332a154e87cf41eed7529be508548e0c0f51ec6f92bc2",
     "data/nickel_ebsd_large/patterns.h5": "3ea6e729c3adfdea9dce461806f011c24bf70b011dcf4d90a23a6aa29f15872c",
+    "data/silicon_ebsd_moving_screen/si_in.h5": "de57b8ef7213420af694c191c939f44818979b3db9873e74cc85cabde824b7eb",
+    "data/silicon_ebsd_moving_screen/si_out5mm.h5": "5d5a53a19f87316c2f20105365660d197302ad8c5e7ec4f1c75d024e787b0a6d",
+    "data/silicon_ebsd_moving_screen/si_out10mm.h5": "540b9dd485b9177741f2175d6225040419b8b585a42da43011fbe86c7a5d26dd",
 }
 registry_urls = {
-    "data/nickel_ebsd_large/patterns.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/nickel_ebsd_large/patterns.h5"
+    "data/nickel_ebsd_large/patterns.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/nickel_ebsd_large/patterns.h5",
+    "data/silicon_ebsd_moving_screen/si_in.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/silicon_ebsd_moving_screen/si_in.h5",
+    "data/silicon_ebsd_moving_screen/si_out5mm.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/silicon_ebsd_moving_screen/si_out5mm.h5",
+    "data/silicon_ebsd_moving_screen/si_out10mm.h5": "https://github.com/pyxem/kikuchipy-data/raw/master/silicon_ebsd_moving_screen/si_out10mm.h5",
 }
 # fmt: on

--- a/kikuchipy/data/tests/test_data.py
+++ b/kikuchipy/data/tests/test_data.py
@@ -94,3 +94,36 @@ class TestData:
         assert isinstance(s, LazyEBSD)
         assert s.data.shape == (55, 75, 60, 60)
         assert np.issubdtype(s.data.dtype, np.uint8)
+
+    def test_load_silicon_ebsd_moving_screen_in(self):
+        """Download external Si pattern."""
+        s = data.silicon_ebsd_moving_screen_in(allow_download=True)
+
+        assert s.data.shape == (480, 480)
+        assert s.data.dtype == np.uint8
+        assert isinstance(
+            s.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background,
+            np.ndarray,
+        )
+
+    def test_load_silicon_ebsd_moving_screen_out5mm(self):
+        """Download external Si pattern."""
+        s = data.silicon_ebsd_moving_screen_out5mm(allow_download=True)
+
+        assert s.data.shape == (480, 480)
+        assert s.data.dtype == np.uint8
+        assert isinstance(
+            s.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background,
+            np.ndarray,
+        )
+
+    def test_load_silicon_ebsd_moving_screen_out10mm(self):
+        """Download external Si pattern."""
+        s = data.silicon_ebsd_moving_screen_out10mm(allow_download=True)
+
+        assert s.data.shape == (480, 480)
+        assert s.data.dtype == np.uint8
+        assert isinstance(
+            s.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background,
+            np.ndarray,
+        )


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Add three single crystal Si EBSD patterns, acquired from the same sample position but with three different camera distances (reference/in/operating position, out 5 mm, out 10 mm), to the `kikuchipy.data` module. The patterns are stored in three separate kikuchipy h5ebsd files (should perhaps be stored in the same file...). These will be used in various user guides, first (will make PR later today) for showing the moving-screen PC estimation technique.
* Add section detailing how to add data to the data module in the contributing guide, `contributing.rst`.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> s1 = kp.data.silicon_ebsd_moving_screen_in()
>>> s1
<EBSD, title: si_in Scan 1, dimensions: (|480, 480)>
>>> s1.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background
array([[7, 8, 7, ..., 7, 7, 7],
       [8, 8, 7, ..., 7, 7, 7],
       [7, 7, 7, ..., 7, 7, 7],
       ...,
       [7, 7, 7, ..., 7, 7, 7],
       [7, 7, 7, ..., 7, 7, 7],
       [7, 7, 7, ..., 7, 7, 7]], dtype=uint8)
>>> s2 = kp.data.silicon_ebsd_moving_screen_out5mm()
>>> s2
<EBSD, title: si_out5mm Scan 1, dimensions: (|480, 480)>
>>> s3 = kp.data.silicon_ebsd_moving_screen_out10mm()
>>> s3
<EBSD, title: si_out10mm Scan 1, dimensions: (|480, 480)>
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.