### PR TITLE
Add automatic creation of tagged release draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on: [push, pull_request]
 

--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from outdated import check_outdated
+
+
+with open("../../kikuchipy/release.py") as fid:
+    for line in fid:
+        if line.startswith("version"):
+            branch_version = line.strip().split(" = ")[-1][1:-1]
+
+# Within a try/except because we don't want to throw the error if a new
+# tagged release draft is to be made, we just want to know if the branch
+# version is different (hopefully always newer if different) from the
+# PyPI version
+try:
+    make_release, pypi_version = check_outdated("kikuchipy", branch_version)
+except ValueError as e:
+    pypi_version = re.findall(r"\s([\d.]+)", e.args[0])[1]
+    make_release = True
+
+# These three prints are collected by a bash script using `eval` and
+# passed to GitHub Action environment variables to be used in a workflow
+print(make_release)
+print(pypi_version)
+print(branch_version)

--- a/.github/workflows/perhaps_make_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_tagged_release_draft.yml
@@ -1,7 +1,7 @@
 name: Perhaps make a tagged release
 
-# Trigger workflow when commits to or PRs merged to the main branch contain a change in
-# the kikuchipy/release.py file. This is because this workflow should only run when a
+# Trigger workflow when commits to the main branch contain a change in the
+# kikuchipy/release.py file. This is because this workflow should only run when a
 # tagged release draft is to be made.
 on:
   push:
@@ -9,14 +9,9 @@ on:
       - main
     paths:
       - "kikuchipy/release.py"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "kikuchipy/release.py"
 
 jobs:
-  perhaps-make-tagged-release:
+  make-tagged-release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +30,7 @@ jobs:
         echo "MAKE_RELEASE=${x[0]}" >> $GITHUB_ENV
         echo "PYPI_VERSION=${x[1]}" >> $GITHUB_ENV
         echo "BRANCH_VERSION=${x[2]}" >> $GITHUB_ENV
-    - name: Create tagged release draft
+    - name: Make tagged release draft
       if: ${{ env.MAKE_RELEASE == 'true' }}
       uses: actions/create-release@v1
       env:

--- a/.github/workflows/perhaps_make_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_tagged_release_draft.yml
@@ -1,0 +1,52 @@
+name: Perhaps make a tagged release
+
+# Trigger workflow when commits to or PRs merged to the main branch contain a change in
+# the kikuchipy/release.py file. This is because this workflow should only run when a
+# tagged release draft is to be made.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "kikuchipy/release.py"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kikuchipy/release.py"
+
+jobs:
+  perhaps-make-tagged-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ runner.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install outdated
+    - name: Check whether a tagged release draft should be made
+      run: |
+        cd .github/workflows
+        eval x=($(python perhaps_make_tagged_release_draft.py))
+        echo "MAKE_RELEASE=${x[0]}" >> $GITHUB_ENV
+        echo "PYPI_VERSION=${x[1]}" >> $GITHUB_ENV
+        echo "BRANCH_VERSION=${x[2]}" >> $GITHUB_ENV
+    - name: Create tagged release draft
+      if: ${{ env.MAKE_RELEASE == 'true' }}
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        draft: true
+        tag_name: v${{ env.BRANCH_VERSION }}
+        release_name: kikuchipy ${{ env.BRANCH_VERSION }}
+        commitish: main
+        body: |
+          kikuchipy is an open-source Python library for processing and analysis of electron backscatter diffraction (EBSD) patterns.
+
+          See the [changelog](https://kikuchipy.org/en/latest/changelog.html) for all updates from the previous release.
+        prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,12 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload package to PyPI
 
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   publish-to-pip:
@@ -16,7 +17,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - name: Install dependencies and package
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,11 +2,11 @@ include kikuchipy/hyperspy_extension.yaml
 include LICENSE
 include MANIFEST.in
 include setup.cfg
-include README.rst
+include README.md
 include RELEASE.rst
 include readthedocs.yml
 include setup.py
 
 recursive-include doc Makefile make.bat *.rst *.py *.ipynb *.bib
-recursive-include doc/_static *.png *.jpg *.svg *.gif
+recursive-include doc/_static *.png *.jpg *.svg
 recursive-include kikuchipy/data *

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://kikuchipy.org">
-    <img width="60%" src="doc/_static/logo/plasma_banner.png">
+    <img width="60%" src="https://raw.githubusercontent.com/pyxem/kikuchipy/develop/doc/_static/logo/plasma_banner.png">
   </a>
 </div>
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -16,10 +16,12 @@ kikuchipy's branching model is similar to the Gitflow Workflow (`original blog p
 - Make a PR of the release branch to `main`. Discuss the changelog with others, and
   make any changes *directly* to the release branch. Merge the branch into `main`. Then
   make a PR of `main` to `develop`, and merge this.
-- Create a release draft (tag) via the GitHub repo from main with the correct tag
-  version name, e.g. v0.42.0, and release title "kikuchipy 0.42.0". Add the new release
-  notes from the changelog, and convert any reStructuredText formatting to Markdown by
-  hand. Publish the release.
+- If the `__version__` in `release.py` on `main` has changed in a merged PR or pushed
+  commit, a tagged, annotated release *draft* is automatically created. If `__version__`
+  is now "0.42.0", the release name is "kikuchipy 0.42.0", and the tag name is
+  "v0.42.0". The tag target will be the `main` branch. The release body contains a
+  static description and a link to the changelog. This release draft can be published as
+  is, or changes to the release body can be made before publishing.
 - Monitor the publish GitHub Action to ensure the release is successfully published to
   PyPI.
 - Download the new version from PyPI with the `dev` dependencies with

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -16,12 +16,12 @@ kikuchipy's branching model is similar to the Gitflow Workflow (`original blog p
 - Make a PR of the release branch to `main`. Discuss the changelog with others, and
   make any changes *directly* to the release branch. Merge the branch into `main`. Then
   make a PR of `main` to `develop`, and merge this.
-- If the `__version__` in `release.py` on `main` has changed in a merged PR or pushed
-  commit, a tagged, annotated release *draft* is automatically created. If `__version__`
-  is now "0.42.0", the release name is "kikuchipy 0.42.0", and the tag name is
-  "v0.42.0". The tag target will be the `main` branch. The release body contains a
-  static description and a link to the changelog. This release draft can be published as
-  is, or changes to the release body can be made before publishing.
+- If the `__version__` in `release.py` on `main` has changed in a new commit, a tagged,
+  annotated release *draft* is automatically created. If `__version__` is now "0.42.0",
+  the release name is "kikuchipy 0.42.0", and the tag name is "v0.42.0". The tag target
+  will be the `main` branch. The release body contains a static description and a link
+  to the changelog. This release draft can be published as is, or changes to the release
+  body can be made before publishing.
 - Monitor the publish GitHub Action to ensure the release is successfully published to
   PyPI.
 - Download the new version from PyPI with the `dev` dependencies with

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,18 @@ best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
+0.5.1 (2021-09-01)
+==================
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Added
+-----
+- Automatic creation of a release using GitHub Actions, which will simplify and lead to
+  more frequent patch releases. (`#433 <https://github.com/pyxem/kikuchipy/pull/433>`_)
+
 0.5.0 (2021-08-31)
 ==================
 

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -35,4 +35,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.5.0"
+version = "0.5.1rc1"

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ extra_feature_requirements = {
 extra_feature_requirements["dev"] = [
     "black",
     "manifix",
+    "outdated",
     "pre-commit >= 1.16",
 ] + list(chain(*list(extra_feature_requirements.values())))
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Prepare for a 0.5.1rc1 release.
* Add GitHub Action workflow to perhaps create a tagged release draft if the `kikuchipy/release.py` file has changed in a commit to or PR merged to the `main` branch. We can either just publish the draft, or make any changes and then publish. A new version will then be uploaded to PyPI.
* Other minor maintenance changes to the release guide, readme, manifest, etc.

Close #417.

Not sure if a tagged release draft will be made from this PR. If not, I'll make a new one after this is merged.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
