### PR TITLE
Silence HyperSpy 1.7 warnings and carry over custom properties after use of map()

### DIFF
--- a/kikuchipy/io/tests/test_io.py
+++ b/kikuchipy/io/tests/test_io.py
@@ -114,6 +114,7 @@ class TestIO:
                     s.save(file_path)
             gc.collect()
 
+    @pytest.mark.filterwarnings("ignore:Using `set_signal_dimension`")
     def test_save_data_dimensions(self):
         s = load(KIKUCHIPY_FILE)
         s.axes_manager.set_signal_dimension(3)

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -29,7 +29,6 @@ from dask.diagnostics import ProgressBar
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy._lazy_signals import LazySignal2D
 from hyperspy.learn.mva import LearningResults
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.roi import BaseInteractiveROI
 from hyperspy.api import interactive
 from h5py import File

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -224,6 +224,7 @@ class TestRemoveStaticBackgroundEBSD:
         assert isinstance(dummy_signal.data, da.Array)
         dummy_signal.static_background = da.from_array(dummy_background)
         dummy_signal.remove_static_background()
+        dummy_signal.remove_static_background(static_bg=dummy_signal.static_background)
 
     def test_remove_static_background_scalebg(self, dummy_signal, dummy_background):
         dummy_signal2 = dummy_signal.deepcopy()


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->

Fixes #516.

Using `kikuchipy.signals.EBSD.map()`, inherited from `hyperspy.signals.BaseSignal.map()`, doesn't carry over custom properties `detector`, `static_background` or `xmap`. This is now done in the methods that use `map()`, introduced in #527.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()
>>> s2 = s.deepcopy()
>>> s2.remove_static_background()
>>> np.allclose(s.static_background, s2.static_background)  # Not the case before this PR
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
