### PR TITLE
Fix 442

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,9 @@ Contributors
 
 Changed
 -------
-- Restricted lowest supported version of orix to >= 0.7.
+- Add gnomonic circles as patches in axes returned from EBSDDetector.plot()
+  (`#445 <https://github.com/pyxem/kikuchipy/pull/445>`_)
+Restricted lowest supported version of orix to >= 0.7.
   (`#444 <https://github.com/pyxem/kikuchipy/pull/444>`_)
 
 0.5.1 (2021-09-01)

--- a/kikuchipy/detectors/ebsd_detector.py
+++ b/kikuchipy/detectors/ebsd_detector.py
@@ -554,7 +554,7 @@ class EBSDDetector:
             if gnomonic_angles is None:
                 gnomonic_angles = np.arange(1, 9) * 10
             for angle in gnomonic_angles:
-                ax.add_artist(
+                ax.add_patch(
                     plt.Circle(
                         (pcx, pcy), np.tan(np.deg2rad(angle)), **gnomonic_circles_kwargs
                     )

--- a/kikuchipy/detectors/tests/test_ebsd_detector.py
+++ b/kikuchipy/detectors/tests/test_ebsd_detector.py
@@ -381,12 +381,12 @@ class TestEBSDDetector:
             n_angles = 8
         else:
             n_angles = len(gnomonic_angles)
-        assert len(ax.artists) == n_angles
+        assert len(ax.patches) == n_angles
         if gnomonic_circles_kwargs is None:
             edgecolor = "k"
         else:
             edgecolor = gnomonic_circles_kwargs["edgecolor"]
-        assert np.allclose(ax.artists[0]._edgecolor[:3], mcolors.to_rgb(edgecolor))
+        assert np.allclose(ax.patches[0]._edgecolor[:3], mcolors.to_rgb(edgecolor))
         plt.close("all")
 
     @pytest.mark.parametrize("pattern", [np.ones((61, 61)), np.ones((59, 60))])


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Add gnomonic circles as patches to axes in EBSDDetector.plot().
* This was done to fix #332 so kikuchipy is (more) compatible with upcoming Matplotlib 3.5.0b1.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> detector = kp.detectors.EBSDDetector(shape=(80, 60))
>>> _, ax = detector.plot(coordinates="gnomonic", draw_gnomonic_circles=True, return_fig_ax=True)
>>> ax.artists  # Previous location of circles
<Axes.ArtistList of 0 artists>
>>> ax.patches  # Current location of circles
<Axes.ArtistList of 8 patches>
>>> ax.patches[:]
[<matplotlib.patches.Circle at 0x7fcdf85f9eb0>,
 <matplotlib.patches.Circle at 0x7fcdf85f9f10>,
 <matplotlib.patches.Circle at 0x7fcdf85f9a90>,
 <matplotlib.patches.Circle at 0x7fcdf85f90d0>,
 <matplotlib.patches.Circle at 0x7fcdf85f9430>,
 <matplotlib.patches.Circle at 0x7fcdf8571bb0>,
 <matplotlib.patches.Circle at 0x7fcdf8567520>,
 <matplotlib.patches.Circle at 0x7fcdf85679d0>]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `doc/changelog.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
