### PR TITLE
Update installation instructions and add warning

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,16 +10,6 @@ kikuchipy can be installed from `Anaconda
 and supports Python >= 3.7. All alternatives are available on Windows, macOS,
 and Linux.
 
-.. _install-with-hyperspy-bundle:
-
-With the HyperSpy Bundle
-========================
-
-The easiest way to install kikuchipy is via the HyperSpy Bundle. See
-`HyperSpy's documentation
-<http://hyperspy.org/hyperspy-doc/current/user_guide/install.html#hyperspy-bundle>`_
-for instructions.
-
 .. _install-with-anaconda:
 
 With Anaconda
@@ -77,6 +67,23 @@ To install a specific version of kikuchipy (say version 0.3.4)::
     $ pip install kikuchipy==0.3.4
 
 .. _install-from-source:
+
+.. _install-with-hyperspy-bundle:
+
+With the HyperSpy Bundle
+========================
+
+The easiest way to install kikuchipy is via the HyperSpy Bundle. See
+`HyperSpy's documentation
+<http://hyperspy.org/hyperspy-doc/current/user_guide/install.html#hyperspy-bundle>`_
+for instructions.
+
+.. warning::
+
+    kikuchipy is updated more frequently than the HyperSpy Bundle, thus the installed
+    version of kikuchipy will most likely not be the latest version available. See the
+    `HyperSpy Bundle repository <https://github.com/hyperspy/hyperspy-bundle>`_ for how
+    to update packages in the bundle.
 
 From source
 ===========


### PR DESCRIPTION
#### Description of the change
Move HyperSpy Bundle installation alternative below Anaconda and pip alternatives and add warning that the latest version might not be installed with the bundle. This is because, as the warning says, kikuchipy release more frequently than the bundle, and we want our users to get the latest release when doing a fresh install.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
