### PR TITLE
Prevent EBSD refinement tests using random data to fail on Azure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ entries are sorted in descending chronological order.
 Unreleased
 ==========
 
+Fixed
+-----
+- Hopefully prevent EBSD refinement tests using random data to fail on Azure.
+  (`#465 <https://github.com/pyxem/kikuchipy/pull/465>`_)
+
 0.5.3 (2021-11-02)
 ==================
 

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -127,22 +127,25 @@ def ebsd_with_axes_and_random_data(request):
     nav_ndim = len(nav_shape)
     sig_ndim = len(sig_shape)
     data_shape = nav_shape + sig_shape
+    data_size = int(np.prod(data_shape))
     axes = []
     if nav_ndim == 1:
         axes.append(dict(name="x", size=nav_shape[0], scale=1))
     if nav_ndim == 2:
         axes.append(dict(name="y", size=nav_shape[0], scale=1))
         axes.append(dict(name="x", size=nav_shape[1], scale=1))
-    #    if sig_ndim == 1:
-    #        axes.append(dict(name="dx", size=sig_shape[0], scale=1))
     if sig_ndim == 2:
         axes.append(dict(name="dy", size=sig_shape[0], scale=1))
         axes.append(dict(name="dx", size=sig_shape[1], scale=1))
+    if np.issubdtype(dtype, np.integer):
+        data_kwds = dict(low=1, high=255, size=data_size)
+    else:
+        data_kwds = dict(low=0.1, high=1, size=data_size)
     if lazy:
-        data = da.random.random(data_shape).astype(dtype)
+        data = da.random.uniform(**data_kwds).reshape(data_shape).astype(dtype)
         yield kp.signals.LazyEBSD(data, axes=axes)
     else:
-        data = np.random.random(data_shape).astype(dtype)
+        data = np.random.uniform(**data_kwds).reshape(data_shape).astype(dtype)
         yield kp.signals.EBSD(data, axes=axes)
 
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Try to fix https://github.com/pyxem/kikuchipy/issues/438 by restricting random data values to a uniform distribution with data ranges [1, 255] for integer dtype and [0.1, 1] for float dtype.

#### Progress of the PR
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [N/A] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
