### PR TITLE
Relax some axes_manager and metadata test comparisons in anticipation of HyperSpy v1.7

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,7 +34,7 @@ Fixed
 -----
 - Passing a static background pattern to EBSD.remove_static_background() for a
   non-square detector dataset works.
-  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+  (`#331 <https://github.com/pyxem/kikuchipy/pull/331>`_)
 
 0.3.2 (2021-02-01)
 ==================

--- a/kikuchipy/io/plugins/tests/test_emsoft_ebsd_masterpattern.py
+++ b/kikuchipy/io/plugins/tests/test_emsoft_ebsd_masterpattern.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 
 from kikuchipy import load
+from kikuchipy.conftest import assert_dictionary
 from kikuchipy.io.plugins.emsoft_ebsd_master_pattern import (
     _check_file_format,
     _get_data_shape_slices,
@@ -32,7 +33,6 @@ from kikuchipy.signals.ebsd_master_pattern import (
     EBSDMasterPattern,
     LazyEBSDMasterPattern,
 )
-from kikuchipy.signals.tests.test_ebsd import assert_dictionary
 
 
 DIR_PATH = os.path.dirname(__file__)
@@ -101,7 +101,7 @@ class TestEMsoftEBSDMasterPatternReader:
         axes_manager = setup_axes_manager(["energy", "height", "width"])
 
         assert s.data.shape == (11, 13, 13)
-        assert s.axes_manager.as_dictionary() == axes_manager
+        assert_dictionary(s.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
         signal_indx = s.axes_manager.signal_indices_in_array
@@ -112,10 +112,8 @@ class TestEMsoftEBSDMasterPatternReader:
     def test_projection_lambert(self):
         s = load(EMSOFT_FILE, projection="lambert", hemisphere="both")
 
-        axes_manager = setup_axes_manager()
-
         assert s.data.shape == (2, 11, 13, 13)
-        assert s.axes_manager.as_dictionary() == axes_manager
+        assert_dictionary(s.axes_manager.as_dictionary(), setup_axes_manager())
 
     def test_check_file_format(self, save_path_hdf5):
         with File(save_path_hdf5, mode="w") as f:

--- a/kikuchipy/io/plugins/tests/test_h5ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_h5ebsd.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 
 from kikuchipy.data import nickel_ebsd_small
+from kikuchipy.conftest import assert_dictionary
 from kikuchipy.io._io import load
 from kikuchipy.io.plugins.h5ebsd import (
     check_h5ebsd,
@@ -91,7 +92,7 @@ class Testh5ebsd:
         s = load(KIKUCHIPY_FILE)
 
         assert s.data.shape == (3, 3, 60, 60)
-        assert s.axes_manager.as_dictionary() == AXES_MANAGER
+        assert_dictionary(s.axes_manager.as_dictionary(), AXES_MANAGER)
 
     def test_load_edax(self):
         with File(EDAX_FILE, mode="r+") as f:
@@ -105,7 +106,7 @@ class Testh5ebsd:
 
         s = load(EDAX_FILE)
         assert s.data.shape == (3, 3, 60, 60)
-        assert s.axes_manager.as_dictionary() == AXES_MANAGER
+        assert_dictionary(s.axes_manager.as_dictionary(), AXES_MANAGER)
 
     def test_load_bruker(self):
         with File(BRUKER_FILE, mode="r+") as f:
@@ -119,7 +120,7 @@ class Testh5ebsd:
 
         s = load(BRUKER_FILE)
         assert s.data.shape == (3, 3, 60, 60)
-        assert s.axes_manager.as_dictionary() == AXES_MANAGER
+        assert_dictionary(s.axes_manager.as_dictionary(), AXES_MANAGER)
 
     def test_load_manufacturer(self, save_path_hdf5):
         s = EBSD((255 * np.random.rand(10, 3, 5, 5)).astype(np.uint8))
@@ -177,7 +178,7 @@ class Testh5ebsd:
         with pytest.warns(UserWarning, match="Will attempt to load by zero"):
             s_reload = load(save_path_hdf5, lazy=lazy)
         AXES_MANAGER["axis-1"]["size"] = new_n_columns
-        assert s_reload.axes_manager.as_dictionary() == AXES_MANAGER
+        assert_dictionary(s_reload.axes_manager.as_dictionary(), AXES_MANAGER)
 
     @pytest.mark.parametrize("remove_phases", (True, False))
     def test_load_save_cycle(self, save_path_hdf5, remove_phases):

--- a/kikuchipy/io/plugins/tests/test_nordif.py
+++ b/kikuchipy/io/plugins/tests/test_nordif.py
@@ -31,6 +31,7 @@ from matplotlib.pyplot import imread
 import numpy as np
 import pytest
 
+from kikuchipy.conftest import assert_dictionary
 from kikuchipy.io._io import load
 from kikuchipy.io.plugins.nordif import get_settings_from_file, get_string
 from kikuchipy.signals.ebsd import EBSD
@@ -235,6 +236,7 @@ AXES_MANAGER = {
         "navigate": False,
     },
 }
+# AXES_MANAGER = make_dicts_compatible_with_hyperspy_v1_7(AXES_MANAGER)
 
 
 @pytest.fixture()
@@ -276,7 +278,7 @@ class TestNORDIF:
         s = load(PATTERN_FILE, setting_file=SETTING_FILE)
 
         assert s.data.shape == (3, 3, 60, 60)
-        assert s.axes_manager.as_dictionary() == AXES_MANAGER
+        assert_dictionary(s.axes_manager.as_dictionary(), AXES_MANAGER)
 
         static_bg = imread(BG_FILE)
         assert np.allclose(
@@ -386,7 +388,7 @@ class TestNORDIF:
                 _ = load(PATTERN_FILE, lazy=lazy, mmap_mode="r+")
         else:
             s = load(PATTERN_FILE, lazy=lazy, mmap_mode="r+")
-            assert s.axes_manager.as_dictionary() == AXES_MANAGER
+            assert_dictionary(s.axes_manager.as_dictionary(), AXES_MANAGER)
 
     def test_save_fresh(self, save_path_nordif):
         scan_size = (10, 3)

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -17,11 +17,9 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from numbers import Number
 
 import dask.array as da
 from hyperspy.utils.roi import RectangularROI
-from hyperspy.misc.utils import DictionaryTreeBrowser
 import matplotlib
 from matplotlib.pyplot import close
 import numpy as np
@@ -33,6 +31,7 @@ from skimage.exposure import rescale_intensity
 
 from kikuchipy import load
 from kikuchipy.data import nickel_ebsd_small, nickel_ebsd_large
+from kikuchipy.conftest import assert_dictionary
 from kikuchipy.filters.window import Window
 from kikuchipy.pattern._pattern import fft_spectrum
 from kikuchipy.signals.ebsd import EBSD, LazyEBSD
@@ -43,25 +42,6 @@ matplotlib.use("Agg")  # For plotting
 DIR_PATH = os.path.dirname(__file__)
 KIKUCHIPY_FILE = os.path.join(DIR_PATH, "../../data/kikuchipy/patterns.h5")
 EMSOFT_FILE = os.path.join(DIR_PATH, "../../data/emsoft_ebsd/simulated_ebsd.h5")
-
-
-def assert_dictionary(input_dict, output_dict):
-    if isinstance(input_dict, DictionaryTreeBrowser):
-        input_dict = input_dict.as_dictionary()
-        output_dict = output_dict.as_dictionary()
-    for key in output_dict.keys():
-        if isinstance(output_dict[key], dict):
-            assert_dictionary(input_dict[key], output_dict[key])
-        else:
-            if isinstance(output_dict[key], list) or isinstance(
-                input_dict[key], list
-            ):
-                output_dict[key] = np.array(output_dict[key])
-                input_dict[key] = np.array(input_dict[key])
-            if isinstance(output_dict[key], (np.ndarray, Number)):
-                assert np.allclose(input_dict[key], output_dict[key])
-            else:
-                assert input_dict[key] == output_dict[key]
 
 
 class TestEBSD:

--- a/kikuchipy/signals/tests/test_ebsd_masterpattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_masterpattern.py
@@ -28,6 +28,7 @@ from orix.quaternion import Rotation
 import pytest
 
 from kikuchipy import load
+from kikuchipy.conftest import assert_dictionary
 from kikuchipy.data import nickel_ebsd_master_pattern_small
 from kikuchipy.detectors import EBSDDetector
 from kikuchipy.io.plugins.tests.test_emsoft_ebsd_masterpattern import (
@@ -89,21 +90,21 @@ class TestIO:
         axes_manager = setup_axes_manager(["energy", "height", "width"])
 
         assert isinstance(s, EBSDMasterPattern)
-        assert s.axes_manager.as_dictionary() == axes_manager
+        assert_dictionary(s.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
         s.save(save_path_hdf5)
 
         s2 = hs_load(save_path_hdf5, signal_type="EBSDMasterPattern")
         assert isinstance(s2, EBSDMasterPattern)
-        assert s2.axes_manager.as_dictionary() == axes_manager
+        assert_dictionary(s2.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s2.metadata.as_dictionary(), METADATA)
 
         s3 = hs_load(save_path_hdf5)
         assert isinstance(s3, Signal2D)
         s3.set_signal_type("EBSDMasterPattern")
         assert isinstance(s3, EBSDMasterPattern)
-        assert s3.axes_manager.as_dictionary() == axes_manager
+        assert_dictionary(s3.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Relax some test comparisons of signal's axes managers and metadata in anticipation of changes to these in the next HyperSpy minor release v1.7, as described in #326. Closes #326.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
