### PR TITLE
Deprecate unused EBSD metadata, remove EBSD.rebin() overriding HyperSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ multi-dimensional data analysis provided by the HyperSpy library.
 [![PyPI version](https://img.shields.io/pypi/v/kikuchipy.svg)](https://pypi.python.org/pypi/kikuchipy)
 [![Downloads per month](https://pepy.tech/badge/kikuchipy/month)](https://pepy.tech/project/kikuchipy)
 [![Zenodo DOI](https://zenodo.org/badge/doi/10.5281/zenodo.3597646.svg)](https://doi.org/10.5281/zenodo.3597646)
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-b1aee3.svg)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/contributors-5-b1aee3.svg)](#contributors-)
 
 - **User guide and API reference**: https://kikuchipy.org. The guide consists of Jupyter
   Notebooks with many links to detailed explanations of the input parameters and output

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -56,6 +56,14 @@ Changed
 - URLs of user guide topics have an extra "/user_guide/<topic>" added to them.
   (`#403 <https://github.com/pyxem/kikuchipy/pull/403>`_)
 
+Deprecated
+----------
+- Custom EBSD metadata, meaning the *Acquisition_instrument.SEM.EBSD.Detector* and
+  *Sample.Phases* nodes, as well as the EBSD *set_experimental_parameters()* and
+  *set_phase_parameters()* methods. This will be removed in v0.6 The *static_background*
+  metadata array will become available as an EBSD property.
+  (`#428 <https://github.com/pyxem/kikuchipy/pull/428>`_)
+
 Removed
 -------
 - *make_similarity_metric()* function is replaced by the need to create a class inheriting

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -508,7 +508,6 @@ See :class:`̃hyperspy._signals.signal2d.Signal2D` for methods inherited from Hy
     get_virtual_bse_intensity
     normalize_intensity
     plot_virtual_bse_intensity
-    rebin
     refine_orientation
     refine_orientation_projection_center
     refine_projection_center

--- a/doc/user_guide/change_navigation_signal_shapes.ipynb
+++ b/doc/user_guide/change_navigation_signal_shapes.ipynb
@@ -51,7 +51,7 @@
     "print(s)\n",
     "\n",
     "s_mp = kp.data.nickel_ebsd_master_pattern_small(hemisphere=\"both\")\n",
-    "print(s_mp, s_mp.projection)"
+    "print(s_mp)"
    ]
   },
   {
@@ -144,8 +144,8 @@
     "## Binning\n",
     "\n",
     "A new `EBSD` signal with patterns binned e.g. by 2 can be obtained using the\n",
-    "[rebin()](../reference.rst#kikuchipy.signals.EBSD.rebin) method provided by\n",
-    "HyperSpy, explained further in\n",
+    "[rebin()](http://hyperspy.org/hyperspy-doc/current/api/hyperspy.signal.html#hyperspy.signal.BaseSignal.rebin)\n",
+    "method provided by HyperSpy, explained further in\n",
     "[their user guide](http://hyperspy.org/hyperspy-doc/current/user_guide/signal.html#rebinning),\n",
     "by passing in either the `scale` or `new_shape` parameter"
    ]
@@ -223,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/doc/user_guide/load_save_data.ipynb
+++ b/doc/user_guide/load_save_data.ipynb
@@ -198,6 +198,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "The `Acquisition_instrument.SEM.Detector.EBSD` and `Sample.Phases` metadata\n",
+    "nodes are deprecated and will be removed in v0.6.\n",
+    "\n",
+    "There are three main reasons for this change: the first is that only the static\n",
+    "background array stored in the\n",
+    "`Acquisition_instrument.SEM.Detector.EBSD.static_background` node is used\n",
+    "internally, and so the remaining metadata is unnecessary. The background pattern\n",
+    "will be stored in its own `EBSD.static_background` property instead. The second\n",
+    "is that keeping track of the unnecessary metadata makes writing and maintaining\n",
+    "input/ouput plugins challenging. The third is that the\n",
+    "[EBSD.xmap](../reference.rst#kikuchipy.signals.EBSD.xmap) and\n",
+    "[EBSD.detector](../reference.rst#kikuchipy.signals.EBSD.detector) properties,\n",
+    "which keeps track of the\n",
+    "[CrystalMap](https://orix.readthedocs.io/en/stable/reference.html#orix.crystal_map.CrystalMap)\n",
+    "and [EBSDDetector](../reference.rst#kikuchipy.detectors.EBSDDetector) for a\n",
+    "signal, respectively, should be used instead of the more \"static\" metadata.\n",
+    "\n",
+    "</div>\n",
+    "\n",
     "The number of patterns in horizontal and vertical direction, pattern size in\n",
     "pixels, scan step size and detector pixel size is stored in the `axes_manager`\n",
     "attribute:"
@@ -1080,7 +1103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/doc/user_guide/metadata_structure.ipynb
+++ b/doc/user_guide/metadata_structure.ipynb
@@ -16,6 +16,29 @@
    "source": [
     "# Metadata structure\n",
     "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "The `Acquisition_instrument.SEM.Detector.EBSD` and `Sample.Phases` metadata\n",
+    "nodes are deprecated and will be removed in v0.6.\n",
+    "\n",
+    "There are three main reasons for this change: the first is that only the static\n",
+    "background array stored in the\n",
+    "`Acquisition_instrument.SEM.Detector.EBSD.static_background` node is used\n",
+    "internally, and so the remaining metadata is unnecessary. The background pattern\n",
+    "will be stored in its own `EBSD.static_background` property instead. The second\n",
+    "is that keeping track of the unnecessary metadata makes writing and maintaining\n",
+    "input/ouput plugins challenging. The third is that the\n",
+    "[EBSD.xmap](../reference.rst#kikuchipy.signals.EBSD.xmap) and\n",
+    "[EBSD.detector](../reference.rst#kikuchipy.signals.EBSD.detector) properties,\n",
+    "which keeps track of the\n",
+    "[CrystalMap](https://orix.readthedocs.io/en/stable/reference.html#orix.crystal_map.CrystalMap)\n",
+    "and [EBSDDetector](../reference.rst#kikuchipy.detectors.EBSDDetector) for a\n",
+    "signal, respectively, should be used instead of the more \"static\" metadata.\n",
+    "\n",
+    "</div>\n",
+    "\n",
     "The [EBSD](../reference.rst#kikuchipy.signals.EBSD) class stores metadata in the\n",
     "`metadata` attribute provided by HyperSpy"
    ]
@@ -236,7 +259,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -250,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/doc/user_guide/pattern_processing.ipynb
+++ b/doc/user_guide/pattern_processing.ipynb
@@ -134,6 +134,29 @@
     "lowest to 0), while the rest is rescaled keeping relative intensities between\n",
     "patterns. With `relative=False`, all patterns are stretched to [0, 255].\n",
     "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "The `Acquisition_instrument.SEM.Detector.EBSD` and `Sample.Phases` metadata\n",
+    "nodes are deprecated and will be removed in v0.6.\n",
+    "\n",
+    "There are three main reasons for this change: the first is that only the static\n",
+    "background array stored in the\n",
+    "`Acquisition_instrument.SEM.Detector.EBSD.static_background` node is used\n",
+    "internally, and so the remaining metadata is unnecessary. The background pattern\n",
+    "will be stored in its own `EBSD.static_background` property instead. The second\n",
+    "is that keeping track of the unnecessary metadata makes writing and maintaining\n",
+    "input/ouput plugins challenging. The third is that the\n",
+    "[EBSD.xmap](../reference.rst#kikuchipy.signals.EBSD.xmap) and\n",
+    "[EBSD.detector](../reference.rst#kikuchipy.signals.EBSD.detector) properties,\n",
+    "which keeps track of the\n",
+    "[CrystalMap](https://orix.readthedocs.io/en/stable/reference.html#orix.crystal_map.CrystalMap)\n",
+    "and [EBSDDetector](../reference.rst#kikuchipy.detectors.EBSDDetector) for a\n",
+    "signal, respectively, should be used instead of the more \"static\" metadata.\n",
+    "\n",
+    "</div>\n",
+    "\n",
     "The static background pattern intensities can be rescaled to each individual\n",
     "pattern's intensity range before removal by passing `scale_bg=True`, which\n",
     "will result in the relative intensity between patterns to be lost (passing\n",
@@ -736,7 +759,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -750,7 +773,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/kikuchipy/_util/_util.py
+++ b/kikuchipy/_util/_util.py
@@ -49,7 +49,6 @@ class deprecated:
     def __init__(
         self,
         since: Union[str, int, float],
-        message: Optional[str] = None,
         alternative: Optional[str] = None,
         removal: Union[str, int, float, None] = None,
     ):
@@ -59,8 +58,6 @@ class deprecated:
         ----------
         since
             The release at which this API became deprecated.
-        message
-            The deprecation message.
         alternative
             An alternative API that the user may use in place of the
             deprecated API.
@@ -68,7 +65,6 @@ class deprecated:
             The expected removal version.
         """
         self.since = since
-        self.message = message
         self.alternative = alternative
         self.removal = removal
 
@@ -88,7 +84,7 @@ class deprecated:
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
-                action="always", category=np.VisibleDeprecationWarning
+                action="always", category=np.VisibleDeprecationWarning, append=True
             )
             func_code = func.__code__
             warnings.warn_explicit(

--- a/kikuchipy/_util/test_util.py
+++ b/kikuchipy/_util/test_util.py
@@ -29,7 +29,7 @@ class TestDeprecationWarning:
         gets the desired additions to their docstring.
         """
 
-        @deprecated(since=0.7, message="Hello", alternative="bar", removal=0.8)
+        @deprecated(since=0.7, alternative="bar", removal=0.8)
         def foo(n):
             """Some docstring."""
             return n + 1
@@ -71,7 +71,7 @@ class TestDeprecationWarning:
         )
 
     def test_deprecation_no_old_doc(self):
-        @deprecated(since=0.7, message="Hello", alternative="bar", removal=0.8)
+        @deprecated(since=0.7, alternative="bar", removal=0.8)
         def foo(n):
             return n + 1
 

--- a/kikuchipy/pattern/_pattern.py
+++ b/kikuchipy/pattern/_pattern.py
@@ -111,7 +111,7 @@ def remove_dynamic_background(
     filter_domain: str = "frequency",
     std: Union[None, int, float] = None,
     truncate: Union[int, float] = 4.0,
-    dtype_out: Union[None, np.dtype, Tuple[int, int], Tuple[float, float]] = None,
+    dtype_out: Union[None, np.dtype, type, Tuple[int, int], Tuple[float, float]] = None,
 ) -> np.ndarray:
     """Remove the dynamic background in an EBSD pattern.
 

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -77,6 +77,7 @@ from kikuchipy.signals.util._map_helper import (
 )
 from kikuchipy.signals._common_image import CommonImage
 from kikuchipy.signals.virtual_bse_image import VirtualBSEImage
+from kikuchipy._util import deprecated
 
 
 class EBSD(CommonImage, Signal2D):
@@ -119,7 +120,9 @@ class EBSD(CommonImage, Signal2D):
             md.update(ebsd_metadata().as_dictionary())
             self.metadata = DictionaryTreeBrowser(md)
         if not self.metadata.has_item("Sample.Phases"):
-            self.set_phase_parameters()
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+                self.set_phase_parameters()
 
     # ---------------------- Custom properties ----------------------- #
 
@@ -158,6 +161,7 @@ class EBSD(CommonImage, Signal2D):
 
     # ------------------------ Custom methods ------------------------ #
 
+    @deprecated(since="0.5", removal="0.6")
     def set_experimental_parameters(
         self,
         detector=None,
@@ -244,7 +248,7 @@ class EBSD(CommonImage, Signal2D):
         >>> node = kp.signals.util.metadata_nodes("ebsd")
         >>> s.metadata.get_item(node + '.xpc')
         -5.64
-        >>> s.set_experimental_parameters(xpc=0.50726)
+        >>> s.set_experimental_parameters(xpc=0.50726)  # doctest: +SKIP
         >>> s.metadata.get_item(node + '.xpc')
         0.50726
         """
@@ -284,6 +288,7 @@ class EBSD(CommonImage, Signal2D):
             ebsd_node,
         )
 
+    @deprecated(since="0.5", removal="0.6")
     def set_phase_parameters(
         self,
         number=1,
@@ -357,7 +362,7 @@ class EBSD(CommonImage, Signal2D):
         ...         'site_occupation': 1,
         ...         'debye_waller_factor': 0.005
         ...     }}
-        ... )
+        ... )  # doctest: +SKIP
         >>> s.metadata.Sample.Phases.Number_1.atom_coordinates.Number_1
         ├── atom = Fe
         ├── coordinates = array([0, 0, 0])

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -249,7 +249,7 @@ class EBSD(CommonImage, Signal2D):
         >>> s.metadata.get_item(node + '.xpc')
         -5.64
         >>> s.set_experimental_parameters(xpc=0.50726)  # doctest: +SKIP
-        >>> s.metadata.get_item(node + '.xpc')
+        >>> s.metadata.get_item(node + '.xpc')  # doctest: +SKIP
         0.50726
         """
         md = self.metadata
@@ -363,7 +363,7 @@ class EBSD(CommonImage, Signal2D):
         ...         'debye_waller_factor': 0.005
         ...     }}
         ... )  # doctest: +SKIP
-        >>> s.metadata.Sample.Phases.Number_1.atom_coordinates.Number_1
+        >>> s.metadata.Sample.Phases.Number_1.atom_coordinates.Number_1  # doctest: +SKIP
         ├── atom = Fe
         ├── coordinates = array([0, 0, 0])
         ├── debye_waller_factor = 0.005

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -77,7 +77,6 @@ from kikuchipy.signals.util._map_helper import (
 )
 from kikuchipy.signals._common_image import CommonImage
 from kikuchipy.signals.virtual_bse_image import VirtualBSEImage
-from kikuchipy._util import deprecated
 
 
 class EBSD(CommonImage, Signal2D):
@@ -2048,33 +2047,6 @@ class EBSD(CommonImage, Signal2D):
         s_model.learning_results = LearningResults()
 
         return s_model
-
-    def rebin(self, new_shape=None, scale=None, crop=True, out=None):
-        s_out = super().rebin(new_shape=new_shape, scale=scale, crop=crop, out=out)
-
-        return_signal = True
-        if s_out is None:
-            s_out = out
-            return_signal = False
-
-        # Update binning in metadata to signal dimension with largest or
-        # lowest binning if downscaling or upscaling, respectively
-        md = s_out.metadata
-        ebsd_node = metadata_nodes("ebsd")
-        if scale is None:
-            sx, sy = self.axes_manager.signal_shape
-            signal_idx = self.axes_manager.signal_indices_in_array
-            scale = (sx / new_shape[signal_idx[0]], sy / new_shape[signal_idx[1]])
-        upscaled_dimensions = np.where(np.array(scale) < 1)[0]
-        if len(upscaled_dimensions):
-            new_binning = np.min(scale)
-        else:
-            new_binning = np.max(scale)
-        original_binning = abs(md.get_item(ebsd_node + ".binning"))
-        md.set_item(ebsd_node + ".binning", original_binning * new_binning)
-
-        if return_signal:
-            return s_out
 
     # ------------------------ Private methods ----------------------- #
 

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -742,40 +742,6 @@ class TestAverageNeighbourPatternsEBSD:
         s.compute()
 
 
-class TestRebin:
-    def test_rebin(self, dummy_signal):
-        ebsd_node = kp.signals.util.metadata_nodes("ebsd")
-
-        # Passing new_shape, only scaling in signal space
-        new_shape = (3, 3, 2, 1)
-        new_binning = dummy_signal.axes_manager.shape[3] / new_shape[3]
-        s2 = dummy_signal.rebin(new_shape=new_shape)
-        assert s2.axes_manager.shape == new_shape
-        assert s2.metadata.get_item(ebsd_node + ".binning") == new_binning
-
-        # Passing scale, also scaling in navigation space
-        scale = (3, 1, 3, 2)
-        s2 = dummy_signal.rebin(scale=scale)
-        expected_new_shape = [
-            int(i / j) for i, j in zip(dummy_signal.axes_manager.shape, scale)
-        ]
-        assert s2.axes_manager.shape == tuple(expected_new_shape)
-        assert s2.metadata.get_item(ebsd_node + ".binning") == float(scale[2])
-
-        # Passing lazy signal to out parameter, only scaling in signal space but
-        # upscaling
-        scale = (1, 1, 1, 0.5)
-        expected_new_shape = [
-            int(i / j) for i, j in zip(dummy_signal.axes_manager.shape, scale)
-        ]
-        s2 = dummy_signal.copy().as_lazy()
-        s3 = dummy_signal.rebin(scale=scale, out=s2)
-        assert isinstance(s2, kp.signals.LazyEBSD)
-        assert s2.axes_manager.shape == tuple(expected_new_shape)
-        assert s2.metadata.get_item(ebsd_node + ".binning") == float(scale[3])
-        assert s3 is None
-
-
 class TestVirtualBackscatterElectronImaging:
     @pytest.mark.parametrize("out_signal_axes", [None, (0, 1), ("x", "y")])
     def test_virtual_backscatter_electron_imaging(self, dummy_signal, out_signal_axes):

--- a/kikuchipy/signals/util/_metadata.py
+++ b/kikuchipy/signals/util/_metadata.py
@@ -36,6 +36,10 @@ def ebsd_metadata() -> DictionaryTreeBrowser:
     Returns
     -------
     md : hyperspy.misc.utils.DictionaryTreeBrowser
+
+    Notes
+    -----
+    .. deprecated:: 0.5
     """
     md = DictionaryTreeBrowser()
     sem_node, ebsd_node = metadata_nodes(["sem", "ebsd"])


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Add deprecation warnings to EBSD methods related to metadata, since the metadata is mostly unused internally and should be removed in v0.6
* Remove the `EBSD.rebin()` overriding HyperSpy's `Signal2D.rebin()`, because it is unnecessary when the custom metadata is removed, and potentially breaking when the HyperSpy rebin() API changes (which it will in v1.7.0)

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
No external changes to `EBSD.rebin()` are made in this PR, and deprecation warnings are added
```python
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_large()
>>> s
<EBSD, title: patterns Scan 1, dimensions: (75, 55|60, 60)>
>>> s2 = s.rebin(scale=(1, 1, 2, 2))
<EBSD, title: patterns Scan 1, dimensions: (75, 55|30, 30)>
>>> s.set_experimental_parameters(xpc=1)
/home/hakon/kode/kikuchipy/kikuchipy/signals/ebsd.py:165: VisibleDeprecationWarning: Function `set_experimental_parameters()` is deprecated and will be removed in version 0.6.
  def set_experimental_parameters(
>>> s.set_phase_parameters(number=2)
/home/hakon/kode/kikuchipy/kikuchipy/signals/ebsd.py:296: VisibleDeprecationWarning: Function `set_phase_parameters()` is deprecated and will be removed in version 0.6.
  def set_phase_parameters(
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
