### PR TITLE
Improve control of memory use in EBSD neighbour pattern averaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Added
 
 Changed
 -------
+- Chunking of EBSD signal navigation dimensions in
+  ``EBSD.average_neighbour_patterns()`` to reduce memory use.
+  (`#532 <https://github.com/pyxem/kikuchipy/pull/532>`_)
 - Remove requirement that the crystal map used for EBSD refinement has identical step
   size(s) to the EBSD signal's navigation axes. This raised an error previously, but now
   only emits a warning. (`#531 <https://github.com/pyxem/kikuchipy/pull/531>`_)

--- a/doc/user_guide/pattern_matching.ipynb
+++ b/doc/user_guide/pattern_matching.ipynb
@@ -118,10 +118,10 @@
      "text": [
       "Removing the static background:\n",
       "[########################################] | 100% Completed |  0.1s\n",
-      "[########################################] | 100% Completed |  0.1s\n",
+      "[########################################] | 100% Completed |  0.2s\n",
       "Removing the dynamic background:\n",
       "[########################################] | 100% Completed |  0.1s\n",
-      "[########################################] | 100% Completed |  0.6s\n"
+      "[########################################] | 100% Completed |  0.8s\n"
      ]
     }
    ],
@@ -227,7 +227,7 @@
     {
      "data": {
       "text/plain": [
-       "<name: ni. space group: Fm-3m. point group: m-3m. proper point group: 432. color: tab:blue>"
+       "<name: ni/ni. space group: Fm-3m. point group: m-3m. proper point group: 432. color: tab:blue>"
       ]
      },
      "execution_count": 6,
@@ -465,15 +465,7 @@
      "output_type": "stream",
      "text": [
       "Creating a dictionary of (30443,) simulated patterns:\n",
-      "[########################################] | 100% Completed |  3.2s\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/hakon/miniconda3/envs/kp-dev/lib/python3.9/site-packages/hyperspy/signal.py:2451: UserWarning: Setting the `metadata` attribute is deprecated and will be removed in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods of the `metadata` attribute instead.\n",
-      "  warnings.warn(\n"
+      "[########################################] | 100% Completed |  3.7s\n"
      ]
     },
     {
@@ -603,7 +595,7 @@
      "output_type": "stream",
      "text": [
       "Dictionary indexing information:\n",
-      "\tPhase name: ni\n",
+      "\tPhase name: ni/ni\n",
       "\tMatching 4125 experimental pattern(s) to 30443 dictionary pattern(s)\n",
       "\tNormalizedCrossCorrelationMetric: float32, greater is better, rechunk: False, signal mask: True\n"
      ]
@@ -612,21 +604,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:13<00:00,  1.24s/it]\n"
+      "100%|████████████████████████████████████████████████████████████████████| 11/11 [00:29<00:00,  2.70s/it]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\tIndexing speed: 301 patterns/s, 9177425 comparisons/s\n"
+      "\tIndexing speed: 138 patterns/s, 4221449 comparisons/s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Phase   Orientations  Name  Space group  Point group  Proper point group     Color\n",
-       "    0  4125 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue\n",
+       "Phase   Orientations   Name  Space group  Point group  Proper point group     Color\n",
+       "    0  4125 (100.0%)  ni/ni        Fm-3m         m-3m                 432  tab:blue\n",
        "Properties: scores, simulation_indices\n",
        "Scan unit: px"
       ]
@@ -901,14 +893,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/hakon/miniconda3/envs/kp-dev/lib/python3.9/site-packages/hyperspy/signal.py:2451: UserWarning: Setting the `metadata` attribute is deprecated and will be removed in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods of the `metadata` attribute instead.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "<EBSD, title: , dimensions: (75, 55|60, 60)>"
@@ -1073,8 +1057,8 @@
       "\tLocal optimization method: Nelder-Mead (minimize)\n",
       "\tKeyword arguments passed to method: {'method': 'Nelder-Mead', 'options': {'fatol': 0.0001}}\n",
       "Refining 4125 orientation(s):\n",
-      "[########################################] | 100% Completed |  1min  9.7s\n",
-      "Refinement speed: 59 patterns/s\n"
+      "[########################################] | 100% Completed |  1min 27.2s\n",
+      "Refinement speed: 47 patterns/s\n"
      ]
     }
    ],
@@ -1303,8 +1287,8 @@
      "output_type": "stream",
      "text": [
       "Refining 4125 projection center(s):\n",
-      "[########################################] | 100% Completed |  1min 20.3s\n",
-      "Refinement speed: 51 patterns/s\n"
+      "[########################################] | 100% Completed |  1min 23.9s\n",
+      "Refinement speed: 49 patterns/s\n"
      ]
     }
    ],
@@ -1509,8 +1493,8 @@
     {
      "data": {
       "text/plain": [
-       "Phase  Orientations  Name  Space group  Point group  Proper point group     Color\n",
-       "    0  999 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue\n",
+       "Phase  Orientations   Name  Space group  Point group  Proper point group     Color\n",
+       "    0  999 (100.0%)  ni/ni        Fm-3m         m-3m                 432  tab:blue\n",
        "Properties: scores, simulation_indices\n",
        "Scan unit: um"
       ]
@@ -1538,8 +1522,8 @@
       "\tLocal optimization method: Nelder-Mead (minimize)\n",
       "\tKeyword arguments passed to method: {'options': {'fatol': 0.001}, 'method': 'Nelder-Mead'}\n",
       "Refining 999 orientation(s) and projection center(s):\n",
-      "[########################################] | 100% Completed |  1min 25.4s\n",
-      "Refinement speed: 11 patterns/s\n"
+      "[########################################] | 100% Completed |  1min 32.5s\n",
+      "Refinement speed: 10 patterns/s\n"
      ]
     }
    ],
@@ -1563,8 +1547,8 @@
     {
      "data": {
       "text/plain": [
-       "Phase  Orientations  Name  Space group  Point group  Proper point group     Color\n",
-       "    0  999 (100.0%)    ni        Fm-3m         m-3m                 432  tab:blue\n",
+       "Phase  Orientations   Name  Space group  Point group  Proper point group     Color\n",
+       "    0  999 (100.0%)  ni/ni        Fm-3m         m-3m                 432  tab:blue\n",
        "Properties: scores\n",
        "Scan unit: um"
       ]
@@ -1750,7 +1734,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/kikuchipy/pattern/_pattern.py
+++ b/kikuchipy/pattern/_pattern.py
@@ -17,7 +17,7 @@
 
 from typing import Callable, List, Optional, Tuple, Union
 
-import numba as nb
+from numba import njit
 import numpy as np
 from scipy.ndimage import gaussian_filter
 from scipy.fft import fft2, rfft2, ifft2, irfft2, fftshift, ifftshift
@@ -85,7 +85,7 @@ def rescale_intensity(
     return _rescale_with_min_max(pattern, imin, imax, omin, omax).astype(dtype_out)
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _rescale_with_min_max(
     pattern: np.ndarray,
     imin: Union[int, float],
@@ -103,7 +103,7 @@ def _rescale_with_min_max(
     return rescaled_pattern * (omax - omin) + omin
 
 
-@nb.njit("float32[:, :](float32[:, :])", cache=True, nogil=True, fastmath=True)
+@njit("float32[:, :](float32[:, :])", cache=True, nogil=True, fastmath=True)
 def _rescale_without_min_max(pattern: np.ndarray) -> np.ndarray:
     """Rescale a pattern to the intensity range [-1, 1].
 
@@ -126,7 +126,7 @@ def _normalize(patterns: np.ndarray, axis: Union[int, tuple]) -> np.ndarray:
     return patterns / patterns_norm_squared
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def normalize_intensity(
     pattern: np.ndarray, num_std: int = 1, divide_by_square_root: bool = False
 ) -> np.ndarray:
@@ -302,7 +302,7 @@ def fft_filter(
     return np.real(ifft(filtered_fft, shift=shift))
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def fft_spectrum(fft_pattern: np.ndarray) -> np.ndarray:
     """Compute the FFT spectrum of a Fourier transformed EBSD pattern.
 
@@ -346,7 +346,7 @@ def fft_frequency_vectors(shape: Tuple[int, int]) -> np.ndarray:
     return frequency_vectors
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _remove_static_background_subtract(
     pattern: np.ndarray,
     static_bg: np.ndarray,
@@ -369,7 +369,7 @@ def _remove_static_background_subtract(
     return pattern.astype(dtype_out)
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _remove_static_background_divide(
     pattern: np.ndarray,
     static_bg: np.ndarray,
@@ -437,7 +437,7 @@ def _remove_dynamic_background(
     return pattern.astype(dtype_out)
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _remove_background_subtract(
     pattern: np.ndarray,
     background: np.ndarray,
@@ -451,7 +451,7 @@ def _remove_background_subtract(
     return _rescale_with_min_max(pattern, imin, imax, omin, omax)
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _remove_background_divide(
     pattern: np.ndarray,
     background: np.ndarray,
@@ -699,6 +699,7 @@ def _get_image_quality(
     frequency_vectors: np.ndarray,
     inertia_max: float,
 ) -> float:
+    """See docstring of :func:`get_image_quality`."""
     pattern = pattern.astype(np.float32)
 
     if normalize:
@@ -711,7 +712,7 @@ def _get_image_quality(
     return _get_image_quality_numba(fft_pattern, frequency_vectors, inertia_max)
 
 
-@nb.njit(cache=True, fastmath=True, nogil=True)
+@njit(cache=True, fastmath=True, nogil=True)
 def _get_image_quality_numba(
     fft_pattern: np.ndarray, frequency_vectors: np.ndarray, inertia_max: float
 ) -> float:

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -556,18 +556,18 @@ class TestAverageNeighbourPatternsEBSD:
                 (3, 3),
                 False,
                 # fmt: off
-                # Ten numbers per line
+                # One pattern per line
                 np.array(
                     [
-                        255, 109, 218, 218, 36, 236, 255, 36, 0, 143,
-                        111, 255, 159, 0, 207, 159, 63, 175, 136, 118,
-                        33, 118, 0, 255, 153, 118, 102, 182, 24, 255,
-                        121, 109, 85, 133, 0, 12, 254, 107, 228, 80,
-                        40, 107, 161, 147, 0, 204, 0, 51, 51, 51,
-                        229, 25, 76, 255, 195, 104, 255, 134, 150, 59,
-                        104, 120, 0, 204, 102, 255, 89, 127, 0, 12,
-                        140, 127, 255, 185, 0, 69, 162, 46, 0, 208,
-                        0
+                        255, 109, 218, 218, 36, 236, 255, 36, 0,
+                        143, 111, 255, 159, 0, 207, 159, 63, 175,
+                        135, 119, 34, 119, 0, 255, 153, 119, 102,
+                        182, 24, 255, 121, 109, 85, 133, 0, 12,
+                        255, 107, 228, 80, 40, 107, 161, 147, 0,
+                        204, 0, 51, 51, 51, 229, 25, 76, 255,
+                        194, 105, 255, 135, 149, 60, 105, 119, 0,
+                        204, 102, 255, 89, 127, 0, 12, 140, 127,
+                        255, 185, 0, 69, 162, 46, 0, 208, 0
                     ],
                 ),
                 # fmt: on
@@ -578,17 +578,18 @@ class TestAverageNeighbourPatternsEBSD:
                 (2, 3),
                 False,
                 # fmt: off
+                # One pattern per line
                 np.array(
                     [
-                        255, 223, 223, 255, 0, 223, 255, 63, 0, 109,
-                        145, 145, 200, 0, 255, 163, 54, 127, 119, 136,
-                        153, 170, 0, 255, 153, 136, 221, 212, 42, 255,
-                        127, 0, 141, 184, 14, 28, 210, 44, 179, 134,
-                        0, 255, 210, 14, 29, 200, 109, 182, 109, 0,
-                        255, 182, 145, 182, 150, 34, 255, 57, 81, 0,
-                        57, 69, 11, 255, 38, 191, 63, 114, 38, 50,
-                        89, 0, 255, 117, 137, 19, 117, 0, 0, 176,
-                        58
+                        255, 223, 223, 255, 0, 223, 255, 63, 0,
+                        109, 145, 145, 200, 0, 255, 163, 54, 127,
+                        119, 136, 153, 170, 0, 255, 153, 136, 221,
+                        212, 42, 255, 127, 0, 141, 184, 14, 28,
+                        210, 45, 180, 135, 0, 255, 210, 15, 30,
+                        200, 109, 182, 109, 0, 255, 182, 145, 182,
+                        150, 34, 255, 57, 81, 0, 57, 69, 11,
+                        255, 38, 191, 63, 114, 38, 51, 89, 0,
+                        255, 117, 137, 19, 117, 0, 0, 176, 58
                     ],
                 ),
                 # fmt: on
@@ -599,17 +600,18 @@ class TestAverageNeighbourPatternsEBSD:
                 (3, 3),
                 True,
                 # fmt: off
+                # one pattern per line
                 np.array(
                     [
-                        218, 46, 255, 139, 0, 150, 194, 3, 11, 211,
-                        63, 196, 145, 0, 255, 211, 33, 55, 175, 105,
-                        155, 110, 0, 255, 169, 135, 177, 184, 72, 255,
-                        112, 59, 62, 115, 55, 0, 255, 51, 225, 107,
-                        21, 122, 85, 47, 0, 254, 129, 152, 77, 0,
-                        169, 48, 187, 170, 153, 36, 255, 63, 86, 0,
-                        57, 69, 4, 255, 45, 206, 58, 115, 16, 33,
-                        98, 0, 255, 121, 117, 32, 121, 14, 0, 174,
-                        66
+                        218, 46, 255, 139, 0, 150, 194, 3, 11,
+                        211, 63, 196, 145, 0, 255, 211, 33, 55,
+                        175, 105, 155, 110, 0, 255, 169, 135, 177,
+                        184, 72, 255, 112, 59, 62, 115, 55, 0,
+                        255, 51, 225, 107, 21, 122, 85, 47, 0,
+                        255, 129, 152, 77, 0, 169, 48, 187, 170,
+                        153, 36, 255, 63, 86, 0, 57, 69, 4,
+                        254, 45, 206, 58, 115, 16, 33, 98, 0,
+                        255, 121, 117, 32, 121, 14, 0, 174, 66
                     ],
                 ),
                 # fmt: on
@@ -630,6 +632,11 @@ class TestAverageNeighbourPatternsEBSD:
             dummy_signal.average_neighbour_patterns(
                 window=window, window_shape=window_shape, **kwargs
             )
+
+        d = dummy_signal.data
+        if lazy:
+            d = d.compute()
+        print(d)
 
         answer = answer.reshape((3, 3, 3, 3)).astype(np.uint8)
         assert np.allclose(dummy_signal.data, answer)
@@ -662,14 +669,18 @@ class TestAverageNeighbourPatternsEBSD:
     def test_average_neighbour_patterns_window_1d(self, dummy_signal):
         dummy_signal.average_neighbour_patterns(window_shape=(3,))
         # fmt: off
+        # One pattern per line
         answer = np.array(
             [
-                233, 106, 212, 233, 170, 233, 255, 21, 0, 191, 95, 255, 95, 0,
-                111, 143, 127, 159, 98, 117, 0, 117, 117, 255, 137, 117, 117,
-                239, 95, 255, 223, 191, 175, 207, 31, 0, 155, 127, 255, 56, 0,
-                14, 70, 155, 84, 175, 111, 0, 143, 127, 255, 95, 127, 191, 231,
-                0, 255, 162, 139, 139, 162, 23, 0, 135, 135, 255, 60, 105, 0,
-                60, 165, 105, 255, 127, 0, 127, 163, 182, 109, 145, 109
+                233, 106, 212, 233, 170, 233, 255, 21, 0,
+                191, 95, 255, 95, 0, 111, 143, 127, 159,
+                98, 117, 0, 117, 117, 255, 137, 117, 117,
+                239, 95, 255, 223, 191, 175, 207, 31, 0,
+                155, 127, 255, 56, 0, 14, 70, 155, 85,
+                175, 111, 0, 143, 127, 255, 95, 127, 191,
+                231, 0, 255, 162, 139, 139, 162, 23, 0,
+                135, 135, 255, 60, 105, 0, 60, 165, 105,
+                255, 127, 0, 127, 163, 182, 109, 145, 109
             ],
             dtype=np.uint8
         ).reshape(dummy_signal.axes_manager.shape)
@@ -681,15 +692,18 @@ class TestAverageNeighbourPatternsEBSD:
         w = kp.filters.Window()
         dummy_signal.average_neighbour_patterns(w)
         # fmt: off
-        # 15 numbers on each line
+        # One pattern per line
         answer = np.array(
             [
-                255, 109, 218, 218, 36, 236, 255, 36, 0, 143, 111, 255, 159, 0, 207,
-                159, 63, 175, 136, 118, 33, 118, 0, 255, 153, 118, 102, 182, 24, 255,
-                121, 109, 85, 133, 0, 12, 254, 107, 228, 80, 40, 107, 161, 147, 0,
-                204, 0, 51, 51, 51, 229, 25, 76, 255, 195, 104, 255, 134, 150, 59,
-                104, 120, 0, 204, 102, 255, 89, 127, 0, 12, 140, 127, 255, 185, 0,
-                69, 162, 46, 0, 208, 0
+                255, 109, 218, 218, 36, 236, 255, 36, 0,
+                143, 111, 255, 159, 0, 207, 159, 63, 175,
+                135, 119, 34, 119, 0, 255, 153, 119, 102,
+                182, 24, 255, 121, 109, 85, 133, 0, 12,
+                255, 107, 228, 80, 40, 107, 161, 147, 0,
+                204, 0, 51, 51, 51, 229, 25, 76, 255,
+                194, 105, 255, 135, 149, 60, 105, 119, 0,
+                204, 102, 255, 89, 127, 0, 12, 140, 127,
+                255, 185, 0, 69, 162, 46, 0, 208, 0
             ],
             dtype=np.uint8
         ).reshape(dummy_signal.axes_manager.shape)
@@ -703,6 +717,42 @@ class TestAverageNeighbourPatternsEBSD:
         s = kp.signals.LazyEBSD(da.zeros((55, 75, 6, 6), chunks=chunks, dtype=np.uint8))
         s.average_neighbour_patterns()
         s.compute()
+
+    def test_average_neighbour_patterns_control(self):
+        """Compare averaged array to array built up manually.
+
+        Also test Numba function directly.
+        """
+        shape = (3, 3, 3, 3)
+        data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+        # Reference
+        data_desired = np.zeros_like(data)
+        window_sums = np.array([[3, 4, 3], [4, 5, 4], [3, 4, 3]])
+        for i in range(shape[0]):
+            for j in range(shape[1]):
+                p = np.zeros(shape[2:], dtype=data.dtype)
+                for k in [(i - 1, j), (i, j), (i + 1, j), (i, j - 1), (i, j + 1)]:
+                    if -1 not in k and 3 not in k:
+                        p += data[k]
+                p /= window_sums[i, j]
+                data_desired[i, j] = kp.pattern.rescale_intensity(p)
+
+        # Averaging
+        s = kp.signals.EBSD(data)
+        s.average_neighbour_patterns()
+
+        assert np.allclose(s.data, data_desired)
+
+        # Test Numba function
+        window = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])[:, :, None, None]
+        correlated_patterns = correlate(data, weights=window, mode="constant", cval=0)
+        rescaled_patterns = (
+            kp.pattern.chunk._rescale_neighbour_averaged_patterns.py_func(
+                correlated_patterns, window_sums, correlated_patterns.dtype, -1, 1
+            )
+        )
+        assert np.allclose(rescaled_patterns, s.data)
 
 
 class TestVirtualBackscatterElectronImaging:


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Addresses #501 by smarter chunking of the EBSD navigation axes (smaller chunks) before neighbour pattern averaging.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
