### PR TITLE
Fix data save issue for non-square patterns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,19 @@ best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
+0.5.5 (2021-12-12)
+==================
+
+Contributors
+------------
+- Håkon Wiik Ånes
+- Zhou Xu
+
+Fixed
+-----
+- Not flipping rows and columns when saving non-square patterns to kikuchipy's h5ebsd
+  format. (`#486 <https://github.com/pyxem/kikuchipy/pull/486>`_)
+
 0.5.4 (2021-11-17)
 ==================
 

--- a/kikuchipy/io/plugins/h5ebsd.py
+++ b/kikuchipy/io/plugins/h5ebsd.py
@@ -880,7 +880,7 @@ def file_writer(
         data_shape[:2] = [i.size for i in nav_axes][::-1]
         data_scales[:2] = [i.scale for i in nav_axes][::-1]
         nav_extent = am.navigation_extent
-    data_shape[2:] = am.signal_shape
+    data_shape[2:] = am.signal_shape[::-1]
     data_scales[2:] = [i.scale for i in am.signal_axes]
     ny, nx, sy, sx = data_shape
     scale_ny, scale_nx, scale_sy, _ = data_scales

--- a/kikuchipy/io/plugins/tests/test_h5ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_h5ebsd.py
@@ -395,3 +395,15 @@ class Testh5ebsd:
         s1 = load(save_path_hdf5)
         assert s1.data.shape == (60, 60)
         assert s1.axes_manager.navigation_axes == ()
+
+    def test_save_load_non_square_patterns(self, save_path_hdf5):
+        """Ensure non-square patterns are written to file correctly."""
+        data_shape = (3, 4, 5, 6)
+        data = np.random.randint(
+            low=0, high=256, size=np.prod(data_shape), dtype=np.uint8
+        ).reshape(data_shape)
+        s = EBSD(data)
+        s.save(save_path_hdf5)
+        s2 = load(save_path_hdf5)
+        assert s.data.shape == s2.data.shape
+        assert np.allclose(s.data, s2.data)

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from packaging import version
+
 import dask.array as da
 import numpy as np
 import pytest
@@ -64,20 +66,11 @@ DYN_CORR_UINT8_SPATIAL_STD2_OMAX250 = np.array(
     [[167, 210, 177], [250, 217, 184], [217, 31, 0]],
     dtype=np.uint8,
 )
-ADAPT_EQ_UINT8_SKIMAGE16 = np.array(
-    [[127, 223, 127], [255, 223, 31], [223, 31, 0]], dtype=np.uint8
-)
-ADAPT_EQ_UINT8_SKIMAGE17 = np.array(
-    [[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8
-)
-ADAPT_EQ_UINT8_SKIMAGE18 = np.array(
-    [[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8
-)
-ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE16
-if skimage_version[2:4] == str(17):  # pragma: no cover
-    ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE17
-elif skimage_version[2:4] == str(18):  # pragma: no cover
-    ADAPT_EQ_UINT8 = ADAPT_EQ_UINT8_SKIMAGE18
+ADAPT_EQ_UINT8 = np.array([[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8)
+if version.parse(skimage_version) < version.parse("0.17"):  # pragma: no cover
+    ADAPT_EQ_UINT8 = np.array(
+        [[127, 223, 127], [255, 223, 31], [223, 31, 0]], dtype=np.uint8
+    )
 
 
 class TestRescaleIntensityChunk:

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -36,4 +36,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.5.4"
+version = "0.5.5"


### PR DESCRIPTION
This is quick patch for fixing data save issue mentioned in #485

Tested on h5ebsd file saved from Oxford .ebsp data file. The saved pattern dimensions are consistent with original patterns.