### PR TITLE
Preparations for a 0.5.8 patch release following orix 0.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask==2021.8.1 diffsims==0.4.0 hyperspy==1.6.5 matplotlib==3.3 numba==0.48 numpy==1.19 orix==0.8.0 scikit-image==0.16.2
+            DEPENDENCIES: dask==2021.8.1 diffsims==0.4.0 hyperspy==1.6.5 matplotlib==3.3 numba==0.48 numpy==1.19 orix==0.9.0 scikit-image==0.16.2
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,23 @@ best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
+0.5.8 (2022-05-16)
+==================
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Changed
+-------
+- Minimal version of ``orix`` is increased to 0.9.
+  (`#520 <https://github.com/pyxem/kikuchipy/pull/520>`_)
+
+Fixed
+-----
+- Internal use of ``orix.vector.Vector3d`` following ``orix``' 0.9.0 release.
+  (`#520 <https://github.com/pyxem/kikuchipy/pull/520>`_)
+
 0.5.7 (2022-01-10)
 ==================
 

--- a/kikuchipy/io/plugins/tests/test_h5ebsd.py
+++ b/kikuchipy/io/plugins/tests/test_h5ebsd.py
@@ -288,9 +288,10 @@ class Testh5ebsd:
 
     def test_load_readonly(self):
         s = load(KIKUCHIPY_FILE, lazy=True)
+        keys = ["array-original", "original-array"]
         k = next(
             filter(
-                lambda x: isinstance(x, str) and x.startswith("array-original"),
+                lambda x: isinstance(x, str) and any([x.startswith(j) for j in keys]),
                 s.data.dask.keys(),
             )
         )

--- a/kikuchipy/io/plugins/tests/test_nordif.py
+++ b/kikuchipy/io/plugins/tests/test_nordif.py
@@ -350,9 +350,10 @@ class TestNORDIF:
 
     def test_load_readonly(self):
         s = load(PATTERN_FILE, lazy=True)
+        keys = ["array-original", "original-array"]
         k = next(
             filter(
-                lambda x: isinstance(x, str) and x.startswith("array-original"),
+                lambda x: isinstance(x, str) and any([x.startswith(j) for j in keys]),
                 s.data.dask.keys(),
             )
         )

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -35,4 +35,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.5.7"
+version = "0.5.8"

--- a/kikuchipy/simulations/features.py
+++ b/kikuchipy/simulations/features.py
@@ -172,7 +172,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         """Distance from the PC (origin) per band, i.e. the right-angle
         component of the distance to the pole.
         """
-        return np.tan(0.5 * np.pi - self.hkl_detector.polar.data)
+        return np.tan(0.5 * np.pi - self.hkl_detector.polar)
 
     @property
     def within_gnomonic_radius(self) -> np.ndarray:
@@ -204,7 +204,7 @@ class KikuchiBand(ReciprocalLatticePoint):
         to NaN.
         """
         # Get alpha1 and alpha2 angles (NaN for bands outside gnomonic radius)
-        azimuth = self.hkl_detector.azimuth.data
+        azimuth = self.hkl_detector.azimuth
         hesse_alpha = self.hesse_alpha
         plane_trace = np.zeros(self.navigation_shape + (self.size, 4))
         alpha1 = azimuth - np.pi + hesse_alpha
@@ -222,11 +222,11 @@ class KikuchiBand(ReciprocalLatticePoint):
 
     @property
     def hesse_line_x(self) -> np.ndarray:
-        return -self.hesse_distance * np.cos(self.hkl_detector.azimuth.data)
+        return -self.hesse_distance * np.cos(self.hkl_detector.azimuth)
 
     @property
     def hesse_line_y(self) -> np.ndarray:
-        return -self.hesse_distance * np.sin(self.hkl_detector.azimuth.data)
+        return -self.hesse_distance * np.sin(self.hkl_detector.azimuth)
 
     def __getitem__(self, key):
         """Get a deepcopy subset of the KikuchiBand object.
@@ -416,7 +416,7 @@ class ZoneAxis(ReciprocalLatticePoint):
     @property
     def r_gnomonic(self) -> np.ndarray:
         """Gnomonic radius for all zone axes per pattern."""
-        return np.sqrt(self.x_gnomonic ** 2 + self.y_gnomonic ** 2)
+        return np.sqrt(self.x_gnomonic**2 + self.y_gnomonic**2)
 
     @property
     def within_gnomonic_radius(self) -> np.ndarray:

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "matplotlib   >= 3.3",
         "numba        >= 0.48",
         "numpy        >= 1.19",
-        "orix         == 0.9.0rc2",
+        "orix         >= 0.9",
         "pooch        >= 0.13",
         "tqdm         >= 0.5.2",
         "scikit-image >= 0.16.2",

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "matplotlib   >= 3.3",
         "numba        >= 0.48",
         "numpy        >= 1.19",
-        "orix         >= 0.8",
+        "orix         == 0.9.0rc2",
         "pooch        >= 0.13",
         "tqdm         >= 0.5.2",
         "scikit-image >= 0.16.2",


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->

Fixes breaking changes coming in orix 0.9.0 where e.g. `Vector3d.azimuth` is a NumPy array and not a `Scalar` (class in orix), which previously had to be accessed as `Vector3d.azimuth.data`.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)
- [x] Update changelog
- [x] Release orix 0.9.0 on PyPI
- [x] Set minimal orix version to 0.9 in `setup.py`

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
