### PR TITLE
Fix row (y) coordinate array in crystal map returned from dictionary indexing

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -57,6 +57,8 @@ Deprecated
 
 Fixed
 -----
+- Row (y) coordinate array returned with the crystal map from dictionary indexing is
+  correctly sorted. (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively, `xmap` and
   `detector`, and `phase`, `hemisphere` and `projection` properties
   (`#356 <https://github.com/pyxem/kikuchipy/pull/356>`_).

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -58,7 +58,7 @@ Deprecated
 Fixed
 -----
 - Row (y) coordinate array returned with the crystal map from dictionary indexing is
-  correctly sorted. (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+  correctly sorted. (`#392 <https://github.com/pyxem/kikuchipy/pull/392>`_)
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively, `xmap` and
   `detector`, and `phase`, `hemisphere` and `projection` properties
   (`#356 <https://github.com/pyxem/kikuchipy/pull/356>`_).

--- a/kikuchipy/indexing/_static_pattern_matching.py
+++ b/kikuchipy/indexing/_static_pattern_matching.py
@@ -130,7 +130,7 @@ class StaticPatternMatching:
 
         step_sizes = tuple([i.scale for i in am.navigation_axes])
         coordinate_arrays, _ = create_coordinate_arrays(
-            shape=am.navigation_shape, step_sizes=step_sizes
+            shape=am.navigation_shape[::-1], step_sizes=step_sizes
         )
 
         n_nav_dims = am.navigation_dimension

--- a/kikuchipy/indexing/_static_pattern_matching.py
+++ b/kikuchipy/indexing/_static_pattern_matching.py
@@ -18,8 +18,7 @@
 
 from typing import Union, List
 
-import numpy as np
-from orix.crystal_map import CrystalMap
+from orix.crystal_map import CrystalMap, create_coordinate_arrays
 
 from kikuchipy.indexing import merge_crystal_maps, orientation_similarity_map
 from kikuchipy.indexing._pattern_matching import _pattern_match
@@ -55,7 +54,7 @@ class StaticPatternMatching:
         n_slices: int = 1,
         return_merged_crystal_map: bool = False,
         get_orientation_similarity_map: bool = False,
-    ) -> Union[CrystalMap, List[CrystalMap]]:
+    ) -> Union[CrystalMap, List[CrystalMap], None]:
         """Match each experimental pattern to all simulated patterns, of
         known crystal orientations in pre-computed dictionaries
         :cite:`chen2015dictionary,jackson2019dictionary`, to determine
@@ -66,9 +65,8 @@ class StaticPatternMatching:
         default, but a valid user-defined similarity metric may be used
         instead.
 
-        :class:`~orix.crystal_map.crystal_map.CrystalMap`'s for each
-        dictionary with "scores" and "simulation_indices" as properties
-        are returned.
+        :class:`~orix.crystal_map.CrystalMap`'s for each dictionary with
+        "scores" and "simulation_indices" as properties are returned.
 
         Parameters
         ----------
@@ -93,9 +91,8 @@ class StaticPatternMatching:
 
         Returns
         -------
-        xmaps : :class:`~orix.crystal_map.crystal_map.CrystalMap` or \
-                list of \
-                :class:`~orix.crystal_map.crystal_map.CrystalMap`
+        xmaps : orix.crystal_map.CrystalMap or list of \
+                orix.crystal_map.CrystalMap
             A crystal map for each dictionary loaded and one merged map
             if `return_merged_crystal_map = True`.
 
@@ -129,25 +126,28 @@ class StaticPatternMatching:
         # return the metric if it is not
         metric = _SIMILARITY_METRICS.get(metric, metric)
 
-        axes_manager = signal.axes_manager
-        spatial_arrays = _get_spatial_arrays(
-            shape=axes_manager.navigation_shape, extent=axes_manager.navigation_extent
+        am = signal.axes_manager
+
+        step_sizes = tuple([i.scale for i in am.navigation_axes])
+        coordinate_arrays, _ = create_coordinate_arrays(
+            shape=am.navigation_shape, step_sizes=step_sizes
         )
-        n_nav_dims = axes_manager.navigation_dimension
+
+        n_nav_dims = am.navigation_dimension
         if n_nav_dims == 0:
             xmap_kwargs = dict()
         elif n_nav_dims == 1:
-            scan_unit = axes_manager.navigation_axes[0].units
-            xmap_kwargs = dict(x=spatial_arrays, scan_unit=scan_unit)
+            scan_unit = am.navigation_axes[0].units
+            xmap_kwargs = dict(x=coordinate_arrays["x"], scan_unit=scan_unit)
         else:  # 2d
-            scan_unit = axes_manager.navigation_axes[0].units
+            scan_unit = am.navigation_axes[0].units
             xmap_kwargs = dict(
-                x=spatial_arrays[0], y=spatial_arrays[1], scan_unit=scan_unit
+                x=coordinate_arrays["x"], y=coordinate_arrays["y"], scan_unit=scan_unit
             )
 
         keep_n = min([keep_n] + [d.xmap.size for d in self.dictionaries])
 
-        # Naively let dask compute them seperately, should try in the
+        # Naively let dask compute them separately, should try in the
         # future combined compute for better performance
         xmaps = []
         patterns = signal.data
@@ -184,17 +184,3 @@ class StaticPatternMatching:
             xmaps = xmaps[0]
 
         return xmaps
-
-
-def _get_spatial_arrays(shape: tuple, extent: tuple) -> Union[tuple, np.ndarray]:
-    n_nav_dims = len(shape)
-    if n_nav_dims == 0:
-        return ()
-    if n_nav_dims == 1:
-        x0, x1 = extent
-        return np.linspace(x0, x1, shape[0])
-    else:
-        x0, x1, y0, y1 = extent
-        x = np.tile(np.linspace(x0, x1, shape[0]), shape[1])
-        y = np.tile(np.linspace(y0, y1, shape[1]), shape[0])
-        return x, y

--- a/kikuchipy/indexing/_static_pattern_matching.py
+++ b/kikuchipy/indexing/_static_pattern_matching.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import List, Union
 
 from orix.crystal_map import CrystalMap, create_coordinate_arrays
 

--- a/kikuchipy/indexing/tests/test_static_pattern_matching.py
+++ b/kikuchipy/indexing/tests/test_static_pattern_matching.py
@@ -20,14 +20,10 @@ import io
 
 import numpy as np
 from orix.crystal_map import CrystalMap
-from orix.quaternion import Rotation
 import pytest
 
 from kikuchipy.data import nickel_ebsd_small
-from kikuchipy.indexing._static_pattern_matching import (
-    StaticPatternMatching,
-    _get_spatial_arrays,
-)
+from kikuchipy.indexing._static_pattern_matching import StaticPatternMatching
 from kikuchipy.io.tests.test_util import replace_stdin
 from kikuchipy.signals import EBSD
 
@@ -48,8 +44,8 @@ class TestStaticPatternMatching:
         s_dict1 = EBSD(s.data.reshape(-1, 60, 60))
         s_dict2 = EBSD(s.data.reshape(-1, 60, 60))
         n_patterns = s_dict1.axes_manager.navigation_size
-        s_dict1._xmap = CrystalMap(Rotation(np.zeros((n_patterns, 4))))
-        s_dict2._xmap = CrystalMap(Rotation(np.zeros((n_patterns, 4))))
+        s_dict1._xmap = CrystalMap.empty((n_patterns,))
+        s_dict2._xmap = CrystalMap.empty((n_patterns,))
         s_dict1.xmap.phases[0].name = "a"
         s_dict2.xmap.phases[0].name = "b"
 
@@ -64,7 +60,7 @@ class TestStaticPatternMatching:
     def test_keep_n(self, n_rot_in, n_rot_out, keep_n):
         s = nickel_ebsd_small()
         s_dict = EBSD(np.random.random((n_rot_in, 60, 60)).astype(np.float32))
-        s_dict._xmap = CrystalMap(Rotation(np.zeros((n_rot_in, 4))))
+        s_dict._xmap = CrystalMap.empty((n_rot_in,))
         sd = StaticPatternMatching(s_dict)
         xmap = sd(s)
 
@@ -82,7 +78,7 @@ class TestStaticPatternMatching:
         s_dict1 = EBSD(s.data.reshape(-1, 60, 60))
         s_dict2 = s_dict1.deepcopy()
         n_patterns = s_dict1.axes_manager.navigation_size
-        s_dict1._xmap = CrystalMap(Rotation(np.zeros((n_patterns, 4))))
+        s_dict1._xmap = CrystalMap.empty((n_patterns,))
         s_dict2._xmap = s_dict1.xmap.deepcopy()
         s_dict1.xmap.phases[0].name = "a"
         s_dict2.xmap.phases[0].name = "b"
@@ -111,7 +107,7 @@ class TestStaticPatternMatching:
             .astype(np.uint8)
         )
         s_dict1 = EBSD(rand_data)
-        s_dict1._xmap = CrystalMap(Rotation(np.zeros((n_sim, 4))))
+        s_dict1._xmap = CrystalMap.empty((n_sim,))
         sd = StaticPatternMatching(s_dict1)
 
         with replace_stdin(io.StringIO("y")):
@@ -131,57 +127,8 @@ class TestStaticPatternMatching:
         sig_shape = dummy_signal.axes_manager.signal_shape
         s_dict1 = EBSD(dummy_signal.data.reshape((-1,) + sig_shape))
         n_sim = s_dict1.axes_manager.navigation_size
-        s_dict1._xmap = CrystalMap(Rotation(np.zeros((n_sim, 4))))
+        s_dict1._xmap = CrystalMap.empty((n_sim,))
         sd = StaticPatternMatching(s_dict1)
         res = sd(s)
 
         assert res.shape == desired_xmap_shape
-
-    @pytest.mark.parametrize(
-        "shape, extent, desired_arrays",
-        [
-            # 0d
-            ((), (), ()),
-            ((0, 0), (0.0, 2.0, 0.0, 2.0), (np.array([]),) * 2),
-            # 1d
-            ((3,), (0.0, 3.0), np.tile(np.linspace(0, 4.5, 3), 3)),
-            # 2d
-            (
-                (3, 2),
-                (0.0, 4.0, 0.0, 1.5),
-                (
-                    np.tile(np.linspace(0, 4, 3), 2),
-                    np.tile(np.linspace(0, 1.5, 2), 3),
-                ),
-            ),
-            (
-                (3, 2),
-                (0.0, 1.0, 0.0, 1.0),
-                (
-                    np.tile(np.linspace(0, 1, 3), 2),
-                    np.tile(np.linspace(0, 1, 2), 3),
-                ),
-            ),
-            (
-                (136, 249),
-                (79.5, 99.75, 30.0, 67.2),
-                (
-                    np.tile(np.linspace(79.5, 99.75, 136), 249),
-                    np.tile(np.linspace(30.0, 67.2, 249), 136),
-                ),
-            ),
-        ],
-    )
-    def test_get_spatial_arrays(self, shape, extent, desired_arrays):
-        """Ensure spatial arrays for 0d, 1d and 2d EBSD signals are
-        returned correctly.
-        """
-        spatial_arrays = _get_spatial_arrays(shape, extent)
-
-        if len(spatial_arrays) == 0:
-            assert spatial_arrays == desired_arrays
-        else:
-            assert [
-                np.allclose(spatial_arrays[i], desired_arrays[i])
-                for i in range(len(spatial_arrays))
-            ]

--- a/kikuchipy/indexing/tests/test_static_pattern_matching.py
+++ b/kikuchipy/indexing/tests/test_static_pattern_matching.py
@@ -70,6 +70,17 @@ class TestStaticPatternMatching:
 
         assert xmap2.rotations_per_point == keep_n
 
+    def test_coordinate_arrays(self):
+        s = nickel_ebsd_small().inav[:, :2]
+        s_dict = EBSD(s.data.reshape(-1, 60, 60))
+        s_dict._xmap = CrystalMap.empty((s.axes_manager.navigation_size,))
+        sd = StaticPatternMatching(s_dict)
+        xmap = sd(s)
+
+        assert s.axes_manager.navigation_shape[::-1] == (2, 3)
+        assert np.allclose(xmap.x, [0, 1.5, 3, 0, 1.5, 3])
+        assert np.allclose(xmap.y, [0, 0, 0, 1.5, 1.5, 1.5])
+
     @pytest.mark.parametrize(
         "return_merged_xmap, desired_n_xmaps_out", [(True, 3), (False, 2)]
     )


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Fix #384.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
