### PR TITLE
Restrict versions of dependencies dask and orix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2.18 diffsims==0.4 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.5.1 scikit-image==0.16.2
+            DEPENDENCIES: dask==2.18 diffsims==0.4.0 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.6.0 scikit-image==0.16.2
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/kikuchipy/projections/gnomonic_projection.py
+++ b/kikuchipy/projections/gnomonic_projection.py
@@ -51,23 +51,23 @@ class GnomonicProjection(SphericalProjection):
         >>> v = np.random.random_sample(30).reshape((10, 3))
         >>> xy = GnomonicProjection.project(v)
         """
-        polar = super().project(v)
-        theta, phi = polar[..., 0], polar[..., 1]
+        polar_coordinates = super().project(v)
+        polar, azimuth = polar_coordinates[..., 0], polar_coordinates[..., 1]
 
         # Map to upper hemisphere
         if isinstance(v, Vector3d):
             is_upper = v.z > 0
         else:
             is_upper = v[..., 2] > 0
-        theta[is_upper] -= np.pi
+        polar[is_upper] -= np.pi
 
         # Formula for gnomonic projection
-        r = np.tan(theta)
+        r = np.tan(polar)
 
         # Compute coordinates
         gnomonic = np.zeros(r.shape + (2,), dtype=r.dtype)
-        gnomonic[..., 0] = np.cos(phi) * r
-        gnomonic[..., 1] = np.sin(phi) * r
+        gnomonic[..., 0] = np.cos(azimuth) * r
+        gnomonic[..., 1] = np.sin(azimuth) * r
 
         return gnomonic
 
@@ -98,6 +98,6 @@ class GnomonicProjection(SphericalProjection):
         >>> xyz = GnomonicProjection.iproject(xy_g)
         """
         x, y = xy[..., 0], xy[..., 1]
-        theta = np.arctan(np.sqrt(x ** 2 + y ** 2))
-        phi = np.arctan2(y, x)
-        return Vector3d.from_polar(theta=theta, phi=phi)
+        polar = np.arctan(np.sqrt(x ** 2 + y ** 2))
+        azimuth = np.arctan2(y, x)
+        return Vector3d.from_polar(polar=polar, azimuth=azimuth)

--- a/kikuchipy/projections/hesse_normal_form.py
+++ b/kikuchipy/projections/hesse_normal_form.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 import numpy as np
 
-from kikuchipy.projections.spherical_projection import get_theta
+from kikuchipy.projections.spherical_projection import get_polar
 
 
 class HesseNormalForm:
@@ -40,7 +40,7 @@ class HesseNormalForm:
         Parameters
         ----------
         polar
-            Spherical coordinates theta, phi, r.
+            The polar, azimuthal and radial spherical coordinates.
         radius
             Hesse radius. Default is 10.
 
@@ -74,9 +74,9 @@ class HesseNormalForm:
         hesse
             Hesse normal form coordinates distance and angle.
         """
-        theta = get_theta(cartesian)
-        hesse = np.zeros((theta.size, 2))
-        hesse_distance = np.tan(0.5 * np.pi - theta)
+        polar = get_polar(cartesian)
+        hesse = np.zeros((polar.size, 2))
+        hesse_distance = np.tan(0.5 * np.pi - polar)
         hesse[..., 0] = hesse_distance
         hesse[..., 1] = np.arccos(hesse_distance / radius)
         return hesse

--- a/kikuchipy/projections/spherical_projection.py
+++ b/kikuchipy/projections/spherical_projection.py
@@ -69,10 +69,10 @@ class SphericalProjection:
         >>> np.allclose(np.arctan2(v[:, 1], v[:, 0]), phi)
         True
         """
-        return _get_polar(v)
+        return _get_polar_coordinates(v)
 
 
-def _get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+def _get_polar_coordinates(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
     if isinstance(v, Vector3d):
         x, y, z = v.xyz
     else:
@@ -80,16 +80,16 @@ def _get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
     polar = np.zeros(x.shape + (3,), dtype=x.dtype)
     polar[..., 1] = np.where(
         np.arctan2(y, x) < 0, np.arctan2(y, x) + 2 * np.pi, np.arctan2(y, x)
-    )  # Phi
+    )  # Azimuth
     polar[..., 2] = np.sqrt(x ** 2 + y ** 2 + z ** 2)  # r
-    polar[..., 0] = np.arccos(z / polar[..., 2])  # Theta
+    polar[..., 0] = np.arccos(z / polar[..., 2])  # Polar
 
     return polar
 
 
-def get_theta(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get spherical coordinate theta from cartesian according to the
-    ISO 31-11 standard [SphericalWolfram]_.
+def get_polar(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+    """Get the polar spherical coordinate from cartesian according to
+    the ISO 31-11 standard [SphericalWolfram]_.
 
     Parameters
     ----------
@@ -98,8 +98,8 @@ def get_theta(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
     Returns
     -------
-    theta
-        Spherical coordinate theta.
+    polar
+        Polar spherical coordinate.
     """
     if isinstance(v, Vector3d):
         x, y, z = v.xyz
@@ -109,9 +109,9 @@ def get_theta(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
     return np.arccos(z / r)
 
 
-def get_phi(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get spherical coordinate phi from cartesian according to the ISO
-    31-11 standard [SphericalWolfram]_.
+def get_azimuth(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+    """Get the azimuthal spherical coordinate from cartesian according
+    to the ISO 31-11 standard [SphericalWolfram]_.
 
     Parameters
     ----------
@@ -120,20 +120,20 @@ def get_phi(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
     Returns
     -------
-    phi
-        Spherical coordinate phi.
+    azimuth
+        Azimuthal spherical coordinate.
     """
     if isinstance(v, Vector3d):
         x, y, _ = v.xyz
     else:
         x, y = v[..., 0], v[..., 1]
-    phi = np.arctan2(y, x)
-    phi += (phi < 0) * 2 * np.pi
-    return phi
+    azimuth = np.arctan2(y, x)
+    azimuth += (azimuth < 0) * 2 * np.pi
+    return azimuth
 
 
-def get_r(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
-    """Get radial spherical coordinate from cartesian coordinates.
+def get_radial(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
+    """Get the radial spherical coordinate from cartesian coordinates.
 
     Parameters
     ----------
@@ -142,8 +142,8 @@ def get_r(v: Union[Vector3d, np.ndarray]) -> np.ndarray:
 
     Returns
     -------
-    phi
-        Spherical coordinate phi.
+    radial
+        Radial spherical coordinate.
     """
     if isinstance(v, Vector3d):
         x, y, z = v.xyz

--- a/kikuchipy/projections/tests/test_hesse_normal_form.py
+++ b/kikuchipy/projections/tests/test_hesse_normal_form.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 from kikuchipy.projections.hesse_normal_form import HesseNormalForm
-from kikuchipy.projections.spherical_projection import _get_polar
+from kikuchipy.projections.spherical_projection import _get_polar_coordinates
 
 
 class TestHesseNormalForm:
@@ -64,7 +64,7 @@ class TestHesseNormalForm:
                 [0.7605, 0.0647, 0.9848],
             ]
         )
-        polar = _get_polar(v)
+        polar = _get_polar_coordinates(v)
         assert np.allclose(
             HesseNormalForm.project_polar(polar, radius=radius),
             desired_result,

--- a/kikuchipy/projections/tests/test_spherical_projection.py
+++ b/kikuchipy/projections/tests/test_spherical_projection.py
@@ -21,9 +21,9 @@ from orix.vector import Vector3d
 
 from kikuchipy.projections.spherical_projection import (
     SphericalProjection,
-    get_theta,
-    get_phi,
-    get_r,
+    get_polar,
+    get_azimuth,
+    get_radial,
 )
 
 
@@ -35,18 +35,18 @@ def test_spherical_projection():
 
     # Vector3d
     polar = SphericalProjection.project(v_arr)
-    assert np.allclose(polar[..., 0], v.theta.data)
-    assert np.allclose(polar[..., 1], v.phi.data)
-    assert np.allclose(polar[..., 2], v.r.data)
-    assert np.allclose(get_theta(v), v.theta.data)
-    assert np.allclose(get_phi(v), v.phi.data)
-    assert np.allclose(get_r(v), v.r.data)
+    assert np.allclose(polar[..., 0], v.polar.data)
+    assert np.allclose(polar[..., 1], v.azimuth.data)
+    assert np.allclose(polar[..., 2], v.radial.data)
+    assert np.allclose(get_polar(v), v.polar.data)
+    assert np.allclose(get_azimuth(v), v.azimuth.data)
+    assert np.allclose(get_radial(v), v.radial.data)
 
     # NumPy array
     polar2 = SphericalProjection.project(v)
-    assert np.allclose(polar2[..., 0], v.theta.data)
-    assert np.allclose(polar2[..., 1], v.phi.data)
-    assert np.allclose(polar2[..., 2], v.r.data)
-    assert np.allclose(get_theta(v_arr), v.theta.data)
-    assert np.allclose(get_phi(v_arr), v.phi.data)
-    assert np.allclose(get_r(v_arr), v.r.data)
+    assert np.allclose(polar2[..., 0], v.polar.data)
+    assert np.allclose(polar2[..., 1], v.azimuth.data)
+    assert np.allclose(polar2[..., 2], v.radial.data)
+    assert np.allclose(get_polar(v_arr), v.polar.data)
+    assert np.allclose(get_azimuth(v_arr), v.azimuth.data)
+    assert np.allclose(get_radial(v_arr), v.radial.data)

--- a/kikuchipy/simulations/features.py
+++ b/kikuchipy/simulations/features.py
@@ -173,7 +173,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         """Distance from the PC (origin) per band, i.e. the right-angle
         component of the distance to the pole.
         """
-        return np.tan(0.5 * np.pi - self.hkl_detector.theta.data)
+        return np.tan(0.5 * np.pi - self.hkl_detector.polar.data)
 
     @property
     def within_gnomonic_radius(self) -> np.ndarray:
@@ -209,11 +209,11 @@ class KikuchiBand(ReciprocalLatticePoint):
         to NaN.
         """
         # Get alpha1 and alpha2 angles (NaN for bands outside gnomonic radius)
-        phi = self.hkl_detector.phi.data
+        azimuth = self.hkl_detector.azimuth.data
         hesse_alpha = self.hesse_alpha
         plane_trace = np.zeros(self.navigation_shape + (self.size, 4))
-        alpha1 = phi - np.pi + hesse_alpha
-        alpha2 = phi - np.pi - hesse_alpha
+        alpha1 = azimuth - np.pi + hesse_alpha
+        alpha2 = azimuth - np.pi - hesse_alpha
 
         # Calculate start and end points for the plane traces
         plane_trace[..., 0] = np.cos(alpha1)
@@ -227,11 +227,11 @@ class KikuchiBand(ReciprocalLatticePoint):
 
     @property
     def hesse_line_x(self) -> np.ndarray:
-        return -self.hesse_distance * np.cos(self.hkl_detector.phi.data)
+        return -self.hesse_distance * np.cos(self.hkl_detector.azimuth.data)
 
     @property
     def hesse_line_y(self) -> np.ndarray:
-        return -self.hesse_distance * np.sin(self.hkl_detector.phi.data)
+        return -self.hesse_distance * np.sin(self.hkl_detector.azimuth.data)
 
     def __getitem__(self, key):
         """Get a deepcopy subset of the KikuchiBand object.
@@ -240,7 +240,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         slicing. As an example, consider a 2 x 3 map with 4 bands. Three
         data shapes are considered:
         * navigation shape (2, 3) (gnomonic_radius)
-        * band shape (4,) (hkl, structure_factor, theta)
+        * band shape (4,) (hkl, structure_factor, polar)
         * full shape (2, 3, 4) (hkl_detector, in_pattern)
         """
         # These are overwritten as the input key length is investigated
@@ -464,7 +464,7 @@ class ZoneAxis(ReciprocalLatticePoint):
         slicing. As an example, consider a 2 x 3 map with 4 zone axes.
         Three data shapes are considered:
         * navigation shape (2, 3) (gnomonic_radius)
-        * zone axes shape (4,) (hkl, structure_factor, theta)
+        * zone axes shape (4,) (hkl, structure_factor, polar)
         * full shape (2, 3, 4) (uvw_detector, in_pattern)
         """
         # These are overwritten as the input key length is investigated

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "matplotlib >= 3.3",
         "numpy >= 1.19",
         "numba >= 0.48",
-        "orix >= 0.5.1",
+        "orix >= 0.6.0",
         "pooch >= 0.13",
         "psutil",
         "tqdm >= 0.5.2",

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,9 @@ setup(
     # Dependencies
     extras_require=extra_feature_requirements,
     install_requires=[
-        "dask[array] >= 2.18",
+        # Restrict newest dask version until
+        # https://github.com/dask/dask/issues/7583 is resolved
+        "dask[array] >= 2.18, <= 2021.03.1",
         "diffsims >= 0.4",
         "hyperspy >= 1.5.2",
         "h5py >= 2.10",


### PR DESCRIPTION
#### Description of the change
* Restrict newest version of dask==2021.03.1 because #359. Restriction will be removed when the dask-issue referenced in that issue is fixed.
* Restrict oldest version of orix==0.6.0 because of `Vector3d`'s spherical coordinate property names have changed (I did this...). 

Will make a v0.3.4 patch release of kikuchipy with these restrictions.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
