### PR TITLE
Fix bugs in getting plot markers from geometrical EBSD simulation

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -32,6 +32,8 @@ Added
 
 Fixed
 -----
+- Bugs in getting plot markers from geometrical EBSD simulation.
+  (`#334 <https://github.com/pyxem/kikuchipy/pull/334>`_)
 - Passing a static background pattern to EBSD.remove_static_background() for a
   non-square detector dataset works.
   (`#331 <https://github.com/pyxem/kikuchipy/pull/331>`_)

--- a/doc/geometrical_ebsd_simulations.ipynb
+++ b/doc/geometrical_ebsd_simulations.ipynb
@@ -173,9 +173,9 @@
     "grain1 = [80, 34, -90]\n",
     "grain2 = [115, 27, -95]\n",
     "r = quaternion.Rotation.from_euler(np.deg2rad([\n",
-    "        [grain1, grain1, grain2],\n",
-    "        [grain1, grain1, grain2],\n",
-    "        [grain1, grain1, grain2]\n",
+    "        [grain1, grain2, grain2],\n",
+    "        [grain1, grain2, grain2],\n",
+    "        [grain1, grain2, grain2]\n",
     "]))\n",
     "r"
    ]
@@ -629,7 +629,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/kikuchipy/draw/markers.py
+++ b/kikuchipy/draw/markers.py
@@ -118,16 +118,5 @@ def get_text_list(
             x[~is_finite[..., i]] = np.nan
             y[~is_finite[..., i]] = np.nan
             text_marker = text(x=x, y=y, text=texts[i], **kwargs,)
-            # TODO: Pass "visible" parameter to text() when HyperSpy allows
-            #  it (merges this PR
-            #  https://github.com/hyperspy/hyperspy/pull/2558 and publishes
-            #  a minor release with that update)
-            # text_marker = text(
-            #     x=coordinates[..., i, 0],
-            #     y=coordinates[..., i, 1],
-            #     text=texts[i],
-            #     visible=is_finite[..., i],
-            #     **kwargs
-            # )
             marker_list.append(text_marker)
     return marker_list

--- a/kikuchipy/draw/tests/test_markers.py
+++ b/kikuchipy/draw/tests/test_markers.py
@@ -296,7 +296,6 @@ class TestMarkers:
             assert text_markers[i].data["text"] == texts[i]
 
     def test_get_text_list_nans(self):
-        """Returns"""
         text_coords = np.ones((2, 3, 2)) * np.nan
         assert (
             len(

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -211,8 +211,8 @@ class GeometricalEBSDSimulation:
                     if _is_equivalent(hkl, table_hkl):
                         family_colors.append(color)
                         break
-        #                else:  # Hopefully we never arrive here
-        #                    family_colors.append([1, 0, 0])
+                else:  # A non-allowed band is passed
+                    family_colors.append([1, 1, 1])
 
         # Append list of markers per family (colors changing with
         # family)

--- a/kikuchipy/simulations/geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/geometrical_ebsd_simulation.py
@@ -270,8 +270,10 @@ class GeometricalEBSDSimulation:
         list
             List of text markers.
         """
+        za = self.zone_axes.hkl.data
+        array_str = np.array2string(za, threshold=za.size)
         return get_text_list(
-            texts=sub("[][ ]", "", str(self.zone_axes.hkl.data)).split("\n"),
+            texts=sub("[][ ]", "", array_str).split("\n"),
             coordinates=self.zone_axes_label_detector_coordinates,
             color=kwargs.pop("color", "k"),
             zorder=kwargs.pop("zorder", 5),

--- a/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
@@ -109,7 +109,16 @@ class TestGeometricalEBSDSimulation:
         )
         assert sim.exclude_outside_detector == exclude
 
-    @pytest.mark.parametrize("nav_shape", [(5, 5), (1, 25), (25, 1), (25,)])
+    @pytest.mark.parametrize(
+        "nav_shape, nickel_rlp",
+        [
+            ((5, 5), [[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1], [1, 2, 3]]),
+            ((1, 25), [[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1], [1, 2, 3]]),
+            ((25, 1), [[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1], [1, 2, 3]]),
+            ((25,), [[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1], [1, 2, 3]]),
+        ],
+        indirect=["nickel_rlp"],
+    )
     def test_bands_as_markers(
         self, nickel_ebsd_simulation_generator, nickel_rlp, nav_shape
     ):

--- a/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
+++ b/kikuchipy/simulations/tests/test_geometrical_ebsd_simulation.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from diffsims.crystallography import ReciprocalLatticePoint
 from hyperspy.utils.markers import line_segment, point, text
 import matplotlib
 import matplotlib.pyplot as plt
@@ -215,6 +216,18 @@ class TestGeometricalEBSDSimulation:
         assert isinstance(se.metadata.Markers.text, text)
         se.plot()
         plt.close("all")
+
+    def test_many_zone_axes_labels_as_markers(
+        self, nickel_ebsd_simulation_generator, nickel_phase
+    ):
+        simgen = nickel_ebsd_simulation_generator
+        rlp = ReciprocalLatticePoint(
+            phase=nickel_phase,
+            hkl=[[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1], [1, 2, 3]],
+        )
+        rlp2 = rlp.symmetrise()
+        sim = simgen.geometrical_simulation(rlp2)
+        _ = sim.zone_axes_labels_as_markers()
 
     @pytest.mark.parametrize("nav_shape", [(5, 5), (1, 25), (25, 1), (25,)])
     def test_pc_as_markers(


### PR DESCRIPTION
#### Description of the change
* Line markers from non-allowed (according to kinematical diffraction) kikuchi bands in a geometrical EBSD simulation are returned as white, instead of not being given a colour and thus an IndexError is later thrown (see #318)
* Zone axes labels are properly returned when the amount of zone axes is large, instead of throwing an IndexError in another place

Added tests to catch these two cases.

Close #318.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
