### PR TITLE
Exchange NumPy objects for Python objects some places

### DIFF
--- a/kikuchipy/filters/window.py
+++ b/kikuchipy/filters/window.py
@@ -135,7 +135,7 @@ class Window(np.ndarray):
             try:
                 if any(np.array(shape) < 1):
                     raise ValueError(f"All window axes {shape} must be > 0.")
-                if any(isinstance(i, np.float) for i in np.array(shape)):
+                if any(isinstance(i, float) for i in np.array(shape)):
                     raise TypeError
             except TypeError:
                 raise TypeError(

--- a/kikuchipy/indexing/orientation_similarity_map.py
+++ b/kikuchipy/indexing/orientation_similarity_map.py
@@ -136,7 +136,7 @@ def _orientation_similarity_per_pixel(
     normalize: bool,
 ) -> np.ndarray:
     # v are indices picked out with the footprint from flat_index_map
-    v = v.astype(np.int)
+    v = v.astype(int)
     center_value = v[center_index]
     # Filter only true neighbours, -1 out of image and not include itself
     neighbours = v[np.where((v != -1) & (v != center_value))]

--- a/kikuchipy/pattern/tests/test_pattern.py
+++ b/kikuchipy/pattern/tests/test_pattern.py
@@ -83,7 +83,7 @@ class TestRescaleIntensityPattern:
             (np.uint8, None, RESCALED_UINT8),
             (np.float32, None, RESCALED_FLOAT32),
             (None, None, RESCALED_UINT8),
-            (np.complex, None, RESCALED_UINT8),
+            (complex, None, RESCALED_UINT8),
             (np.uint8, (0, 100), RESCALED_UINT8_0100),
         ],
     )
@@ -93,7 +93,7 @@ class TestRescaleIntensityPattern:
         pattern = dummy_signal.inav[0, 0].data
 
         # Check for accepted data types
-        if dtype_out == np.complex:
+        if dtype_out == complex:
             with pytest.raises(KeyError, match="Could not set output"):
                 _ = rescale_intensity(
                     pattern=pattern,

--- a/kikuchipy/signals/util/_map_helper.py
+++ b/kikuchipy/signals/util/_map_helper.py
@@ -45,10 +45,10 @@ def _map_helper(
     """Return output of :func:`scipy.ndimage.generic_filter` after
     wrapping the `map_function` to apply at each element of
     `flat_index_map`.
-    
+
     The generic filter function will be applied at each navigation
     point.
-    
+
     Parameters
     ----------
     patterns
@@ -79,7 +79,7 @@ def _map_helper(
         # from `flat_index_map`
         return map_function(
             patterns=patterns,
-            indices=indices.astype(np.int),
+            indices=indices.astype(int),
             nav_shape=nav_shape,
             dtype_out=dtype_out,
             **kwargs,
@@ -109,7 +109,7 @@ def _neighbour_dot_products(
 ) -> Union[float, int]:
     """Return either an average of a dot product matrix between a
     pattern and it's neighbours, or the matrix.
-    
+
     Parameters
     ----------
     patterns
@@ -127,7 +127,7 @@ def _neighbour_dot_products(
         Index into `patterns` for the current pattern to calculate the
         dot products for.
     zero_mean
-        Whether to center the pattern intensities by subtracting the 
+        Whether to center the pattern intensities by subtracting the
         mean intensity to get an average intensity of zero,
         individually.
     normalize


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Address deprecation warnings raised by NumPy v1.20, by exchanging NumPy objects for Python objects some places. I believe this also should close #319.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
