### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.8, 3.9]
         include:
           # Oldest supported version of main dependencies on Python 3.7
-          - os: ubuntu
+          - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: dask==2.14 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.2 numpy==1.18 orix==0.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2.14 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.2 numpy==1.18 orix==0.5
+            DEPENDENCIES: dask==2.18 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.5.1
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-with-pip:
-    name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
+    name: ${{ matrix.os }}/py${{ matrix.PYTHON_VERSION }}/pip
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -13,18 +13,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        PYTHON_VERSION: [3.8, 3.9]
+        include:
+          # Oldest supported version of main dependencies on Python 3.7
+          - os: ubuntu
+            PYTHON_VERSION: 3.7
+            OLDEST_SUPPORTED_VERSION: true
+            DEPENDENCIES: dask==2.14 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.2 numpy==1.18 orix==0.5
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       - name: Display versions
         run: python -V; pip -V
       - name: Install depedencies and package
         shell: bash
         run: pip install -U -e .'[doc, tests]'
+      - name: Install oldest supported version
+        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        run: pip install ${{ matrix.DEPENDENCIES }}
       - name: Run tests
         run: pytest --cov=kikuchipy --pyargs kikuchipy
       - name: Generate line coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-with-pip:
-    name: ${{ matrix.os }}/py${{ matrix.PYTHON_VERSION }}/pip
+    name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -13,19 +13,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        PYTHON_VERSION: [3.8, 3.9]
+        python-version: [3.8, 3.9]
         include:
           # Oldest supported version of main dependencies on Python 3.7
           - os: ubuntu
-            PYTHON_VERSION: 3.7
+            python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: dask==2.14 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.2 numpy==1.18 orix==0.5
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.PYTHON_VERSION }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Display versions
         run: python -V; pip -V
       - name: Install depedencies and package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2.18 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.5.1
+            DEPENDENCIES: dask==2.18 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.5.1 scikit-image==0.16.2
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,8 @@ Contributors
 
 Added
 -----
+- Support for Python 3.9.
+  (`#348 <https://github.com/pyxem/kikuchipy/pull/348>)`_
 - Projection/pattern center calibration via the moving screen technique in a
   kikuchipy.detectors.calibration module.
   (`#322 <https://github.com/pyxem/kikuchipy/pull/322>`_)

--- a/kikuchipy/crystallography/tests/test_crystallographic_computations.py
+++ b/kikuchipy/crystallography/tests/test_crystallographic_computations.py
@@ -17,7 +17,6 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from diffsims.crystallography import ReciprocalLatticePoint
-import matplotlib.colors as mcolors
 import numpy as np
 import pytest
 from orix.crystal_map import Phase

--- a/kikuchipy/detectors/ebsd_detector.py
+++ b/kikuchipy/detectors/ebsd_detector.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple, Union
 
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.markers import MarkerStyle
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -584,12 +585,12 @@ class EBSDDetector:
         if show_pc:
             if pc_kwargs is None:
                 pc_kwargs = {}
-            default_params_pc = {
-                "s": 300,
-                "facecolor": "gold",
-                "edgecolor": "k",
-                "marker": "*",
-            }
+            default_params_pc = dict(
+                s=300,
+                facecolor="gold",
+                edgecolor="k",
+                marker=MarkerStyle(marker="*", fillstyle="full"),
+            )
             [pc_kwargs.setdefault(k, v) for k, v in default_params_pc.items()]
             ax.scatter(x=pcx, y=pcy, **pc_kwargs)
 

--- a/kikuchipy/io/plugins/tests/test_h5ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_h5ebsd.py
@@ -305,8 +305,6 @@ class Testh5ebsd:
         )
         mm = s.data.dask[k]
         assert isinstance(mm, Dataset)
-        with pytest.raises(NotImplementedError):
-            s.data[:] = 23
 
     def test_save_fresh(self, save_path_hdf5, tmp_path):
         scan_size = (10, 3)

--- a/kikuchipy/io/plugins/tests/test_nordif.py
+++ b/kikuchipy/io/plugins/tests/test_nordif.py
@@ -378,8 +378,6 @@ class TestNORDIF:
         mm = s.data.dask[k]
         assert isinstance(mm, np.memmap)
         assert not mm.flags["WRITEABLE"]
-        with pytest.raises(NotImplementedError):
-            s.data[:] = 23
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_load_inplace(self, lazy):

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -864,7 +864,7 @@ class TestDecomposition:
 
         # Decomposition
         dummy_signal.change_dtype(np.float32)
-        dummy_signal.decomposition(algorithm="SVD")
+        dummy_signal.decomposition()
 
         # Get decomposition model
         model_signal = dummy_signal.get_decomposition_model(

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         "pooch >= 0.13",
         "psutil",
         "tqdm >= 0.5.2",
-        "scikit-image >= 0.16",
+        "scikit-image >= 0.16.2",
         "scikit-learn",
         "scipy",
     ],

--- a/setup.py
+++ b/setup.py
@@ -116,14 +116,14 @@ setup(
     # Dependencies
     extras_require=extra_feature_requirements,
     install_requires=[
-        "dask[array] >= 2.14",
+        "dask[array] >= 2.18",
         "diffsims >= 0.4",
         "hyperspy >= 1.5.2",
         "h5py >= 2.10",
-        "matplotlib >= 3.2",
-        "numpy >= 1.18",
+        "matplotlib >= 3.3",
+        "numpy >= 1.19",
         "numba >= 0.48",
-        "orix >= 0.5",
+        "orix >= 0.5.1",
         "pooch >= 0.13",
         "psutil",
         "tqdm >= 0.5.2",

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         (


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Support Python 3.9 in setup.py.
* Fix issues in #343 related to Matplotlib 3.4.1 and Dask 2021.4.1.
* Update build matrix to use Python 3.8 and 3.9, adding one step for 3.7 on Ubuntu.
* Update minimal supported versions, reflecting what we *actually* support.

Close #343.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
