### PR TITLE
Allow static background in metadata to be a Dask array

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,8 @@ Changed
 
 Fixed
 -----
+- Allow static background in EBSD metadata to be a Dask array.
+  (`#413 <https://github.com/pyxem/kikuchipy/pull/413>`_)
 - Set newest supported version of Sphinx to 4.0.2 so that nbsphinx works.
   (`#403 <https://github.com/pyxem/kikuchipy/pull/403>`_)
 

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -243,10 +243,10 @@ class TestRemoveStaticBackgroundEBSD:
             (
                 np.ones((3, 3), dtype=np.int8),
                 ValueError,
-                "The static background dtype_out",
+                "Static background dtype_out",
             ),
-            (None, OSError, "The static background is not a numpy or dask"),
-            (np.ones((3, 2), dtype=np.uint8), OSError, "The pattern"),
+            (None, ValueError, "`static_bg` is not a valid NumPy or Dask array"),
+            (np.ones((3, 2), dtype=np.uint8), ValueError, "Signal"),
         ],
     )
     def test_incorrect_static_background_pattern(
@@ -264,6 +264,12 @@ class TestRemoveStaticBackgroundEBSD:
         dummy_signal = dummy_signal.as_lazy()
         dummy_signal.remove_static_background(static_bg=dummy_background)
         assert isinstance(dummy_signal.data, da.Array)
+
+        ebsd_node = kp.signals.util.metadata_nodes("ebsd")
+        dummy_signal.metadata.set_item(
+            ebsd_node + ".static_background", da.from_array(dummy_background)
+        )
+        dummy_signal.remove_static_background()
 
     def test_remove_static_background_scalebg(self, dummy_signal, dummy_background):
         dummy_signal2 = dummy_signal.deepcopy()


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Fix #399.

After v0.5 has been released, bug fixes such as this should be branched off of `main` and merged back into `main`, possibly with the necessary patch release updates (changelog, patch version increment) included so we could release a patch release immediately.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
The following doesn't throw a `TypeError`

```python
>>> import kikuchipy as kp
>>> import dask.array as da
>>> s = kp.data.nickel_ebsd_small()
>>> s.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background = da.from_array(s.metadata.Acquisition_instrument.SEM.Detector.EBSD.static_background)
>>> s.remove_static_background()
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
