### PR TITLE
Pass parameters required by later SciPy versions in tests of kikuchipy.filters.Window()

### DIFF
--- a/kikuchipy/filters/tests/test_fft_barnes.py
+++ b/kikuchipy/filters/tests/test_fft_barnes.py
@@ -25,7 +25,8 @@ from kikuchipy.filters.window import Window
 
 class TestBarnesFFTFilter:
     @pytest.mark.parametrize(
-        "shape, expected_offset", [((10, 10), (5, 5)), ((17, 31), (8, 15))],
+        "shape, expected_offset",
+        [((10, 10), (5, 5)), ((17, 31), (8, 15))],
     )
     def test_offset_before_fft(self, shape, expected_offset):
         offset = barnes._offset_before_fft(shape)
@@ -36,7 +37,8 @@ class TestBarnesFFTFilter:
         assert np.issubdtype(type(offset[0]), np.signedinteger)
 
     @pytest.mark.parametrize(
-        "shape, expected_offset", [((10, 10), (4, 4)), ((17, 31), (8, 15))],
+        "shape, expected_offset",
+        [((10, 10), (4, 4)), ((17, 31), (8, 15))],
     )
     def test_offset_after_ifft(self, shape, expected_offset):
         offset = barnes._offset_after_ifft(shape)
@@ -59,7 +61,8 @@ class TestBarnesFFTFilter:
         w = Window("gaussian", shape=(21, 23), std=5)
 
         fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape, window=w,
+            image_shape=p.shape,
+            window=w,
         )
         p_padded = barnes._pad_image(
             image=p,
@@ -75,7 +78,7 @@ class TestBarnesFFTFilter:
     def test_pad_window(self):
         window_shape = (5, 5)
         ky, kx = window_shape
-        w = Window("gaussian", shape=window_shape)
+        w = Window("gaussian", shape=window_shape, std=1)
         fft_shape = (10, 10)
         w_padded = barnes._pad_window(window=w, fft_shape=fft_shape)
 
@@ -83,7 +86,7 @@ class TestBarnesFFTFilter:
         assert np.allclose(np.sum(w_padded[:ky, :kx]), np.sum(w), atol=1e-5)
 
     def test_pad_window_raises(self):
-        w = Window("gaussian", shape=(5, 5))
+        w = Window("gaussian", shape=(5, 5), std=1)
         with pytest.raises(ValueError, match="could not broadcast input array"):
             _ = barnes._pad_window(window=w, fft_shape=(4, 4))
 
@@ -92,7 +95,8 @@ class TestBarnesFFTFilter:
         w = Window("gaussian", shape=(10, 10), std=5)
 
         fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape, window=w,
+            image_shape=p.shape,
+            window=w,
         )
 
         assert isinstance(fft_shape, tuple)
@@ -113,7 +117,8 @@ class TestBarnesFFTFilter:
         w = Window("gaussian", shape=(10, 10), std=5)
 
         fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape, window=w,
+            image_shape=p.shape,
+            window=w,
         )
 
         p_filtered = barnes._fft_filter(

--- a/kikuchipy/filters/tests/test_fft_barnes.py
+++ b/kikuchipy/filters/tests/test_fft_barnes.py
@@ -25,8 +25,7 @@ from kikuchipy.filters.window import Window
 
 class TestBarnesFFTFilter:
     @pytest.mark.parametrize(
-        "shape, expected_offset",
-        [((10, 10), (5, 5)), ((17, 31), (8, 15))],
+        "shape, expected_offset", [((10, 10), (5, 5)), ((17, 31), (8, 15))]
     )
     def test_offset_before_fft(self, shape, expected_offset):
         offset = barnes._offset_before_fft(shape)
@@ -37,8 +36,7 @@ class TestBarnesFFTFilter:
         assert np.issubdtype(type(offset[0]), np.signedinteger)
 
     @pytest.mark.parametrize(
-        "shape, expected_offset",
-        [((10, 10), (4, 4)), ((17, 31), (8, 15))],
+        "shape, expected_offset", [((10, 10), (4, 4)), ((17, 31), (8, 15))]
     )
     def test_offset_after_ifft(self, shape, expected_offset):
         offset = barnes._offset_after_ifft(shape)
@@ -60,9 +58,8 @@ class TestBarnesFFTFilter:
         p = np.ones(image_shape, dtype=np.uint8)
         w = Window("gaussian", shape=(21, 23), std=5)
 
-        fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape,
-            window=w,
+        fft_shape, _, off1, _ = barnes._fft_filter_setup(
+            image_shape=p.shape, window=w
         )
         p_padded = barnes._pad_image(
             image=p,
@@ -95,8 +92,7 @@ class TestBarnesFFTFilter:
         w = Window("gaussian", shape=(10, 10), std=5)
 
         fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape,
-            window=w,
+            image_shape=p.shape, window=w
         )
 
         assert isinstance(fft_shape, tuple)
@@ -117,8 +113,7 @@ class TestBarnesFFTFilter:
         w = Window("gaussian", shape=(10, 10), std=5)
 
         fft_shape, window_rfft, off1, off2 = barnes._fft_filter_setup(
-            image_shape=p.shape,
-            window=w,
+            image_shape=p.shape, window=w
         )
 
         p_filtered = barnes._fft_filter(

--- a/kikuchipy/filters/tests/test_window.py
+++ b/kikuchipy/filters/tests/test_window.py
@@ -98,12 +98,7 @@ class TestWindow:
                 ValueError,
                 "Window <class 'list'> must be of type numpy.ndarray,",
             ),
-            (
-                "boxcar",
-                (5, -5),
-                ValueError,
-                "All window axes .* must be > 0",
-            ),
+            ("boxcar", (5, -5), ValueError, "All window axes .* must be > 0"),
             (
                 "boxcar",
                 (5, 5.1),
@@ -147,12 +142,7 @@ class TestWindow:
     def test_init_general_gaussian(self):
         window = "general_gaussian"
         shape = (5, 5)
-        w = Window(
-            window=window,
-            shape=shape,
-            p=0.5,
-            std=2,
-        )
+        w = Window(window=window, shape=shape, p=0.5, std=2)
         assert w.is_valid()
         np.testing.assert_array_almost_equal(w.data, GENERAL_GAUSS55_PWR05_STD2)
         assert w.name == window
@@ -253,20 +243,8 @@ class TestWindow:
     @pytest.mark.parametrize(
         "window, answer_coeff, cmap, textcolors, cmap_label",
         [
-            (
-                "circular",
-                CIRCULAR33,
-                "viridis",
-                ["k", "w"],
-                "Coefficient",
-            ),
-            (
-                "rectangular",
-                RECTANGULAR33,
-                "inferno",
-                ["b", "r"],
-                "Coeff.",
-            ),
+            ("circular", CIRCULAR33, "viridis", ["k", "w"], "Coefficient"),
+            ("rectangular", RECTANGULAR33, "inferno", ["b", "r"], "Coeff."),
         ],
     )
     def test_plot(
@@ -417,10 +395,7 @@ class TestWindow:
 
         assert np.allclose(w, answer, atol=1e-4)
 
-    @pytest.mark.parametrize(
-        "Nx, answer",
-        [(96, 61.1182), (801, 509.9328)],
-    )
+    @pytest.mark.parametrize("Nx, answer", [(96, 61.1182), (801, 509.9328)])
     def test_modified_hann_direct_sum(self, Nx, answer):
         # py_func ensures coverage for a Numba decorated function
         w = modified_hann.py_func(Nx)
@@ -449,11 +424,7 @@ class TestWindow:
                     ]
                 ),
             ),
-            (
-                (5,),
-                (2,),
-                np.array([2, 1, 0, 1, 2]),
-            ),
+            ((5,), (2,), np.array([2, 1, 0, 1, 2])),
             (
                 (4, 4),
                 (2, 3),
@@ -504,10 +475,7 @@ class TestWindow:
         [
             ((3, 3), (1, 1)),
             ((3,), (1,)),
-            (
-                (7, 5),
-                (3, 2),
-            ),
+            ((7, 5), (3, 2)),
             ((6, 5), (2, 2)),
             ((5, 7), (2, 3)),
         ],

--- a/kikuchipy/filters/tests/test_window.py
+++ b/kikuchipy/filters/tests/test_window.py
@@ -98,7 +98,12 @@ class TestWindow:
                 ValueError,
                 "Window <class 'list'> must be of type numpy.ndarray,",
             ),
-            ("boxcar", (5, -5), ValueError, "All window axes .* must be > 0",),
+            (
+                "boxcar",
+                (5, -5),
+                ValueError,
+                "All window axes .* must be > 0",
+            ),
             (
                 "boxcar",
                 (5, 5.1),
@@ -142,7 +147,12 @@ class TestWindow:
     def test_init_general_gaussian(self):
         window = "general_gaussian"
         shape = (5, 5)
-        w = Window(window=window, shape=shape, p=0.5, std=2,)
+        w = Window(
+            window=window,
+            shape=shape,
+            p=0.5,
+            std=2,
+        )
         assert w.is_valid()
         np.testing.assert_array_almost_equal(w.data, GENERAL_GAUSS55_PWR05_STD2)
         assert w.name == window
@@ -196,7 +206,10 @@ class TestWindow:
     def test_make_circular(
         self, window, shape, answer_coeff, answer_circular, answer_type
     ):
-        k = Window(window=window, shape=shape)
+        kwargs = dict()
+        if window == "gaussian":
+            kwargs["std"] = 1
+        k = Window(window=window, shape=shape, **kwargs)
         k.make_circular()
 
         np.testing.assert_array_almost_equal(k, answer_coeff)
@@ -240,8 +253,20 @@ class TestWindow:
     @pytest.mark.parametrize(
         "window, answer_coeff, cmap, textcolors, cmap_label",
         [
-            ("circular", CIRCULAR33, "viridis", ["k", "w"], "Coefficient",),
-            ("rectangular", RECTANGULAR33, "inferno", ["b", "r"], "Coeff.",),
+            (
+                "circular",
+                CIRCULAR33,
+                "viridis",
+                ["k", "w"],
+                "Coefficient",
+            ),
+            (
+                "rectangular",
+                RECTANGULAR33,
+                "inferno",
+                ["b", "r"],
+                "Coeff.",
+            ),
         ],
     )
     def test_plot(
@@ -393,7 +418,8 @@ class TestWindow:
         assert np.allclose(w, answer, atol=1e-4)
 
     @pytest.mark.parametrize(
-        "Nx, answer", [(96, 61.1182), (801, 509.9328)],
+        "Nx, answer",
+        [(96, 61.1182), (801, 509.9328)],
     )
     def test_modified_hann_direct_sum(self, Nx, answer):
         # py_func ensures coverage for a Numba decorated function
@@ -423,7 +449,11 @@ class TestWindow:
                     ]
                 ),
             ),
-            ((5,), (2,), np.array([2, 1, 0, 1, 2]),),
+            (
+                (5,),
+                (2,),
+                np.array([2, 1, 0, 1, 2]),
+            ),
             (
                 (4, 4),
                 (2, 3),
@@ -474,7 +504,10 @@ class TestWindow:
         [
             ((3, 3), (1, 1)),
             ((3,), (1,)),
-            ((7, 5), (3, 2),),
+            (
+                (7, 5),
+                (3, 2),
+            ),
             ((6, 5), (2, 2)),
             ((5, 7), (2, 3)),
         ],

--- a/kikuchipy/filters/window.py
+++ b/kikuchipy/filters/window.py
@@ -17,15 +17,15 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from copy import copy
-from typing import List, Tuple, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 from dask.array import Array
-from numba import njit
-import numpy as np
 from matplotlib.figure import Figure
 from matplotlib.image import AxesImage
 from matplotlib.colorbar import Colorbar
 from matplotlib.pyplot import subplots
+from numba import njit
+import numpy as np
 from scipy.signal.windows import get_window
 
 
@@ -58,8 +58,7 @@ class Window(np.ndarray):
         `window`. This can be either 1D or 2D, and can be asymmetrical.
         Default is (3, 3).
     **kwargs
-        Keyword arguments passed to the window type. If none are
-        passed, the default values of that particular window are used.
+        Required keyword arguments passed to the window type.
 
     Examples
     --------


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Add Gaussian window standard deviation parameter to `kikuchipy.filters.Window()` initialization in tests, which is required by later versions of SciPy. Close https://github.com/pyxem/kikuchipy/issues/367.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
As argued in https://github.com/pyxem/kikuchipy/issues/367, I think it is OK to require the user to provide the keyword, as the error message raised by SciPy is quite understandable

```python
>>> import kikuchipy as kp
>>> w = kp.filters.Window(window="gaussian")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/hakon/kode/kikuchipy/kikuchipy/filters/window.py", line 179, in __new__
    data = window_func(**window_kwargs)
  File "/home/hakon/miniconda3/envs/kp-dev-latest/lib/python3.9/site-packages/scipy/signal/windows/windows.py", line 2162, in get_window
    return winfunc(*params, sym=sym)
TypeError: gaussian() missing 1 required positional argument: 'std'
>>> w = kp.filters.Window(window="gaussian", std=1)
Window (3, 3) gaussian
[[0.3679 0.6065 0.3679]
 [0.6065 1.     0.6065]
 [0.3679 0.6065 0.3679]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
