### PR TITLE
Acknowledge that Oxford Instruments' provided info about the .ebsp file format

### DIFF
--- a/kikuchipy/io/plugins/oxford_binary.py
+++ b/kikuchipy/io/plugins/oxford_binary.py
@@ -17,7 +17,8 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 """Read support for uncompressed EBSD patterns in Oxford Instruments'
-binary .ebsp format.
+binary .ebsp file format. Information about the file format was provided
+by Oxford Instruments.
 """
 
 import os
@@ -59,6 +60,11 @@ def file_reader(filename: str, lazy: bool = False) -> List[dict]:
     -------
     scan
         Data, axes, metadata and original metadata.
+
+    Notes
+    -----
+    Information about the .ebsp file format was provided by Oxford
+    Instruments.
     """
     with open(filename, mode="rb") as f:
         obf = OxfordBinaryFileReader(f)

--- a/kikuchipy/io/plugins/oxford_binary.py
+++ b/kikuchipy/io/plugins/oxford_binary.py
@@ -17,8 +17,9 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 """Read support for uncompressed EBSD patterns in Oxford Instruments'
-binary .ebsp file format. Information about the file format was provided
-by Oxford Instruments.
+binary .ebsp file format.
+
+Information about the file format was provided by Oxford Instruments.
 """
 
 import os


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Acknowledge that Oxford Instruments' provided info about the .ebsp file format in the documentation.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `doc/changelog.rst`.
