### PR TITLE
Automatically add relevant changelog part to tagged release draft

### DIFF
--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -36,6 +36,24 @@ except ValueError as e:
     pypi_version = re.findall(r"\s([\d.]+)", e.args[0])[1]
     make_release = True
 
+if make_release:
+    with open("../../doc/changelog.rst", mode="r") as f:
+        content = f.readlines()
+        changelog_start = 0
+        changelog_end = 0
+        for i, line in enumerate(content):
+            if line.startswith(branch_version):
+                changelog_start = i + 3
+            elif line.startswith(pypi_version):
+                changelog_end = i - 1
+    with open("release_part_in_changelog.rst", mode="w") as f:
+        f.write(
+            "kikuchipy is an open-source Python library for processing and analysis of electron backscatter diffraction (EBSD) patterns.\n\n"
+            "See the `changelog <https://kikuchipy.org/en/latest/changelog.html>`_ for all updates from the previous release.\n\n"
+        )
+        for line in content[changelog_start:changelog_end]:
+            f.write(line)
+
 # These three prints are collected by a bash script using `eval` and
 # passed to GitHub Action environment variables to be used in a workflow
 print(make_release)

--- a/.github/workflows/perhaps_make_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_tagged_release_draft.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: r-lib/actions/setup-pandoc@v1
     - name: Set up Python ${{ runner.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -30,6 +31,9 @@ jobs:
         echo "MAKE_RELEASE=${x[0]}" >> $GITHUB_ENV
         echo "PYPI_VERSION=${x[1]}" >> $GITHUB_ENV
         echo "BRANCH_VERSION=${x[2]}" >> $GITHUB_ENV
+    - name: Make tagged release draft body from changelog
+      if: ${{ env.MAKE_RELEASE == 'true' }}
+      run: pandoc .github/workflows/release_part_in_changelog.rst -f rst -t markdown -o release_part_in_changelog.md
     - name: Make tagged release draft
       if: ${{ env.MAKE_RELEASE == 'true' }}
       uses: actions/create-release@v1
@@ -40,8 +44,5 @@ jobs:
         tag_name: v${{ env.BRANCH_VERSION }}
         release_name: kikuchipy ${{ env.BRANCH_VERSION }}
         commitish: main
-        body: |
-          kikuchipy is an open-source Python library for processing and analysis of electron backscatter diffraction (EBSD) patterns.
-
-          See the [changelog](https://kikuchipy.org/en/latest/changelog.html) for all updates from the previous release.
+        body_path: release_part_in_changelog.md
         prerelease: false

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -35,4 +35,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.5.1rc1"
+version = "0.5.1"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Automatically add relevant changelog part to tagged release draft by parsing the changelog and converting the relevant part to markdown with Pandoc

Not fool proof at all, but should work if we follow semantic version naming. Nothing should raise an error in the Python script if we cannot get the relevant part of the changelog.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
