### PR TITLE
Merge v0.4.x into master

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -57,6 +57,8 @@ Deprecated
 
 Fixed
 -----
+- Set minimal requirement of importlib_metadata to v3.6 so Binder can run user guide
+  notebooks with HyperSpy 1.6.3. (`#395 <https://github.com/pyxem/kikuchipy/pull/395>`_)
 - Row (y) coordinate array returned with the crystal map from dictionary indexing is
   correctly sorted. (`#392 <https://github.com/pyxem/kikuchipy/pull/392>`_)
 - Deep copying EBSD and EBSDMasterPattern signals carry over, respectively, `xmap` and

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,8 +12,8 @@ to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
-Unreleased
-==========
+0.4.0 (2021-07-08)
+==================
 
 Contributors
 ------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,16 +10,6 @@ kikuchipy can be installed from `Anaconda
 and supports Python >= 3.7. All alternatives are available on Windows, macOS,
 and Linux.
 
-.. _install-with-hyperspy-bundle:
-
-With the HyperSpy Bundle
-========================
-
-The easiest way to install kikuchipy is via the HyperSpy Bundle. See
-`HyperSpy's documentation
-<http://hyperspy.org/hyperspy-doc/current/user_guide/install.html#hyperspy-bundle>`_
-for instructions.
-
 .. _install-with-anaconda:
 
 With Anaconda
@@ -77,6 +67,23 @@ To install a specific version of kikuchipy (say version 0.3.4)::
     $ pip install kikuchipy==0.3.4
 
 .. _install-from-source:
+
+.. _install-with-hyperspy-bundle:
+
+With the HyperSpy Bundle
+========================
+
+The easiest way to install kikuchipy is via the HyperSpy Bundle. See
+`HyperSpy's documentation
+<http://hyperspy.org/hyperspy-doc/current/user_guide/install.html#hyperspy-bundle>`_
+for instructions.
+
+.. warning::
+
+    kikuchipy is updated more frequently than the HyperSpy Bundle, thus the installed
+    version of kikuchipy will most likely not be the latest version available. See the
+    `HyperSpy Bundle repository <https://github.com/hyperspy/hyperspy-bundle>`_ for how
+    to update packages in the bundle.
 
 From source
 ===========

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -34,4 +34,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.4.dev0"
+version = "0.4.0"

--- a/setup.py
+++ b/setup.py
@@ -119,20 +119,23 @@ setup(
     extras_require=extra_feature_requirements,
     # fmt: off
     install_requires=[
-        # Restrict newest dask version until
-        # https://github.com/dask/dask/issues/7583 is resolved
-        "dask[array]    >= 2.18, <= 2021.03.1",
-        "diffsims       >= 0.4",
-        "hyperspy       >= 1.5.2",
-        "h5py           >= 2.10",
-        "matplotlib     >= 3.3",
-        "numpy          >= 1.19",
-        "numba          >= 0.48",
-        "orix           >= 0.6",
-        "pooch          >= 0.13",
+        # TODO: Restrict newest dask version until
+        #   https://github.com/dask/dask/issues/7583 is resolved
+        "dask[array]        >= 2.18, <= 2021.03.1",
+        "diffsims           >= 0.4",
+        "hyperspy           >= 1.5.2",
+        "h5py               >= 2.10",
+        # TODO: Remove after new HyperSpy release after v1.6.3.
+        #   See https://github.com/hyperspy/hyperspy/issues/2792.
+        "importlib_metadata >= 3.6",
+        "matplotlib         >= 3.3",
+        "numpy              >= 1.19",
+        "numba              >= 0.48",
+        "orix               >= 0.6",
+        "pooch              >= 0.13",
         "psutil",
-        "tqdm           >= 0.5.2",
-        "scikit-image   >= 0.16.2",
+        "tqdm               >= 0.5.2",
+        "scikit-image       >= 0.16.2",
         "scikit-learn",
         "scipy",
     ],


### PR DESCRIPTION
#### Description of the change
Merge various minor changes on release branch `v0.4.x` into `master`. 

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
