### PR TITLE
Add Gitter chat badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,10 @@
     :target: https://mybinder.org/v2/gh/pyxem/kikuchipy/HEAD
     :alt: Launch binder
 
+.. Gitter chat
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+    :target: https://gitter.im/pyxem/kikuchipy
+
 .. Read the Docs
 .. image:: https://readthedocs.org/projects/kikuchipy/badge/?version=latest
     :target: https://kikuchipy.org/en/latest/


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Add Gitter chat badge pointing to https://gitter.im/pyxem/kikuchipy#

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
