### PR TITLE
Make Pandoc not wrap changelog lines in release draft

### DIFF
--- a/.github/workflows/perhaps_make_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_tagged_release_draft.yml
@@ -33,7 +33,7 @@ jobs:
         echo "BRANCH_VERSION=${x[2]}" >> $GITHUB_ENV
     - name: Make tagged release draft body from changelog
       if: ${{ env.MAKE_RELEASE == 'true' }}
-      run: pandoc .github/workflows/release_part_in_changelog.rst -f rst -t markdown -o release_part_in_changelog.md
+      run: pandoc .github/workflows/release_part_in_changelog.rst -f rst -t markdown -o release_part_in_changelog.md --wrap=none
     - name: Make tagged release draft
       if: ${{ env.MAKE_RELEASE == 'true' }}
       uses: actions/create-release@v1


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Make pandoc not wrap lines.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
