### PR TITLE
Set minimal requirement of importlib_metadata

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -57,6 +57,8 @@ Deprecated
 
 Fixed
 -----
+- Set minimal requirement of importlib_metadata to v3.6 so Binder can run user guide
+  notebooks with HyperSpy 1.6.3. (`#395 <https://github.com/pyxem/kikuchipy/pull/395>`_)
 - Row (y) coordinate array returned with the crystal map from dictionary indexing is
   correctly sorted. (`#392 <https://github.com/pyxem/kikuchipy/pull/392>`_)
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively, `xmap` and

--- a/setup.py
+++ b/setup.py
@@ -119,20 +119,23 @@ setup(
     extras_require=extra_feature_requirements,
     # fmt: off
     install_requires=[
-        # Restrict newest dask version until
-        # https://github.com/dask/dask/issues/7583 is resolved
-        "dask[array]    >= 2.18, <= 2021.03.1",
-        "diffsims       >= 0.4",
-        "hyperspy       >= 1.5.2",
-        "h5py           >= 2.10",
-        "matplotlib     >= 3.3",
-        "numpy          >= 1.19",
-        "numba          >= 0.48",
-        "orix           >= 0.6",
-        "pooch          >= 0.13",
+        # TODO: Restrict newest dask version until
+        #   https://github.com/dask/dask/issues/7583 is resolved
+        "dask[array]        >= 2.18, <= 2021.03.1",
+        "diffsims           >= 0.4",
+        "hyperspy           >= 1.5.2",
+        "h5py               >= 2.10",
+        # TODO: Remove after new HyperSpy release after v1.6.3.
+        #   See https://github.com/hyperspy/hyperspy/issues/2792.
+        "importlib_metadata >= 3.6",
+        "matplotlib         >= 3.3",
+        "numpy              >= 1.19",
+        "numba              >= 0.48",
+        "orix               >= 0.6",
+        "pooch              >= 0.13",
         "psutil",
-        "tqdm           >= 0.5.2",
-        "scikit-image   >= 0.16.2",
+        "tqdm               >= 0.5.2",
+        "scikit-image       >= 0.16.2",
         "scikit-learn",
         "scipy",
     ],


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Fix #394 so that Binder can run our user guide notebooks with HyperSpy v1.6.3.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
