### PR TITLE
Change error to warning when checking EBSD and CrystalMap step sizes for refinement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Changed
 -------
 - Remove requirement that the crystal map used for EBSD refinement has identical step
   size(s) to the EBSD signal's navigation axes. This raised an error previously, but now
-  only emits a warning. (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
+  only emits a warning. (`#531 <https://github.com/pyxem/kikuchipy/pull/531>`_)
 - Restrict minimal version of HyperSpy to 1.7.
   (`#527 <https://github.com/pyxem/kikuchipy/pull/527>`_)
 - Restrict minimal version of SciPy to 1.7.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Added
 
 Changed
 -------
+- Remove requirement that the crystal map used for EBSD refinement has identical step
+  size(s) to the EBSD signal's navigation axes. This raised an error previously, but now
+  only emits a warning. (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 - Restrict minimal version of HyperSpy to 1.7.
   (`#527 <https://github.com/pyxem/kikuchipy/pull/527>`_)
 - Restrict minimal version of SciPy to 1.7.

--- a/kikuchipy/_util/test_util.py
+++ b/kikuchipy/_util/test_util.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+import warnings
 
 import numpy as np
 import pytest
@@ -108,9 +109,9 @@ class TestDeprecateArgument:
         my_foo = Foo()
 
         # Does not warn
-        with pytest.warns(None) as record1:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             assert my_foo.bar_arg(b=1) == {"b": 1}
-        assert len(record1) == 0
 
         # Warns
         with pytest.warns(np.VisibleDeprecationWarning) as record2:

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -1128,16 +1128,20 @@ class TestEBSDXmapProperty:
         xmap_bad = get_single_phase_xmap(
             nav_shape=nav_shape[::-1], step_sizes=step_sizes
         )
-        with pytest.raises(ValueError, match="The crystal map shape"):
+
+        with pytest.raises(ValueError, match="The `xmap` shape"):
             s.xmap = xmap_bad
-        with pytest.raises(ValueError, match="The crystal map shape"):
-            s.axes_manager["x"].scale = 2
+
+        s.axes_manager["x"].scale = 2
+        with pytest.warns(UserWarning, match="The `xmap` step size"):
             s.xmap = xmap_good
-        with pytest.raises(ValueError, match="The crystal map shape"):
-            s.axes_manager["x"].scale = 1
-            s.axes_manager["x"].name = "x2"
+
+        s2 = s.inav[:, :-2]
+        with pytest.raises(ValueError, match="The `xmap` shape"):
+            s2.axes_manager["x"].scale = 1
+            s2.axes_manager["x"].name = "x2"
             with pytest.warns(UserWarning, match="The signal navigation axes"):
-                s.xmap = xmap_good
+                s2.xmap = xmap_good
 
     def test_attribute_carry_over_from_deepcopy(self, get_single_phase_xmap):
         s = kp.data.nickel_ebsd_small(lazy=True)
@@ -1836,7 +1840,7 @@ class TestEBSDRefinement:
         assert detector_refined.pc.shape == nav_shape + (3,)
 
     @pytest.mark.filterwarnings("ignore: The line search algorithm did not converge")
-    @pytest.mark.filterwarnings("ignore: Angles are assumed to be in radians, ")
+    #    @pytest.mark.filterwarnings("ignore: Angles are assumed to be in radians, ")
     @pytest.mark.parametrize(
         "method, method_kwargs",
         [

--- a/kikuchipy/signals/util/_crystal_map.py
+++ b/kikuchipy/signals/util/_crystal_map.py
@@ -32,25 +32,28 @@ def _crystal_map_is_compatible_with_signal(
     crystal map.
     """
     nav_shape = tuple([a.size for a in navigation_axes])
-    nav_scale = tuple([a.scale for a in navigation_axes])
+    nav_scale = list([a.scale for a in navigation_axes])
 
     try:
-        xmap_scale = tuple([xmap._step_sizes[a.name] for a in navigation_axes])
+        xmap_scale = list([xmap._step_sizes[a.name] for a in navigation_axes])
     except KeyError:
         warnings.warn(
             "The signal navigation axes must be named 'x' and/or 'y' in order to "
             "compare the signal navigation scale to the CrystalMap step sizes 'dx' and "
             "'dy' (see `EBSD.axes_manager`)"
         )
-        xmap_scale = list(xmap._step_sizes.values())[: -len(nav_shape)]
+        xmap_scale = list(xmap._step_sizes.values())[-len(navigation_axes) :]
 
-    compatible = xmap.shape == nav_shape and np.allclose(
-        xmap_scale, nav_scale, atol=1e-6
-    )
+    compatible = xmap.shape == nav_shape
+    if compatible and not np.allclose(xmap_scale, nav_scale, atol=1e-6):
+        warnings.warn(
+            f"The `xmap` step size(s) {xmap_scale} are different from the signal's "
+            f"step size(s) {nav_scale} (see `EBSD.axes_manager`)"
+        )
     if not compatible and raise_if_not:
         raise ValueError(
-            f"The crystal map shape {xmap.shape} and step sizes {xmap_scale} aren't "
-            f"compatible with the signal navigation shape {nav_shape} and step sizes "
+            f"The `xmap` shape {xmap.shape} and step size(s) {xmap_scale} are not "
+            f"compatible with the signal navigation shape {nav_shape} and step size(s) "
             f"{nav_scale} (see `EBSD.axes_manager`)"
         )
     else:


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Addresses #526 by making an error into a warning.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
# Setup
>>> import kikuchipy as kp
>>> from orix import sampling
>>> s = kp.data.nickel_ebsd_large(lazy=True)
>>> s = s.inav[:13, 0]
>>> s.remove_static_background()
>>> s.remove_dynamic_background()
>>> s.compute()
>>> mp = kp.data.nickel_ebsd_master_pattern_small(projection="lambert")
>>> rot = sampling.get_sample_fundamental(3, point_group=mp.phase.point_group)
>>> detector = kp.detectors.EBSDDetector(
>>>     shape=s.axes_manager.signal_shape[::-1],
>>>     pc=[0.421, 0.7794, 0.5049],
>>>     sample_tilt=70,
>>>     convention="edax",
>>> )

# "Mess up" axes manager
>>> s.axes_manager[0].name = ""
>>> s.axes_manager[0].scale = 1

# Index
>>> sim = mp.get_patterns(rotations=rot, detector=detector, energy=20)
>>> xmap = s.dictionary_indexing(sim)

# Refine
>>> xmap_ref = s.refine_orientation(
>>>     xmap=xmap,
>>>     detector=detector,
>>>     master_pattern=mp,
>>>     energy=20,
>>> )
/home/hakon/kode/kikuchipy/kikuchipy/signals/util/_crystal_map.py:40: UserWarning: The signal navigation axes must be named 'x' and/or 'y' in order to compare the signal navigation scale to the CrystalMap step sizes 'dx' and 'dy' (see `EBSD.axes_manager`)
  warnings.warn(
/home/hakon/kode/kikuchipy/kikuchipy/signals/util/_crystal_map.py:49: UserWarning: The `xmap` step size(s) [1.5] are different from the signal's step size(s) [1.0] (see `EBSD.axes_manager`)
  warnings.warn(
```

The second warning was previously an error.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
