### PR TITLE
Add manifest check to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,18 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
+  # Make sure all necessary files are included in a release
+  manifest:
+    name: check manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: pip install manifix
+      - name: Check MANIFEST.in file
+        run: python setup.py manifix
+
   build-with-pip:
     name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
     runs-on: ${{ matrix.os }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,12 @@
 include kikuchipy/hyperspy_extension.yaml
 include LICENSE
 include MANIFEST.in
-include pyproject.toml
 include setup.cfg
 include README.rst
 include RELEASE.rst
 include readthedocs.yml
 include setup.py
 
-recursive-include doc Makefile make.bat *.rst *.py *.ipynb
+recursive-include doc Makefile make.bat *.rst *.py *.ipynb *.bib
 recursive-include doc/_static *.png *.jpg *.svg *.gif
 recursive-include kikuchipy/data *

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,5 +31,7 @@ known_excludes =
     .git/**
     **/*.pyc
     doc/build*
+    doc/.ipynb_checkpoints/*
+    doc/**/*.h5
     htmlcov/**
     *.code-workspace

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ extra_feature_requirements = {
 # Create a development project, including both the doc and tests projects
 extra_feature_requirements["dev"] = [
     "black",
+    "manifix",
     "pre-commit >= 1.16",
 ] + list(chain(*list(extra_feature_requirements.values())))
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Add manifest check to CI, to ensure all necessary files are included in a release (like source files and license file). The manifest is checked with the manifix package.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.