### PR TITLE
Deprecate kikuchipy.pattern.correlate module

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -42,6 +42,9 @@ Changed
 
 Deprecated
 ----------
+- The kikuchipy.pattern.correlate module will be removed in v0.5. Use
+  kikuchipy.indexing.similarity_metrics instead.
+  (`#377 <https://github.com/pyxem/kikuchipy/pull/377>`_)
 - Rename the EBSD.match_patterns() method to EBSD.dictionary_indexing().
   match_patterns() will be removed in v0.5.
   (`#376 <https://github.com/pyxem/kikuchipy/pull/376>`_)

--- a/kikuchipy/pattern/correlate.py
+++ b/kikuchipy/pattern/correlate.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+# TODO: Remove file after v0.4 is released
+
 """Compute similarities between EBSD patterns."""
 
 from typing import Union
@@ -23,7 +25,14 @@ from typing import Union
 from dask.array import Array
 import numpy as np
 
+# from kikuchipy._util import deprecated
 
+
+# @deprecated(
+#    since="0.4",
+#    alternative="kikuchipy.indexing.similarity_metrics.ncc",
+#    removal="0.5",
+# )
 def normalized_correlation_coefficient(
     pattern: Union[np.ndarray, Array],
     template: Union[np.ndarray, Array],

--- a/kikuchipy/pattern/correlate.py
+++ b/kikuchipy/pattern/correlate.py
@@ -25,14 +25,14 @@ from typing import Union
 from dask.array import Array
 import numpy as np
 
-# from kikuchipy._util import deprecated
+from kikuchipy._util import deprecated
 
 
-# @deprecated(
-#    since="0.4",
-#    alternative="kikuchipy.indexing.similarity_metrics.ncc",
-#    removal="0.5",
-# )
+@deprecated(
+    since="0.4",
+    alternative="kikuchipy.indexing.similarity_metrics.ncc",
+    removal="0.5",
+)
 def normalized_correlation_coefficient(
     pattern: Union[np.ndarray, Array],
     template: Union[np.ndarray, Array],

--- a/kikuchipy/pattern/tests/test_correlate.py
+++ b/kikuchipy/pattern/tests/test_correlate.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+# TODO: Remove file after v0.4 is released
+
 import numpy as np
 import pytest
 
@@ -30,9 +32,10 @@ class TestNormalizedCrossCorrelation:
     def test_normalised_correlation_coefficient(
         self, dummy_signal, pattern_idx, template_idx, answer
     ):
-        coefficient = normalized_correlation_coefficient(
-            pattern=dummy_signal.inav[pattern_idx].data,
-            template=dummy_signal.inav[template_idx].data,
-            zero_normalised=True,
-        )
-        assert np.allclose(coefficient, answer, atol=1e-7)
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            coefficient = normalized_correlation_coefficient(
+                pattern=dummy_signal.inav[pattern_idx].data,
+                template=dummy_signal.inav[template_idx].data,
+                zero_normalised=True,
+            )
+            assert np.allclose(coefficient, answer, atol=1e-7)


### PR DESCRIPTION
#### Description of the change
* Deprecate kikuchipy.pattern.correlate module, to be removed in v0.5. Use kikuchipy.indexing.similarity_metrics instead.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()
>>> p1 = s.inav[0, 0].data
>>> p2 = s.inav[0, 1].data
>>> print(kp.pattern.correlate.normalized_correlation_coefficient(p1, p2))
0.9974703
/home/hakon/kode/kikuchipy/kikuchipy/pattern/correlate.py:32: VisibleDeprecationWarning: Function `normalized_correlation_coefficient()` is deprecated and will be removed in version 0.5. Use `kikuchipy.indexing.similarity_metrics.ncc()` instead.
  since="0.4",
>>> print(kp.indexing.similarity_metrics.ncc(p1, p2))
0.99747044
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.