### PR TITLE
Overwrite deepcopy for EBSD and EBSDMasterPattern to carry over custom properties

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -38,7 +38,7 @@ Fixed
 -----
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively,
   `xmap` and `detector`, and `phase`, `hemisphere` and `projection` properties
-  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_).
+  (`#356 <https://github.com/pyxem/kikuchipy/pull/356>`_).
 - Scaling of region of interest coordinates used in virtual backscatter electron
   imaging to physical coordinates.
   (`#349 <https://github.com/pyxem/kikuchipy/pull/349>`_)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -36,8 +36,11 @@ Added
 
 Fixed
 -----
+- Deep copying EBSD and EBSDMasterPattern signals carry over, respectively,
+  `xmap` and `detector`, and `phase`, `hemisphere` and `projection` properties
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_).
 - Scaling of region of interest coordinates used in virtual backscatter electron
-  imaging to physical coordinates
+  imaging to physical coordinates.
   (`#349 <https://github.com/pyxem/kikuchipy/pull/349>`_)
 
 0.3.3 (2021-04-18)
@@ -50,7 +53,7 @@ Contributors
 
 Fixed
 -----
-- Reading of EBSD patterns from Bruker h5ebsd with a region of interest
+- Reading of EBSD patterns from Bruker h5ebsd with a region of interest.
   (`#339 <https://github.com/pyxem/kikuchipy/pull/339>`_)
 - Merging of (typically refined) crystal maps, where either a simulation indices
   array is not present or the array contains more indices per point than scores.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -84,6 +84,11 @@ EBSDDetector
 .. currentmodule:: kikuchipy.detectors.EBSDDetector
 
 .. autosummary::
+    deepcopy
+    pc_bruker
+    pc_emsoft
+    pc_oxford
+    pc_tsl
     plot
 
 .. autoclass:: kikuchipy.detectors.EBSDDetector
@@ -482,6 +487,9 @@ EBSD
 All methods listed here are also available to
 :class:`~kikuchipy.signals.LazyEBSD` objects.
 
+See :class:`hyperspy._signals.signal2d.Signal2D` for methods inherited
+from HyperSpy.
+
 .. currentmodule:: kikuchipy.signals.EBSD
 
 .. autosummary::
@@ -532,6 +540,9 @@ EBSDMasterPattern
 All methods listed here are also available to
 :class:`~kikuchipy.signals.LazyEBSDMasterPattern` objects.
 
+See :class:`hyperspy._signals.signal2d.Signal2D` for methods inherited
+from HyperSpy.
+
 .. currentmodule:: kikuchipy.signals.EBSDMasterPattern
 
 .. autosummary::
@@ -553,6 +564,9 @@ There are no methods exclusive to LazyEBSDMasterPattern objects.
 
 VirtualBSEImage
 ---------------
+
+See :class:`hyperspy._signals.signal2d.Signal2D` for methods inherited
+from HyperSpy.
 
 .. currentmodule:: kikuchipy.signals.VirtualBSEImage
 

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -370,8 +370,9 @@ def get_single_phase_xmap(rotations):
         prop_names=["scores", "simulation_indices"],
         name="a",
         phase_id=0,
+        step_sizes=(1.5, 1),
     ):
-        d, map_size = _get_spatial_array_dicts(nav_shape)
+        d, map_size = _get_spatial_array_dicts(nav_shape, step_sizes)
         rot_idx = np.random.choice(
             np.arange(rotations.size), map_size * rotations_per_point
         )

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-
+import copy
 import sys
 from typing import Optional, Union
 
@@ -61,6 +61,8 @@ class EBSDMasterPattern(CommonImage, Signal2D):
     _signal_type = "EBSDMasterPattern"
     _alias_signal_types = ["ebsd_master_pattern", "master_pattern"]
     _lazy = False
+
+    # ---------------------- Custom properties ----------------------- #
 
     phase = Phase()
     projection = None
@@ -257,6 +259,14 @@ class EBSDMasterPattern(CommonImage, Signal2D):
             out = LazyEBSD(simulated, axes=axes, **kwargs)
 
         return out
+
+    # ------ Methods overwritten from hyperspy.signals.Signal2D ------ #
+    def deepcopy(self):
+        new = super().deepcopy()
+        new.phase = self.phase.deepcopy()
+        new.projection = copy.deepcopy(self.projection)
+        new.hemisphere = copy.deepcopy(self.hemisphere)
+        return new
 
 
 class LazyEBSDMasterPattern(EBSDMasterPattern, LazySignal2D):

--- a/kikuchipy/signals/tests/test_ebsd_masterpattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_masterpattern.py
@@ -27,23 +27,20 @@ from orix.vector import Vector3d
 from orix.quaternion import Rotation
 import pytest
 
+import kikuchipy as kp
 from kikuchipy import load
 from kikuchipy.conftest import assert_dictionary
 from kikuchipy.data import nickel_ebsd_master_pattern_small
-from kikuchipy.detectors import EBSDDetector
 from kikuchipy.io.plugins.tests.test_emsoft_ebsd_masterpattern import (
     setup_axes_manager,
     METADATA,
 )
 from kikuchipy.signals.tests.test_ebsd import assert_dictionary
 from kikuchipy.signals.ebsd_master_pattern import (
-    EBSDMasterPattern,
-    LazyEBSDMasterPattern,
     _get_direction_cosines,
     _get_lambert_interpolation_parameters,
     _get_patterns_chunk,
 )
-from kikuchipy.signals.ebsd import LazyEBSD, EBSD
 from kikuchipy.indexing.similarity_metrics import ncc, ndp
 
 
@@ -55,7 +52,7 @@ EMSOFT_FILE = os.path.join(
 
 class TestEBSDMasterPatternInit:
     def test_init_no_metadata(self):
-        s = EBSDMasterPattern(
+        s = kp.signals.EBSDMasterPattern(
             np.zeros((2, 10, 11, 11)),
             projection="lambert",
             hemisphere="both",
@@ -68,15 +65,15 @@ class TestEBSDMasterPatternInit:
         assert s.hemisphere == "both"
 
     def test_ebsd_masterpattern_lazy_data_init(self):
-        s = EBSDMasterPattern(da.zeros((2, 10, 11, 11)))
+        s = kp.signals.EBSDMasterPattern(da.zeros((2, 10, 11, 11)))
 
-        assert isinstance(s, EBSDMasterPattern)
+        assert isinstance(s, kp.signals.EBSDMasterPattern)
         assert isinstance(s.data, da.Array)
 
     def test_ebsd_masterpattern_lazy_init(self):
-        s = LazyEBSDMasterPattern(da.zeros((2, 10, 11, 11)))
+        s = kp.signals.LazyEBSDMasterPattern(da.zeros((2, 10, 11, 11)))
 
-        assert isinstance(s, LazyEBSDMasterPattern)
+        assert isinstance(s, kp.signals.LazyEBSDMasterPattern)
         assert isinstance(s.data, da.Array)
 
 
@@ -89,21 +86,21 @@ class TestIO:
 
         axes_manager = setup_axes_manager(["energy", "height", "width"])
 
-        assert isinstance(s, EBSDMasterPattern)
+        assert isinstance(s, kp.signals.EBSDMasterPattern)
         assert_dictionary(s.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
         s.save(save_path_hdf5)
 
         s2 = hs_load(save_path_hdf5, signal_type="EBSDMasterPattern")
-        assert isinstance(s2, EBSDMasterPattern)
+        assert isinstance(s2, kp.signals.EBSDMasterPattern)
         assert_dictionary(s2.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s2.metadata.as_dictionary(), METADATA)
 
         s3 = hs_load(save_path_hdf5)
         assert isinstance(s3, Signal2D)
         s3.set_signal_type("EBSDMasterPattern")
-        assert isinstance(s3, EBSDMasterPattern)
+        assert isinstance(s3, kp.signals.EBSDMasterPattern)
         assert_dictionary(s3.axes_manager.as_dictionary(), axes_manager)
         assert_dictionary(s.metadata.as_dictionary(), METADATA)
 
@@ -128,7 +125,7 @@ class TestIO:
 
         s.save(save_path_hdf5)
         s2 = hs_load(save_path_hdf5, signal_type="EBSDMasterPattern")
-        assert isinstance(s2, EBSDMasterPattern)
+        assert isinstance(s2, kp.signals.EBSDMasterPattern)
 
         omd_dict_keys2 = s2.original_metadata.as_dictionary().keys()
         assert [k in omd_dict_keys2 for k in desired_keys]
@@ -141,16 +138,30 @@ class TestProperties:
     )
     def test_properties(self, projection, hemisphere):
         mp = nickel_ebsd_master_pattern_small(
-            projection=projection, hemisphere=hemisphere
+            projection=projection, hemisphere=hemisphere, lazy=True
         )
-
         assert mp.projection == projection
         assert mp.hemisphere == hemisphere
+
+        # Deepcopy
+        mp2 = mp.deepcopy()
+
+        assert mp2.projection == projection
+        mp2.projection = "gnomonic"
+        assert mp2.projection != projection
+
+        assert mp2.hemisphere == hemisphere
+        mp2.hemisphere = "west"
+        assert mp2.hemisphere != hemisphere
+
+        assert mp2.phase.point_group.name == mp.phase.point_group.name
+        mp2.phase.space_group = 220
+        assert mp2.phase.point_group.name != mp.phase.point_group.name
 
 
 class TestSimulatedPatternDictionary:
     # Create detector model
-    detector = EBSDDetector(
+    detector = kp.detectors.EBSDDetector(
         shape=(480, 640),
         px_size=50,
         pc=(20, 20, 15000),
@@ -168,18 +179,9 @@ class TestSimulatedPatternDictionary:
         npx = 1001
         npy = 1001
         scale = 500
-        (
-            nii,
-            nij,
-            niip,
-            nijp,
-            di,
-            dj,
-            dim,
-            djm,
-        ) = _get_lambert_interpolation_parameters(
+        nii, nij, niip, nijp = _get_lambert_interpolation_parameters(
             rotated_direction_cosines=dc, npx=npx, npy=npy, scale=scale,
-        )
+        )[:4]
 
         assert (nii <= niip).all()
         assert (nij <= nijp).all()
@@ -220,7 +222,7 @@ class TestSimulatedPatternDictionary:
 
         detector_shape = self.detector.shape
         r2 = Rotation.from_euler(((0, 0, 0), (1, 1, 1), (2, 2, 2)))
-        mp_a = EBSDMasterPattern(np.zeros((2, 10, 11, 11)))
+        mp_a = kp.signals.EBSDMasterPattern(np.zeros((2, 10, 11, 11)))
         print(mp_a.axes_manager)
         mp_a.axes_manager[0].name = "hemisphere"
         mp_a.axes_manager[1].name = "energy"
@@ -228,40 +230,40 @@ class TestSimulatedPatternDictionary:
         mp_a.phase = Phase("Ni", 225)
         out_a = mp_a.get_patterns(r2, self.detector, 5)
 
-        assert isinstance(out_a, LazyEBSD)
+        assert isinstance(out_a, kp.signals.LazyEBSD)
         desired_data_shape = (3,) + detector_shape[::-1]
         assert out_a.axes_manager.shape == desired_data_shape
 
-        mp_b = EBSDMasterPattern(np.zeros((10, 11, 11)))
+        mp_b = kp.signals.EBSDMasterPattern(np.zeros((10, 11, 11)))
         mp_b.axes_manager[0].name = "energy"
         mp_b.projection = "lambert"
         mp_b.phase = Phase("Ni", 225)
         out_b = mp_b.get_patterns(r2, self.detector, 5)
 
-        assert isinstance(out_b, LazyEBSD)
+        assert isinstance(out_b, kp.signals.LazyEBSD)
         assert out_b.axes_manager.shape == desired_data_shape
 
-        mp_c = EBSDMasterPattern(np.zeros((11, 11)))
+        mp_c = kp.signals.EBSDMasterPattern(np.zeros((11, 11)))
         mp_c.projection = "lambert"
         mp_c.phase = Phase("Ni", 225)
         out_c = mp_c.get_patterns(r2, self.detector, 5)
         out_c_2 = mp_c.get_patterns(r2, self.detector, 5, compute=True)
 
-        assert isinstance(out_c, LazyEBSD)
-        assert isinstance(out_c_2, EBSD)
+        assert isinstance(out_c, kp.signals.LazyEBSD)
+        assert isinstance(out_c_2, kp.signals.EBSD)
         assert out_c.axes_manager.shape == desired_data_shape
 
-        mp_c2 = EBSDMasterPattern(np.zeros((11, 11)))
+        mp_c2 = kp.signals.EBSDMasterPattern(np.zeros((11, 11)))
         mp_c2.projection = "lambert"
         mp_c2.phase = Phase("!Ni", 220)
         with pytest.raises(AttributeError):
             mp_c2.get_patterns(r2, self.detector, 5)
 
-        mp_d = EBSDMasterPattern(np.zeros((2, 11, 11)))
+        mp_d = kp.signals.EBSDMasterPattern(np.zeros((2, 11, 11)))
         with pytest.raises(NotImplementedError):
             mp_d.get_patterns(r2, self.detector, 5)
 
-        mp_e = EBSDMasterPattern(np.zeros((10, 11, 11)))
+        mp_e = kp.signals.EBSDMasterPattern(np.zeros((10, 11, 11)))
         mp_e.axes_manager[0].name = "energy"
         mp_e.projection = "lambert"
         mp_e.phase = Phase("!Ni", 220)
@@ -270,7 +272,7 @@ class TestSimulatedPatternDictionary:
 
         # More than one Projection center is currently not supported so
         # it should fail
-        d2 = EBSDDetector(
+        d2 = kp.detectors.EBSDDetector(
             shape=(10, 10),
             px_size=50,
             pc=((0, 0, 15000), (0, 0, 15000)),
@@ -307,7 +309,7 @@ class TestSimulatedPatternDictionary:
     def test_simulated_patterns_xmap_detector(self):
         mp = nickel_ebsd_master_pattern_small(projection="lambert")
         r = Rotation.from_euler([[0, 0, 0], [0, np.pi / 2, 0]])
-        detector = EBSDDetector(
+        detector = kp.detectors.EBSDDetector(
             shape=(60, 60),
             pc=[0.5, 0.5, 0.5],
             sample_tilt=70,
@@ -327,13 +329,13 @@ class TestSimulatedPatternDictionary:
     def test_get_patterns_navigation_shape(self, nav_shape):
         mp = nickel_ebsd_master_pattern_small(projection="lambert")
         r = Rotation(np.random.uniform(low=0, high=1, size=nav_shape + (4,)))
-        detector = EBSDDetector(shape=(60, 60))
+        detector = kp.detectors.EBSDDetector(shape=(60, 60))
         sim = mp.get_patterns(rotations=r, detector=detector, energy=20)
         assert sim.axes_manager.navigation_shape[::-1] == nav_shape
 
     def test_get_patterns_navigation_shape_raises(self):
         mp = nickel_ebsd_master_pattern_small(projection="lambert")
         r = Rotation(np.random.uniform(low=0, high=1, size=(1, 2, 3, 4)))
-        detector = EBSDDetector(shape=(60, 60))
+        detector = kp.detectors.EBSDDetector(shape=(60, 60))
         with pytest.raises(ValueError, match="The rotations object can only"):
             _ = mp.get_patterns(rotations=r, detector=detector, energy=20)

--- a/kikuchipy/signals/util/_crystal_map.py
+++ b/kikuchipy/signals/util/_crystal_map.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for combining a crystallographic map,
+:class:`orix.crystal_map.CrystalMap` with an EBSD signal,
+:class:`kikuchipy.signals.EBSD`.
+"""
+
+import warnings
+
+from hyperspy.axes import AxesManager
+from orix.crystal_map import CrystalMap
+
+
+def crystal_map_is_compatible_with_signal(
+    xmap: CrystalMap, axes_manager: AxesManager, raise_if_false: bool = False
+) -> bool:
+    nav_axes = axes_manager.navigation_axes[::-1]
+    nav_shape = tuple([a.size for a in nav_axes])
+    nav_scale = tuple([a.scale for a in nav_axes])
+    compatible = None
+    try:
+        xmap_scale = tuple([xmap._step_sizes[a.name] for a in nav_axes])
+    except KeyError:
+        warnings.warn(
+            "The signal navigation axes must be named 'x' and/or 'y' in order "
+            "to compare the signal navigation scale to the CrystalMap step "
+            "sizes 'dx' and 'dy' (see `EBSD.axes_manager`)"
+        )
+        xmap_scale = (None,) * len(nav_axes)
+        compatible = False
+    compatible = xmap.shape == nav_shape and xmap_scale == nav_scale
+    if not compatible and raise_if_false:
+        raise AttributeError(
+            f"The crystal map shape {xmap.shape} and step sizes {xmap_scale} "
+            f"aren't compatible with the signal navigation shape {nav_shape} "
+            f"and step sizes {nav_scale} (see `EBSD.axes_manager`)"
+        )
+    else:
+        return compatible


### PR DESCRIPTION
#### Description of the change
- `Signal2D.deepcopy()` is overwritten for the `EBSD` and `EBSDMasterPattern` signals to carry over the following custom properties:
    - EBSD: `xmap` and `detector`
    - EBSDMasterPattern: `phase` (orix.crystal_map.Phase), `projection` (str), and `hemisphere`
- Make the `EBSD.xmap` property settable. A private function located in `kikuchipy.signals.util._crystal_map.py` is added to ensure that the crystal map and EBSD signal has the same navigation shape and navigation step sizes (e.g. 1 um). This function should be used whenever the `EBSD.xmap` property is used, ensuring that a reasonable error message is raised if the map and signal aren't compatible.

Close #345.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()
>>> s.xmap
<CrystalMap repr>
>>> s.detector
<EBSDDetector repr>
>>> s2 = s.deepcopy()
>>> np.may_share_memory(s.xmap.rotations.data, s2.xmap.rotations.data)
False
>>> np.may_share_memory(s.detector.pc, s2.detector.pc)
False
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
