### PR TITLE
Unpin dask following dask 2021.8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2.18 diffsims==0.4.0 hyperspy==1.5.2 matplotlib==3.3 numpy==1.19 orix==0.6.0 scikit-image==0.16.2
+            DEPENDENCIES: dask==2021.8.1 diffsims==0.4.0 hyperspy==1.6.4 matplotlib==3.3 numpy==1.19 orix==0.6.0 scikit-image==0.16.2
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -49,12 +49,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display versions
         run: python -V; pip -V
-      - name: Install depedencies and package
-        shell: bash
-        run: pip install -U -e .'[tests]'
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: pip install ${{ matrix.DEPENDENCIES }}
+      - name: Install depedencies and package
+        shell: bash
+        run: pip install -U -e .'[tests]'
       - name: Run docstring tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: pytest --doctest-modules --ignore-glob=kikuchipy/*/tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2021.8.1 diffsims==0.4.0 hyperspy==1.6.4 matplotlib==3.3 numpy==1.19 orix==0.6.0 scikit-image==0.16.2
+            DEPENDENCIES: dask==2021.8.1 diffsims==0.4.0 hyperspy==1.6.4 matplotlib==3.3 numba==0.48 numpy==1.19 orix==0.6.0 scikit-image==0.16.2
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -119,15 +119,10 @@ setup(
     extras_require=extra_feature_requirements,
     # fmt: off
     install_requires=[
-        # TODO: Restrict newest dask version until
-        #   https://github.com/dask/dask/issues/7583 is resolved
-        "dask[array]        >= 2.18, <= 2021.03.1",
+        "dask[array]        >= 2021.8.1",
         "diffsims           >= 0.4",
-        "hyperspy           >= 1.5.2",
+        "hyperspy           >= 1.6.4",
         "h5py               >= 2.10",
-        # TODO: Remove after new HyperSpy release after v1.6.3.
-        #   See https://github.com/hyperspy/hyperspy/issues/2792.
-        "importlib_metadata >= 3.6",
         "matplotlib         >= 3.3",
         "numpy              >= 1.19",
         "numba              >= 0.48",


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
- Unpin dask, since the fix for https://github.com/dask/dask/issues/7583 have been released in 2021.8.1.
- Tidy up `install_requires` in setup.py
- Specify numba version in oldest supported version build

#### Progress of the PR
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [N/A] Unit tests with pytest for all lines
- [N/A] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
