### PR TITLE
Updates to develop post v0.5.4 release

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -26,12 +26,13 @@ kikuchipy's branching model is similar to the Gitflow Workflow (`original blog p
   PyPI.
 - Download the new version from PyPI with the ``tests`` dependencies with
   ``pip install kikuchipy[tests]==0.42.0`` locally and run the tests with
-  ``pytest --pyargs kikuchipy`` to make sure everything is as it should be.
-- Bring changes in ``main`` onto ``develop`` by branching off of ``main``, merge
-  ``develop`` into the new branch, fix conflicts, and make a PR to ``develop``.
-- Make a PR to ``develop`` with ``__version__`` updated (or reverted), e.g. from
-  "0.42.0" to "0.43.dev0".
-- Make a PR to ``develop`` with any updates to this guide if necessary.
+  ``pytest --pyargs kikuchipy`` to make sure all tests pass.
+- Monitor the documentation build at https://readthedocs.org/projects/kikuchipy/builds
+  to make sure the new stable documentation is successfully built from the release.
+- Bring changes on ``main`` onto ``develop`` by branching off of ``main``, merge
+  ``develop`` onto the new branch, fix conflicts, and make a PR to ``develop``.
+- Make a post-release PR to ``develop`` with ``__version__`` updated (or reverted), e.g.
+  from "0.42.0" to "0.43.dev0", and any updates to this guide if necessary.
 
 conda-forge
 -----------

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -36,4 +36,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.5.4"
+version = "0.6.dev0"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Revert version from 0.5.4 to 0.6.dev0
* Add note about checking a successful doc build in the release guide

#### Progress of the PR
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [N/A] Unit tests with pytest for all lines
- [N/A] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
