### PR TITLE
Update changelog and release version for a v0.4.0 minor release

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,8 +12,8 @@ to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
-Unreleased
-==========
+0.4.0 (2021-07-08)
+==================
 
 Contributors
 ------------

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -34,4 +34,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.4.dev0"
+version = "0.4.0"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Update changelog and release version for a v0.4.0 minor release planned for today 2021-07-08.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
