### PR TITLE
Automatically merge changes in main branch into develop branch

### DIFF
--- a/.github/workflows/merge_main_into_develop.yml
+++ b/.github/workflows/merge_main_into_develop.yml
@@ -1,0 +1,27 @@
+name: 'Merge main into develop'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-main-into-develop:
+
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Merge main into develop
+      uses: robotology/gh-action-nightly-merge@v1.3.1
+      with:
+        stable_branch: 'main'
+        development_branch: 'develop'
+        allow_ff: true
+        allow_forks: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Add GitHub Action to automatically merge changes in main branch into develop branch. Uses https://github.com/marketplace/actions/nightly-merge, but is only triggered when something is pushed to `main` (for example when we merge a PR to `main`). This action is [used by HyperSpy](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/.github/workflows/nightly-merge.yml) (currently disabled, apparently).

This will be tested when we now merge #470 into `main`. I'm sure there will be some problems hickups, but this will hopefully automate parts of the post-release work.

#### Progress of the PR
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [N/A] Unit tests with pytest for all lines
- [N/A] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
