### PR TITLE
Allow not passing simulation indices property array to crystal map merging

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -32,6 +32,9 @@ Added
 
 Fixed
 -----
+- Merging of (typically refined) crystal maps, where either a simulation indices
+  is not present, or it contains more indices per point than scores.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 - Bugs in getting plot markers from geometrical EBSD simulation.
   (`#334 <https://github.com/pyxem/kikuchipy/pull/334>`_)
 - Passing a static background pattern to EBSD.remove_static_background() for a

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,7 +34,7 @@ Fixed
 -----
 - Merging of (typically refined) crystal maps, where either a simulation indices
   is not present, or it contains more indices per point than scores.
-  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+  (`#335 <https://github.com/pyxem/kikuchipy/pull/335>`_)
 - Bugs in getting plot markers from geometrical EBSD simulation.
   (`#334 <https://github.com/pyxem/kikuchipy/pull/334>`_)
 - Passing a static background pattern to EBSD.remove_static_background() for a

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,7 +33,7 @@ Added
 Fixed
 -----
 - Merging of (typically refined) crystal maps, where either a simulation indices
-  is not present, or it contains more indices per point than scores.
+  array is not present or the array contains more indices per point than scores.
   (`#335 <https://github.com/pyxem/kikuchipy/pull/335>`_)
 - Bugs in getting plot markers from geometrical EBSD simulation.
   (`#334 <https://github.com/pyxem/kikuchipy/pull/334>`_)

--- a/kikuchipy/indexing/_merge_crystal_maps.py
+++ b/kikuchipy/indexing/_merge_crystal_maps.py
@@ -41,9 +41,8 @@ def merge_crystal_maps(
     :class:`~orix.crystal_map.crystal_map.CrystalMap` with a 1D or 2D
     navigation shape into one multi phase map.
 
-    It is required that there are at least as many simulation indices as
-    scores per point, and that all maps have the same number of
-    rotations, scores and simulation indices per point.
+    It is required that all maps have the same number of rotations and
+    scores (and simulation indices if applicable) per point.
 
     Parameters
     ----------

--- a/kikuchipy/indexing/_merge_crystal_maps.py
+++ b/kikuchipy/indexing/_merge_crystal_maps.py
@@ -17,7 +17,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from math import copysign
-from typing import List, Union, Tuple
+from typing import List, Optional, Tuple, Union
 import warnings
 
 import numpy as np
@@ -34,8 +34,8 @@ def merge_crystal_maps(
     crystal_maps: List[CrystalMap],
     mean_n_best: int = 1,
     metric: Union[str, SimilarityMetric] = None,
-    simulation_indices_prop: str = "simulation_indices",
     scores_prop: str = "scores",
+    simulation_indices_prop: Optional[str] = None,
 ):
     """Merge a list of at least two single phase
     :class:`~orix.crystal_map.crystal_map.CrystalMap` with a 1D or 2D
@@ -56,22 +56,26 @@ def merge_crystal_maps(
         comparing. Default is 1.
     metric : str or SimilarityMetric, optional
         Similarity metric, default is None.
-    simulation_indices_prop : str, optional
-        Name of simulated indices array in the crystal maps' properties.
-        Default is "simulation_indices".
     scores_prop : str, optional
         Name of scores array in the crystal maps' properties. Default
         is "scores".
+    simulation_indices_prop : str, optional
+        Name of simulated indices array in the crystal maps' properties.
+        If None (default), the merged crystal map will not contain
+        an array of merged simulation indices from the input crystal
+        maps' properties. If a string, there must be as many simulation
+        indices per point as there are scores.
 
     Returns
     -------
     merged_xmap : ~orix.crystal_map.crystal_map.CrystalMap
         A crystal map where the rotation of the phase with the best
         matching score(s) is assigned to each point. The best matching
-        simulation indices and scores, merge sorted, are added to its
-        properties with names equal to whatever passed to `scores_prop`
-        and `simulation_indices_prop` with "merged" as a suffix,
-        respectively.
+        scores, merge sorted, are added to its properties with a name
+        equal to whatever passed to `scores_prop` with "merged" as a
+        suffix. If `simulation_indices_prop` is passed, the best
+        matching simulation indices are added in the same way as the
+        scores.
 
     Notes
     -----
@@ -85,8 +89,8 @@ def merge_crystal_maps(
     rot_per_point_per_map = [xmap.rotations_per_point for xmap in crystal_maps]
     if not all(np.diff(rot_per_point_per_map) == 0):
         raise ValueError(
-            "All crystal maps must have the same number of rotations, scores "
-            "and simulation indices per point."
+            "All crystal maps must have the same number of rotations and scores"
+            " per point."
         )
 
     if metric is None:
@@ -127,13 +131,17 @@ def merge_crystal_maps(
     # to one phase per point (uncombined)
     new_rotations = Rotation(np.zeros_like(crystal_maps[0].rotations.data))
     new_scores = np.zeros_like(crystal_maps[0].prop[scores_prop])
-    new_indices = np.zeros_like(crystal_maps[0].prop[simulation_indices_prop])
+    if simulation_indices_prop is not None:
+        new_indices = np.zeros_like(
+            crystal_maps[0].prop[simulation_indices_prop]
+        )
     phase_list = PhaseList()
     for i, xmap in enumerate(crystal_maps):
         mask = phase_id == i
         new_rotations[mask] = xmap.rotations[mask]
         new_scores[mask] = xmap.prop[scores_prop][mask]
-        new_indices[mask] = xmap.prop[simulation_indices_prop][mask]
+        if simulation_indices_prop is not None:
+            new_indices[mask] = xmap.prop[simulation_indices_prop][mask]
         if np.sum(mask) != 0:
             current_id = xmap.phases_in_data.ids[0]
             phase = xmap.phases_in_data[current_id].deepcopy()
@@ -163,31 +171,49 @@ def merge_crystal_maps(
         comb_scores_reshaped, best_sorted_idx, axis=-1
     )
 
-    # Combined (unsorted) simulation indices array of shape (M, N, K) or
-    # (M, K), accounting for the case where there are more simulation
-    # indices per point than scores (e.g. refined dot products from
-    # EMsoft)
-    comb_sim_idx = np.dstack(
-        [xmap.prop[simulation_indices_prop] for xmap in crystal_maps]
-    )
+    # Set up merged map's properties
+    props = {
+        scores_prop: new_scores,
+        f"merged_{scores_prop}": merged_best_scores,
+    }
 
-    # To enable calculation of an orientation similarity map from the
-    # combined, sorted simulation indices array, we must make the
-    # indices unique across all maps
-    for i in range(1, comb_sim_idx.shape[-1]):
-        increment = (
-            abs(comb_sim_idx[..., i - 1].max() - comb_sim_idx[..., i].min()) + 1
+    if simulation_indices_prop is not None:
+        # Combined (unsorted) simulation indices array of shape
+        # (M, N, K) or (M, K), accounting for the case where there are
+        # more simulation indices per point than scores (e.g. refined
+        # dot products from EMsoft)
+        comb_sim_idx = np.dstack(
+            [xmap.prop[simulation_indices_prop] for xmap in crystal_maps]
         )
-        comb_sim_idx[..., i] += increment
 
-    # Collapse axes as for the combined scores array above
-    comb_sim_idx = comb_sim_idx.reshape(mergesort_shape)
+        if comb_sim_idx.size != np.prod(mergesort_shape):
+            raise ValueError(
+                "Cannot merge maps with more simulation indices than scores per"
+                " point."
+            )
 
-    # Best, sorted simulation indices in all maps (for all phases) per
-    # point
-    merged_simulated_indices = np.take_along_axis(
-        comb_sim_idx, best_sorted_idx, axis=-1
-    )
+        # To enable calculation of an orientation similarity map from
+        # the combined, sorted simulation indices array, we must make
+        # the indices unique across all maps
+        for i in range(1, comb_sim_idx.shape[-1]):
+            increment = (
+                abs(comb_sim_idx[..., i - 1].max() - comb_sim_idx[..., i].min())
+                + 1
+            )
+            comb_sim_idx[..., i] += increment
+
+        # Collapse axes as for the combined scores array above
+        comb_sim_idx = comb_sim_idx.reshape(mergesort_shape)
+
+        # Best, sorted simulation indices in all maps (for all phases)
+        # per point
+        merged_simulated_indices = np.take_along_axis(
+            comb_sim_idx, best_sorted_idx, axis=-1
+        )
+
+        # Finally, add to properties
+        props[simulation_indices_prop] = new_indices
+        props[f"merged_{simulation_indices_prop}"] = merged_simulated_indices
 
     return CrystalMap(
         rotations=new_rotations,
@@ -196,12 +222,7 @@ def merge_crystal_maps(
         x=crystal_maps[0].x,
         y=crystal_maps[0].y,
         z=crystal_maps[0].z,
-        prop={
-            scores_prop: new_scores,
-            simulation_indices_prop: new_indices,
-            f"merged_{scores_prop}": merged_best_scores,
-            f"merged_{simulation_indices_prop}": merged_simulated_indices,
-        },
+        prop=props,
         scan_unit=crystal_maps[0].scan_unit,
     )
 

--- a/kikuchipy/indexing/tests/test_merge_crystal_maps.py
+++ b/kikuchipy/indexing/tests/test_merge_crystal_maps.py
@@ -255,7 +255,9 @@ class TestMergeCrystalMaps:
         desired_phase_id[3] = 1
 
         merged_xmap = merge_crystal_maps(
-            crystal_maps=[xmap1, xmap2], metric=metric,
+            crystal_maps=[xmap1, xmap2],
+            metric=metric,
+            simulation_indices_prop=sim_idx_prop,
         )
 
         assert np.allclose(merged_xmap.phase_id, desired_phase_id)
@@ -358,10 +360,13 @@ class TestMergeCrystalMaps:
         """Ensure that the mergesorted scores and simulation index
         properties in the merged map has the correct values and shape.
         """
+        prop_names = ["scores", "simulation_indices"]
         n_phases = np.shape(desired_merged_scores)[-1] // rot_per_point
         xmaps = []
         for i in range(n_phases):
-            xmap = get_single_phase_xmap(nav_shape, rot_per_point, name=str(i))
+            xmap = get_single_phase_xmap(
+                nav_shape, rot_per_point, name=str(i), prop_names=prop_names
+            )
             xmap[i].scores += i
             xmaps.append(xmap)
 
@@ -370,7 +375,9 @@ class TestMergeCrystalMaps:
         assert np.sum(np.diff(all_sim_idx)) == 0
 
         merged_xmap = merge_crystal_maps(
-            crystal_maps=xmaps, mean_n_best=mean_n_best,
+            crystal_maps=xmaps,
+            mean_n_best=mean_n_best,
+            simulation_indices_prop=prop_names[1],
         )
 
         assert merged_xmap.phases.size == n_phases


### PR DESCRIPTION
#### Description of the change
* See https://github.com/pyxem/kikuchipy/issues/323#issuecomment-820290730 in #323. Close #323.

The fact that we now have to pass `simulation_indices_prop` to `merge_crystal_maps()` in order to get the simulation indices in the merged map, instead of getting these by default, is breaking the API. However, I will ignore that fact and include this in the forthcoming v0.3.3 patch release.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
The following didn't work previously, but now works
```python
import kikuchipy as kp
import numpy as np
from orix import crystal_map, quaternion

nav_shape = (3, 3)
ny, nx = nav_shape
nav_size = np.prod(nav_shape)
r = quaternion.Rotation.from_euler(np.ones((nav_size, 3)))
x = np.tile(np.arange(ny), nx)
y = np.repeat(np.arange(nx), ny)

# Simulation indices
n_sim_indices = 10
sim_indices1 = np.random.randint(
    low=0, high=1000, size=n_sim_indices * nav_size
).reshape((nav_size, n_sim_indices))
sim_indices2 = np.random.randint(
    low=0, high=1000, size=n_sim_indices * nav_size
).reshape((nav_size, n_sim_indices))

# Scores
scores1 = np.ones(nav_size)
scores1[0] = 3
scores2 = 2 * np.ones(nav_size)

xmap1 = crystal_map.CrystalMap(
    rotations=r,
    phase_id=np.ones(nav_size) * 0,
    x=x,
    y=y,
    prop={"simulation_indices": sim_indices1, "scores": scores1},
)
xmap2 = crystal_map.CrystalMap(
    rotations=r,
    phase_id=np.ones(nav_size),
    x=x,
    y=y,
    prop={"simulation_indices": sim_indices2, "scores": scores2},
)
xmap_merged = kp.indexing.merge_crystal_maps(
    crystal_maps=[xmap1, xmap2],
#    simulation_indices_prop="simulation_indices",
)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.