### PR TITLE
Rename EBSD dictionary indexing method to dictionary_indexing()

### DIFF
--- a/doc/_static/data/pattern_match_ni_large.py
+++ b/doc/_static/data/pattern_match_ni_large.py
@@ -1,5 +1,6 @@
-import kikuchipy as kp
 from orix import sampling, io
+
+import kikuchipy as kp
 
 
 s_large = kp.data.nickel_ebsd_large()
@@ -25,6 +26,6 @@ sim = mp.get_patterns(
     rotations=r, detector=detector, energy=20, dtype_out=np.uint8, compute=True
 )
 
-xmap = s_large.match_patterns(sim, keep_n=1, n_slices=10, metric="ncc")
+xmap = s_large.dictionary_indexing(sim, keep_n=1, n_slices=10, metric="ncc")
 
 io.save("/home/hakon/ni_large.h5", xmap)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -40,6 +40,12 @@ Changed
   colorbar only if desired.
   (`#375 <https://github.com/pyxem/kikuchipy/pull/375>`_)
 
+Deprecated
+----------
+- The EBSD.match_patterns() method changes name to EBSD.dictionary_indexing(),
+  and will be removed in v0.5.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+
 Fixed
 -----
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -42,8 +42,8 @@ Changed
 
 Deprecated
 ----------
-- The EBSD.match_patterns() method changes name to EBSD.dictionary_indexing(),
-  and will be removed in v0.5.
+- Rename the EBSD.match_patterns() method to EBSD.dictionary_indexing().
+  match_patterns() will be removed in v0.5.
   (`#376 <https://github.com/pyxem/kikuchipy/pull/376>`_)
 
 Fixed

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -44,7 +44,7 @@ Deprecated
 ----------
 - The EBSD.match_patterns() method changes name to EBSD.dictionary_indexing(),
   and will be removed in v0.5.
-  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+  (`#376 <https://github.com/pyxem/kikuchipy/pull/376>`_)
 
 Fixed
 -----

--- a/doc/pattern_matching.ipynb
+++ b/doc/pattern_matching.ipynb
@@ -305,9 +305,9 @@
    "metadata": {},
    "source": [
     "Finally, let's use the\n",
-    "[match_patterns()](reference.rst#kikuchipy.signals.EBSD.match_patterns) method\n",
-    "to match the simulated patterns to our nine experimental patterns, using the\n",
-    "[zero-mean normalized cross correlation (NCC)](reference.rst#kikuchipy.indexing.similarity_metrics.ncc)\n",
+    "[dictionary_indexing()](reference.rst#kikuchipy.signals.EBSD.dictionary_indexing)\n",
+    "method to match the simulated patterns to our nine experimental patterns, using\n",
+    "the [zero-mean normalized cross correlation (NCC)](reference.rst#kikuchipy.indexing.similarity_metrics.ncc)\n",
     "coefficient $r$\n",
     "<cite data-cite=\"gonzalez2017digital\">Gonzalez & Woods (2017)</cite>, which is\n",
     "the default similarity metric. Let's keep the 10 best matching orientations. A\n",
@@ -324,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xmap = s.match_patterns(sim, n_slices=10, keep_n=10)\n",
+    "xmap = s.dictionary_indexing(sim, n_slices=10, keep_n=10)\n",
     "xmap"
    ]
   },

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -495,7 +495,7 @@ from HyperSpy.
 .. autosummary::
     adaptive_histogram_equalization
     average_neighbour_patterns
-    match_patterns
+    dictionary_indexing
     fft_filter
     get_average_neighbour_dot_product_map
     get_decomposition_model

--- a/kikuchipy/_util/__init__.py
+++ b/kikuchipy/_util/__init__.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Helper functions and classes for managing kikuchipy.
+
+This module and documentation is only relevant for kikuchioy developers,
+not for users.
+
+.. warning:
+    This module and its submodules are for internal use only.  Do not
+    use them in your own code. We may change the API at any time with no
+    warning.
+"""
+
+from kikuchipy._util._util import deprecated
+
+
+__all__ = ["deprecated"]

--- a/kikuchipy/_util/_util.py
+++ b/kikuchipy/_util/_util.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Helper functions and classes for managing kikuchipy.
+
+This module and documentation is only relevant for kikuchipy developers,
+not for users.
+
+.. warning:
+    This module and its submodules are for internal use only.  Do not
+    use them in your own code. We may change the API at any time with no
+    warning.
+"""
+
+import functools
+import inspect
+import warnings
+
+import numpy as np
+
+
+class deprecated:
+    """Decorator to mark deprecated functions with an informative
+    warning.
+
+    Adapted from
+    `scikit-image
+    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L297>`_
+    and `matplotlib
+    <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py#L122>`_.
+    """
+
+    def __init__(self, since, message=None, alternative=None, removal=None):
+        """Visible deprecation warning.
+
+        Parameters
+        ----------
+        since : str
+            The release at which this API became deprecated.
+        message : str, optional
+            The deprecation message.
+        alternative : str, optional
+            An alternative API that the user may use in place of the
+            deprecated API.
+        removal : str, optional
+            The expected removal version.
+        """
+        self.since = since
+        self.message = message
+        self.alternative = alternative
+        self.removal = removal
+
+    def __call__(self, func):
+        # Wrap function to raise warning when called, and add warning to
+        # docstring
+        if self.alternative is not None:
+            alt_msg = f" Use `{self.alternative}()` instead."
+        else:
+            alt_msg = ""
+        if self.removal is not None:
+            rm_msg = f" and will be removed in version {self.removal}"
+        else:
+            rm_msg = ""
+        msg = f"Function `{func.__name__}()` is deprecated{rm_msg}.{alt_msg}"
+
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            warnings.simplefilter(
+                action="always", category=np.VisibleDeprecationWarning
+            )
+            func_code = func.__code__
+            warnings.warn_explicit(
+                message=msg,
+                category=np.VisibleDeprecationWarning,
+                filename=func_code.co_filename,
+                lineno=func_code.co_firstlineno + 1,
+            )
+            return func(*args, **kwargs)
+
+        # Modify docstring to display deprecation warning
+        old_doc = inspect.cleandoc(func.__doc__ or "").strip("\n")
+        notes_header = "\nNotes\n-----"
+        new_doc = (
+            f"[*Deprecated*] {old_doc}\n"
+            f"{notes_header if notes_header not in old_doc else ''}\n"
+            f".. deprecated:: {self.since}\n"
+            f"   {msg.strip()}"  # Matplotlib uses three spaces
+        )
+        if not old_doc:
+            new_doc += r"\ "
+        wrapped.__doc__ = new_doc
+
+        return wrapped

--- a/kikuchipy/_util/test_util.py
+++ b/kikuchipy/_util/test_util.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from kikuchipy._util import deprecated
+
+
+class TestDeprecationWarning:
+    def test_deprecation_since(self):
+        """Ensure functions decorated with the custom deprecated
+        decorator returns desired output, raises a desired warning, and
+        gets the desired additions to their docstring.
+        """
+
+        @deprecated(since=0.7, message="Hello", alternative="bar", removal=0.8)
+        def foo(n):
+            """Some docstring."""
+            return n + 1
+
+        with pytest.warns(np.VisibleDeprecationWarning) as record:
+            assert foo(4) == 5
+        desired_msg = (
+            "Function `foo()` is deprecated and will be removed in version 0.8. "
+            "Use `bar()` instead."
+        )
+        assert str(record[0].message) == desired_msg
+        assert foo.__doc__ == (
+            "[*Deprecated*] Some docstring.\n"
+            "\nNotes\n-----\n"
+            ".. deprecated:: 0.7\n"
+            f"   {desired_msg}"
+        )
+
+        @deprecated(since=1.9)
+        def foo2(n):
+            """Another docstring.
+
+            Notes
+            -----
+            Some existing notes.
+            """
+            return n + 2
+
+        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+            assert foo2(4) == 6
+        desired_msg2 = "Function `foo2()` is deprecated."
+        assert str(record2[0].message) == desired_msg2
+        assert foo2.__doc__ == (
+            "[*Deprecated*] Another docstring.\n"
+            "\nNotes\n-----\n"
+            "Some existing notes.\n\n"
+            ".. deprecated:: 1.9\n"
+            f"   {desired_msg2}"
+        )

--- a/kikuchipy/indexing/__init__.py
+++ b/kikuchipy/indexing/__init__.py
@@ -19,7 +19,7 @@
 """Tools for indexing of EBSD patterns by comparison to simulated
 patterns.
 
-The EBSD method :meth:`~kikuchipy.signals.EBSD.match_patterns` uses
+The EBSD method :meth:`~kikuchipy.signals.EBSD.dictionary_indexing` uses
 these tools for pattern matching.
 """
 

--- a/kikuchipy/indexing/similarity_metrics.py
+++ b/kikuchipy/indexing/similarity_metrics.py
@@ -52,7 +52,7 @@ def make_similarity_metric(
     equal size.
 
     This factory function wraps metric functions for use in
-    :meth:`~kikuchipy.signals.EBSD.match_patterns` (which uses
+    :meth:`~kikuchipy.signals.EBSD.dictionary_indexing` (which uses
     :class:`~kikuchipy.indexing.StaticPatternMatching`).
 
     Parameters

--- a/kikuchipy/indexing/tests/test_pattern_matching.py
+++ b/kikuchipy/indexing/tests/test_pattern_matching.py
@@ -110,9 +110,9 @@ class TestPatternMatching:
         exp = nickel_ebsd_small().data
         sim = exp.reshape((-1,) + exp.shape[-2:])
 
-        sim_idx1, scores1 = _pattern_match(exp, sim, n_slices=2)
-        sim_idx2, scores2 = _pattern_match(exp, sim, phase_name="a", n_slices=2)
-        sim_idx3, scores3 = _pattern_match(exp, sim, phase_name="", n_slices=2)
+        sim_idx1, _ = _pattern_match(exp, sim, n_slices=2)
+        sim_idx2, _ = _pattern_match(exp, sim, phase_name="a", n_slices=2)
+        sim_idx3, _ = _pattern_match(exp, sim, phase_name="", n_slices=2)
 
         assert np.allclose(sim_idx1[0], [0, 3, 6, 4, 7, 1, 8, 5, 2])
         assert np.allclose(sim_idx2[0], [0, 3, 6, 4, 7, 1, 8, 5, 2])
@@ -140,9 +140,9 @@ class TestPatternMatching:
         )
         sim = mp.get_patterns(rotations=r, detector=detector, energy=20)
 
-        xmap = s.match_patterns(sim, keep_n=1)
-        scores = xmap.scores.reshape(xmap.size,)
-        sim_idx = xmap.simulation_indices.reshape(xmap.size,)
+        xmap = s.dictionary_indexing(sim, keep_n=1)
+        scores = xmap.scores.reshape(xmap.size)
+        sim_idx = xmap.simulation_indices.reshape(xmap.size)
 
         assert np.allclose(
             scores,

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -76,6 +76,7 @@ from kikuchipy.signals.util._map_helper import (
 from kikuchipy.signals.virtual_bse_image import VirtualBSEImage
 from kikuchipy.signals._common_image import CommonImage
 from kikuchipy.detectors import EBSDDetector
+from kikuchipy._util import deprecated
 
 
 class EBSD(CommonImage, Signal2D):
@@ -141,7 +142,9 @@ class EBSD(CommonImage, Signal2D):
     @xmap.setter
     def xmap(self, value: CrystalMap):
         if crystal_map_is_compatible_with_signal(
-            value, self.axes_manager, raise_if_false=True,
+            value,
+            self.axes_manager,
+            raise_if_false=True,
         ):
             self._xmap = value
 
@@ -927,7 +930,17 @@ class EBSD(CommonImage, Signal2D):
 
         return image_quality_map
 
+    @deprecated(
+        since="0.4",
+        alternative="kikuchipy.signals.EBSD.dictionary_indexing",
+        removal="0.5",
+    )
     def match_patterns(
+        self, *args, **kwargs
+    ) -> Union[CrystalMap, List[CrystalMap]]:
+        return self.dictionary_indexing(*args, **kwargs)
+
+    def dictionary_indexing(
         self,
         simulations,
         metric: Union[str, SimilarityMetric] = "ncc",
@@ -1339,7 +1352,9 @@ class EBSD(CommonImage, Signal2D):
             averaging_window = copy.copy(window)
         else:
             averaging_window = Window(
-                window=window, shape=window_shape, **kwargs,
+                window=window,
+                shape=window_shape,
+                **kwargs,
             )
 
         # Do nothing if a window of shape (1, ) or (1, 1) is passed

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -142,9 +142,7 @@ class EBSD(CommonImage, Signal2D):
     @xmap.setter
     def xmap(self, value: CrystalMap):
         if crystal_map_is_compatible_with_signal(
-            value,
-            self.axes_manager,
-            raise_if_false=True,
+            value, self.axes_manager, raise_if_false=True
         ):
             self._xmap = value
 
@@ -1352,9 +1350,7 @@ class EBSD(CommonImage, Signal2D):
             averaging_window = copy.copy(window)
         else:
             averaging_window = Window(
-                window=window,
-                shape=window_shape,
-                **kwargs,
+                window=window, shape=window_shape, **kwargs
             )
 
         # Do nothing if a window of shape (1, ) or (1, 1) is passed

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -41,7 +41,6 @@ EMSOFT_FILE = os.path.join(DIR_PATH, "../../data/emsoft_ebsd/simulated_ebsd.h5")
 
 class TestEBSD:
     def test_init(self):
-
         # Signal shape
         array0 = np.zeros(shape=(10, 10, 10, 10))
         s0 = kp.signals.EBSD(array0)
@@ -261,7 +260,6 @@ class TestRemoveStaticBackgroundEBSD:
         """Test for expected error messages when passing an incorrect
         static background pattern to `remove_static_background().`
         """
-
         ebsd_node = kp.signals.util.metadata_nodes("ebsd")
         dummy_signal.metadata.set_item(
             ebsd_node + ".static_background", static_bg
@@ -282,11 +280,11 @@ class TestRemoveStaticBackgroundEBSD:
         dummy_signal2 = dummy_signal.deepcopy()
 
         dummy_signal.remove_static_background(
-            scale_bg=True, relative=False, static_bg=dummy_background,
+            scale_bg=True, relative=False, static_bg=dummy_background
         )
 
         dummy_signal2.remove_static_background(
-            scale_bg=False, relative=False, static_bg=dummy_background,
+            scale_bg=False, relative=False, static_bg=dummy_background
         )
 
         p1 = dummy_signal.inav[0, 0].data
@@ -302,7 +300,7 @@ class TestRemoveStaticBackgroundEBSD:
     ):
         with pytest.raises(ValueError, match="'scale_bg' must be False"):
             dummy_signal.remove_static_background(
-                relative=True, scale_bg=True, static_bg=dummy_background,
+                relative=True, scale_bg=True, static_bg=dummy_background
             )
 
     def test_non_square_patterns(self):
@@ -395,9 +393,8 @@ class TestRemoveDynamicBackgroundEBSD:
         to be made, these hard-coded answers will have to be
         recalculated for the tests to pass.
         """
-
         dummy_signal.remove_dynamic_background(
-            operation=operation, std=std, filter_domain="spatial",
+            operation=operation, std=std, filter_domain="spatial"
         )
         answer = answer.reshape((3,) * 4).astype(np.uint8)
         assert np.allclose(dummy_signal.data, answer)
@@ -465,7 +462,7 @@ class TestRemoveDynamicBackgroundEBSD:
 
         filter_domain = "frequency"
         dummy_signal.remove_dynamic_background(
-            operation=operation, std=std, filter_domain=filter_domain,
+            operation=operation, std=std, filter_domain=filter_domain
         )
 
         assert dummy_signal.data.dtype == dtype_out
@@ -529,7 +526,6 @@ class TestRescaleIntensityEBSD:
         to be made, these hard-coded answers will have to be
         recalculated for the tests to pass.
         """
-
         dummy_signal.rescale_intensity(relative=relative, dtype_out=dtype_out)
 
         assert dummy_signal.data.dtype == answer.dtype
@@ -576,14 +572,12 @@ class TestRescaleIntensityEBSD:
     def test_rescale_intensity_raises_in_range_percentiles(self, dummy_signal):
         with pytest.raises(ValueError, match="'percentiles' must be None"):
             dummy_signal.rescale_intensity(
-                in_range=(1, 254), percentiles=(1, 99),
+                in_range=(1, 254), percentiles=(1, 99)
             )
 
     def test_rescale_intensity_raises_in_range_relative(self, dummy_signal):
         with pytest.raises(ValueError, match="'in_range' must be None if "):
-            dummy_signal.rescale_intensity(
-                in_range=(1, 254), relative=True,
-            )
+            dummy_signal.rescale_intensity(in_range=(1, 254), relative=True)
 
 
 class TestAdaptiveHistogramEqualizationEBSD:
@@ -591,7 +585,6 @@ class TestAdaptiveHistogramEqualizationEBSD:
         """Test setup of equalization only. Tests of the result of the
         actual equalization are found elsewhere.
         """
-
         s = kp.load(KIKUCHIPY_FILE)
 
         # These window sizes should work without issue
@@ -675,18 +668,18 @@ class TestAverageNeighbourPatternsEBSD:
         ],
     )
     def test_average_neighbour_patterns(
-        self, dummy_signal, window, window_shape, lazy, answer, kwargs,
+        self, dummy_signal, window, window_shape, lazy, answer, kwargs
     ):
         if lazy:
             dummy_signal = dummy_signal.as_lazy()
 
         if kwargs is None:
             dummy_signal.average_neighbour_patterns(
-                window=window, window_shape=window_shape,
+                window=window, window_shape=window_shape
             )
         else:
             dummy_signal.average_neighbour_patterns(
-                window=window, window_shape=window_shape, **kwargs,
+                window=window, window_shape=window_shape, **kwargs
             )
 
         answer = answer.reshape((3, 3, 3, 3)).astype(np.uint8)
@@ -697,7 +690,7 @@ class TestAverageNeighbourPatternsEBSD:
         answer = dummy_signal.data.copy()
         with pytest.warns(UserWarning, match="A window of shape .* was "):
             dummy_signal.average_neighbour_patterns(
-                window="rectangular", window_shape=(1, 1),
+                window="rectangular", window_shape=(1, 1)
             )
         assert np.allclose(dummy_signal.data, answer)
         assert dummy_signal.data.dtype == answer.dtype
@@ -963,7 +956,7 @@ class TestGetDynamicBackgroundEBSD:
     def test_get_dynamic_background_spatial(self, dummy_signal):
         dtype_out = dummy_signal.data.dtype
         bg = dummy_signal.get_dynamic_background(
-            filter_domain="spatial", std=2, truncate=3,
+            filter_domain="spatial", std=2, truncate=3
         )
 
         assert bg.data.dtype == dtype_out
@@ -972,7 +965,7 @@ class TestGetDynamicBackgroundEBSD:
     def test_get_dynamic_background_frequency(self, dummy_signal):
         dtype_out = np.float32
         bg = dummy_signal.get_dynamic_background(
-            filter_domain="frequency", std=2, truncate=3, dtype_out=dtype_out,
+            filter_domain="frequency", std=2, truncate=3, dtype_out=dtype_out
         )
 
         assert bg.data.dtype == dtype_out
@@ -987,11 +980,9 @@ class TestGetDynamicBackgroundEBSD:
         lazy_signal = dummy_signal.as_lazy()
 
         bg = lazy_signal.get_dynamic_background()
-
         assert isinstance(bg, kp.signals.LazyEBSD)
 
         bg.compute()
-
         assert isinstance(bg, kp.signals.EBSD)
 
 
@@ -1030,7 +1021,6 @@ class TestGetImageQualityEBSD:
             dummy_signal = dummy_signal.as_lazy()
 
         iq = dummy_signal.get_image_quality(normalize=normalize)
-
         if lazy:
             iq = iq.compute()
 
@@ -1076,7 +1066,7 @@ class TestFFTFilterEBSD:
         w = kp.filters.Window(transfer_function, shape=shape, **kwargs)
 
         dummy_signal.fft_filter(
-            transfer_function=w, function_domain="frequency", shift=shift,
+            transfer_function=w, function_domain="frequency", shift=shift
         )
 
         assert isinstance(dummy_signal, kp.signals.EBSD)
@@ -1095,7 +1085,7 @@ class TestFFTFilterEBSD:
         w = np.array([[1, 0, -1], [2, 0, -2], [1, 0, -1]])
 
         dummy_signal.fft_filter(
-            transfer_function=w, function_domain="spatial", shift=False,
+            transfer_function=w, function_domain="spatial", shift=False
         )
         p2 = dummy_signal.inav[0, 0].data
         assert not np.allclose(p, p2, atol=1e-1)
@@ -1240,7 +1230,7 @@ class TestEBSDXmapProperty:
 
         # Should fail
         xmap_bad = get_single_phase_xmap(
-            nav_shape=nav_shape[::-1], step_sizes=step_sizes,
+            nav_shape=nav_shape[::-1], step_sizes=step_sizes
         )
         with pytest.raises(AttributeError, match="The crystal map shape"):
             s.xmap = xmap_bad
@@ -1275,19 +1265,26 @@ class TestEBSDDetectorProperty:
     def test_attribute_carry_over_from_deepcopy(self):
         s = kp.data.nickel_ebsd_small(lazy=True)
         s._detector = None
-        s2 = s.deepcopy()
+        _ = s.deepcopy()
 
 
-class TestPatternMatching:
-    def test_match_patterns(self, dummy_signal):
+class TestDictionaryIndexing:
+    def test_dictionary_indexing(self, dummy_signal):
         """Scores are all 1.0 for a dictionary containing all patterns
         from dummy_signal().
         """
         s_dict = kp.signals.EBSD(dummy_signal.data.reshape(-1, 3, 3))
         s_dict._xmap = CrystalMap(Rotation(np.zeros((9, 4))))
-        xmap = dummy_signal.match_patterns(s_dict)
+        xmap = dummy_signal.dictionary_indexing(s_dict)
 
         assert np.allclose(xmap.scores[:, 0], 1)
+
+    def test_match_patterns_warns(self, dummy_signal):
+        # TODO: Remove test after v0.4 is released
+        s_dict = kp.signals.EBSD(dummy_signal.data.reshape(-1, 3, 3))
+        s_dict._xmap = CrystalMap(Rotation(np.zeros((9, 4))))
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            _ = dummy_signal.match_patterns(s_dict)
 
 
 class TestAverageNeighbourDotProductMap:
@@ -1540,10 +1537,7 @@ class TestNeighbourDotProductMatrices:
         dp_matrices = s.get_neighbour_dot_product_matrices(window=window)
 
         assert np.allclose(
-            dp_matrices[1, 1],
-            desired_dp_matrices_11,
-            atol=1e-5,
-            equal_nan=True,
+            dp_matrices[1, 1], desired_dp_matrices_11, atol=1e-5, equal_nan=True
         )
 
     @pytest.mark.parametrize("dtype_out", [np.float16, np.float32, np.float64])
@@ -1579,7 +1573,7 @@ class TestNeighbourDotProductMatrices:
         dp_matrices = s.get_neighbour_dot_product_matrices(zero_mean=zero_mean)
 
         assert np.allclose(
-            dp_matrices[1, 1], desired_dp_matrices11, atol=1e-5, equal_nan=True,
+            dp_matrices[1, 1], desired_dp_matrices11, atol=1e-5, equal_nan=True
         )
 
     @pytest.mark.parametrize(
@@ -1608,7 +1602,7 @@ class TestNeighbourDotProductMatrices:
         dp_matrices = s.get_neighbour_dot_product_matrices(normalize=normalize)
 
         assert np.allclose(
-            dp_matrices[1, 1], desired_dp_matrices11, atol=1e-5, equal_nan=True,
+            dp_matrices[1, 1], desired_dp_matrices11, atol=1e-5, equal_nan=True
         )
 
     def test_dp_matrices_large(self):

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -24,7 +24,6 @@ import matplotlib
 from matplotlib.pyplot import close
 import numpy as np
 from orix.crystal_map import CrystalMap
-from orix.quaternion import Rotation
 import pytest
 from scipy.ndimage import correlate
 from skimage.exposure import rescale_intensity
@@ -1274,7 +1273,8 @@ class TestDictionaryIndexing:
         from dummy_signal().
         """
         s_dict = kp.signals.EBSD(dummy_signal.data.reshape(-1, 3, 3))
-        s_dict._xmap = CrystalMap(Rotation(np.zeros((9, 4))))
+        s_dict.axes_manager[0].name = "x"
+        s_dict.xmap = CrystalMap.empty((9,))
         xmap = dummy_signal.dictionary_indexing(s_dict)
 
         assert np.allclose(xmap.scores[:, 0], 1)
@@ -1282,7 +1282,8 @@ class TestDictionaryIndexing:
     def test_match_patterns_warns(self, dummy_signal):
         # TODO: Remove test after v0.4 is released
         s_dict = kp.signals.EBSD(dummy_signal.data.reshape(-1, 3, 3))
-        s_dict._xmap = CrystalMap(Rotation(np.zeros((9, 4))))
+        s_dict.axes_manager[0].name = "x"
+        s_dict.xmap = CrystalMap.empty((9,), step_sizes=(1,))
         with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
             _ = dummy_signal.match_patterns(s_dict)
 


### PR DESCRIPTION
#### Description of the change
* Rename `EBSD.match_patterns()` to `EBSD.dictionary_indexing()`. The methods are identical. See discussion for reasons in #355. `EBSD.match_patterns()` will be deprecated in v0.4 and removed in v0.5.
* Add `@deprecated` decorator to mark functions and methods as deprecated. The decorator is added in a private `kikuchipy._util` module, clearly marked as private, not to be used outside the package. The decorator is taken from orix, which I added there, which is inspired by similar decorators in Matplotlib and scikit-image.
* Update documentation and other code use accordingly.

Close #355.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> import kikuchipy as kp
>>> from orix.crystal_map import CrystalMap
>>> s = kp.data.nickel_ebsd_small()
>>> s2 = kp.signals.EBSD(s.data.reshape((-1, 60, 60)))
>>> s2.axes_manager[0].name = "x"
>>> s2._xmap = CrystalMap.empty((9,))
>>> s.match_patterns(s2)
[########################################] | 100% Completed |  0.1s
/home/hakon/kode/kikuchipy/kikuchipy/signals/ebsd.py:934: VisibleDeprecationWarning: Function `match_patterns()` is deprecated and will be removed in version 0.5. Use `kikuchipy.signals.EBSD.dictionary_indexing()` instead.
  since="0.4",
Phase  Orientations  Name  Space group  Point group  Proper point group     Color
    0    9 (100.0%)  None         None         None                None  tab:blue
Properties: scores, simulation_indices
Scan unit: um
>>> s.dictionary_indexing(s2)
[########################################] | 100% Completed |  0.1s
Phase  Orientations  Name  Space group  Point group  Proper point group     Color
    0    9 (100.0%)  None         None         None                None  tab:blue
Properties: scores, simulation_indices
Scan unit: um
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.