### PR TITLE
Use correct signal shape in shape comparison in EBSD.remove_static_background

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -30,6 +30,12 @@ Added
 - Reading of NORDIF calibration patterns specified in a setting file into an
   EBSD signal. (`#317 <https://github.com/pyxem/kikuchipy/pull/317>`_)
 
+Fixed
+-----
+- Passing a static background pattern to EBSD.remove_static_background() for a
+  non-square detector dataset works.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+
 0.3.2 (2021-02-01)
 ==================
 

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -495,7 +495,7 @@ class EBSD(CommonImage, Signal2D):
                 f"The static background dtype_out {static_bg.dtype} is not the "
                 f"same as pattern dtype_out {dtype_out}."
             )
-        pat_shape = self.axes_manager.signal_shape
+        pat_shape = self.axes_manager.signal_shape[::-1]
         bg_shape = static_bg.shape
         if bg_shape != pat_shape:
             raise OSError(

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -330,6 +330,13 @@ class TestRemoveStaticBackgroundEBSD:
                 relative=True, scale_bg=True, static_bg=dummy_background,
             )
 
+    def test_non_square_patterns(self):
+        s = nickel_ebsd_small()
+        s = s.isig[:, :-5]  # Remove bottom five rows
+        static_bg = s.mean(axis=(0, 1))
+        static_bg.change_dtype(np.uint8)
+        s.remove_static_background(static_bg=static_bg.data)
+
 
 class TestRemoveDynamicBackgroundEBSD:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Passing a static background pattern to EBSD.remove_static_background() for a non-square detector dataset works. Closes #330.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
The following code, from #330, now passes as expected
```python
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()
>>> s = s.isig[:, :-5]  # Remove bottom five rows
>>> static_bg = s.mean(axis=(0, 1))
>>> static_bg.change_dtype(np.uint8)
>>> s.remove_static_background(static_bg=static_bg.data)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
