### PR TITLE
Deprecate instead of removing three chunk processing functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,15 +44,20 @@ Changed
 - Restrict minimal version of SciPy to 1.7.
   (`#504 <https://github.com/pyxem/kikuchipy/pull/504>`_)
 
+Deprecated
+----------
+- The following functions for processing of pattern chunks in the
+  ``kikuchipy.pattern.chunk`` module are deprecated in 0.6 and will be removed in 0.7:
+  ``get_image_quality()``, ``remove_dynamic_background()`` and
+  ``remove_static_background()``. Use the ``EBSD`` class for processing of many
+  patterns. (`#527 <https://github.com/pyxem/kikuchipy/pull/527>`_,
+  `#533 <https://github.com/pyxem/kikuchipy/pull/533>`_  )
+
 Removed
 -------
 - The ``relative`` parameter in ``kikuchipy.signals.EBSD.remove_static_background()``.
   The parameter is accepted but not used. Passing it after this release will result in
   an error. (`#527 <https://github.com/pyxem/kikuchipy/pull/527>`_)
-- The following functions for processing of pattern chunks in the
-  ``kikuchipy.pattern.chunk`` module: ``get_image_quality()``,
-  ``remove_dynamic_background()`` and ``remove_static_background()``.
-  (`#527 <https://github.com/pyxem/kikuchipy/pull/527>`_)
 
 Fixed
 -----

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -397,6 +397,7 @@ Single and chunk pattern processing used by signals.
     ifft
     normalize_intensity
     remove_dynamic_background
+    remove_static_background
     rescale_intensity
 
 Functions operating on single EBSD patterns as :class:`~numpy.ndarray`.
@@ -418,7 +419,10 @@ of EBSD patterns.
     average_neighbour_patterns
     fft_filter
     get_dynamic_background
+    get_image_quality
     normalize_intensity
+    remove_dynamic_background
+    remove_static_background
     rescale_intensity
 
 .. automodule:: kikuchipy.pattern.chunk

--- a/kikuchipy/pattern/chunk.py
+++ b/kikuchipy/pattern/chunk.py
@@ -32,11 +32,13 @@ from numba import njit
 import numpy as np
 from scipy.ndimage import correlate, gaussian_filter
 from skimage.exposure import equalize_adapthist
+from skimage.util.dtype import dtype_range
 
 import kikuchipy.pattern._pattern as pattern_processing
 import kikuchipy.filters.fft_barnes as barnes
 from kikuchipy.filters.window import Window
 from kikuchipy.pattern._pattern import _rescale_with_min_max
+from kikuchipy._util import deprecated
 
 
 def rescale_intensity(
@@ -95,6 +97,88 @@ def rescale_intensity(
     return rescaled_patterns
 
 
+@deprecated(
+    since=0.6,
+    removal=0.7,
+    alternative="kikuchipy.signals.EBSD.remove_static_background",
+)
+def remove_static_background(
+    patterns: Union[np.ndarray, da.Array],
+    static_bg: Union[np.ndarray, da.Array],
+    operation_func: Union[np.subtract, np.divide],
+    scale_bg: bool = False,
+    in_range: Union[None, Tuple[int, int], Tuple[float, float]] = None,
+    out_range: Union[None, Tuple[int, int], Tuple[float, float]] = None,
+    dtype_out: Union[None, np.dtype, Tuple[int, int], Tuple[float, float]] = None,
+) -> np.ndarray:
+    """Remove the static background in a chunk of EBSD patterns.
+    Removal is performed by subtracting or dividing by a static
+    background pattern. Resulting pattern intensities are rescaled
+    keeping relative intensities or not and stretched to fill the
+    available grey levels in the patterns' data type range.
+    Parameters
+    ----------
+    patterns
+        EBSD patterns.
+    static_bg
+        Static background pattern. If None is passed (default) we try to
+        read it from the signal metadata.
+    operation_func
+        Function to subtract or divide by the dynamic background
+        pattern.
+    scale_bg
+        Whether to scale the static background pattern to each
+        individual pattern's data range before removal (default is
+        False).
+    in_range
+        Min./max. intensity values of input and output patterns. If None
+        (default), it is set to the overall pattern min./max, losing
+        relative intensities between patterns.
+    out_range
+        Min./max. intensity values of the output patterns. If None
+        (default), `out_range` is set to `dtype_out` min./max according
+        to `skimage.util.dtype.dtype_range`.
+    dtype_out
+        Data type of corrected patterns. If None (default), it is set to
+        input patterns' data type.
+    Returns
+    -------
+    corrected_patterns : numpy.ndarray
+        Patterns with the static background removed.
+    """
+    if dtype_out is None:
+        dtype_out = patterns.dtype.type
+
+    if out_range is None:
+        out_range = dtype_range[dtype_out]
+
+    corrected_patterns = np.empty_like(patterns, dtype=dtype_out)
+
+    for nav_idx in np.ndindex(patterns.shape[:-2]):
+        # Get pattern
+        pattern = patterns[nav_idx]
+
+        # Scale background
+        new_static_bg = static_bg
+        if scale_bg:
+            new_static_bg = pattern_processing.rescale_intensity(
+                pattern=static_bg, out_range=(np.min(pattern), np.max(pattern))
+            )
+
+        # Remove the static background
+        corrected_pattern = operation_func(pattern, new_static_bg)
+
+        # Rescale the intensities
+        corrected_patterns[nav_idx] = pattern_processing.rescale_intensity(
+            pattern=corrected_pattern,
+            in_range=in_range,
+            out_range=out_range,
+            dtype_out=dtype_out,
+        )
+
+    return corrected_patterns
+
+
 def get_dynamic_background(
     patterns: Union[np.ndarray, da.Array],
     filter_func: Union[gaussian_filter, barnes.fft_filter],
@@ -133,6 +217,138 @@ def get_dynamic_background(
         background[nav_idx] = filter_func(patterns[nav_idx], **kwargs)
 
     return background
+
+
+@deprecated(
+    since=0.6,
+    removal=0.7,
+    alternative="kikuchipy.signals.EBSD.remove_dynamic_background",
+)
+def remove_dynamic_background(
+    patterns: Union[np.ndarray, da.Array],
+    filter_func: Union[gaussian_filter, barnes.fft_filter],
+    operation_func: Union[np.subtract, np.divide],
+    out_range: Union[None, Tuple[int, int], Tuple[float, float]] = None,
+    dtype_out: Union[None, np.dtype, Tuple[int, int], Tuple[float, float]] = None,
+    **kwargs,
+) -> np.ndarray:
+    """Correct the dynamic background in a chunk of EBSD patterns.
+    The correction is performed by subtracting or dividing by a Gaussian
+    blurred version of each pattern. Returned pattern intensities are
+    rescaled to fill the input data type range.
+    Parameters
+    ----------
+    patterns
+        EBSD patterns.
+    filter_func
+        Function where a Gaussian convolution filter is applied, in the
+        frequency or spatial domain. Either
+        :func:`scipy.ndimage.gaussian_filter` or
+        :func:`kikuchipy.util.barnes_fftfilter.fft_filter`.
+    operation_func
+        Function to subtract or divide by the dynamic background
+        pattern.
+    out_range
+        Min./max. intensity values of the output patterns. If None
+        (default), `out_range` is set to `dtype_out` min./max according
+        to `skimage.util.dtype.dtype_range`.
+    dtype_out
+        Data type of corrected patterns. If None (default), it is set to
+        input patterns' data type.
+    kwargs :
+        Keyword arguments passed to the Gaussian blurring function
+        passed to `filter_func`.
+    Returns
+    -------
+    corrected_patterns : numpy.ndarray
+        Dynamic background corrected patterns.
+    See Also
+    --------
+    kikuchipy.signals.ebsd.EBSD.remove_dynamic_background
+    kikuchipy.util.pattern.remove_dynamic_background
+    """
+    if dtype_out is None:
+        dtype_out = patterns.dtype.type
+
+    if out_range is None:
+        out_range = dtype_range[dtype_out]
+
+    corrected_patterns = np.empty_like(patterns, dtype=dtype_out)
+
+    for nav_idx in np.ndindex(patterns.shape[:-2]):
+        # Get pattern
+        pattern = patterns[nav_idx]
+
+        # Get dynamic background by Gaussian filtering in frequency or
+        # spatial domain
+        dynamic_bg = filter_func(pattern, **kwargs)
+
+        # Remove dynamic background
+        corrected_pattern = operation_func(pattern, dynamic_bg)
+
+        # Rescale intensities
+        corrected_patterns[nav_idx] = pattern_processing.rescale_intensity(
+            pattern=corrected_pattern,
+            out_range=out_range,
+            dtype_out=dtype_out,
+        )
+
+    return corrected_patterns
+
+
+@deprecated(
+    since=0.6, removal=0.7, alternative="kikuchipy.signals.EBSD.get_image_quality"
+)
+def get_image_quality(
+    patterns: Union[np.ndarray, da.Array],
+    frequency_vectors: Optional[np.ndarray] = None,
+    inertia_max: Union[None, int, float] = None,
+    normalize: bool = True,
+) -> np.ndarray:
+    """Compute the image quality in a chunk of EBSD patterns.
+    The image quality is calculated based on the procedure defined by
+    Krieger Lassen [Lassen1994]_.
+    Parameters
+    ----------
+    patterns
+        EBSD patterns.
+    frequency_vectors
+        Integer 2D array with values corresponding to the weight given
+        each FFT spectrum frequency component. If None (default), these
+        are calculated from
+        :func:`~kikuchipy.util.pattern.fft_frequency_vectors`.
+    inertia_max
+        Maximum inertia of the FFT power spectrum of the image. If None
+        (default), this is calculated from the `frequency_vectors`.
+    normalize
+        Whether to normalize patterns to a mean of zero and standard
+        deviation of 1 before calculating the image quality. Default
+        is True.
+    Returns
+    -------
+    image_quality_chunk : numpy.ndarray
+        Image quality of patterns.
+    """
+    dtype_out = np.float64
+
+    image_quality_chunk = np.empty(patterns.shape[:-2], dtype=dtype_out)
+
+    for nav_idx in np.ndindex(patterns.shape[:-2]):
+        # Get (normalized) pattern
+        if normalize:
+            pattern = pattern_processing.normalize_intensity(pattern=patterns[nav_idx])
+        else:
+            pattern = patterns[nav_idx]
+
+        # Compute image quality
+        image_quality_chunk[nav_idx] = pattern_processing.get_image_quality(
+            pattern=pattern,
+            normalize=False,
+            frequency_vectors=frequency_vectors,
+            inertia_max=inertia_max,
+        )
+
+    return image_quality_chunk
 
 
 def adaptive_histogram_equalization(

--- a/kikuchipy/pattern/chunk.py
+++ b/kikuchipy/pattern/chunk.py
@@ -112,10 +112,12 @@ def remove_static_background(
     dtype_out: Union[None, np.dtype, Tuple[int, int], Tuple[float, float]] = None,
 ) -> np.ndarray:
     """Remove the static background in a chunk of EBSD patterns.
+
     Removal is performed by subtracting or dividing by a static
     background pattern. Resulting pattern intensities are rescaled
     keeping relative intensities or not and stretched to fill the
     available grey levels in the patterns' data type range.
+
     Parameters
     ----------
     patterns
@@ -141,6 +143,7 @@ def remove_static_background(
     dtype_out
         Data type of corrected patterns. If None (default), it is set to
         input patterns' data type.
+
     Returns
     -------
     corrected_patterns : numpy.ndarray
@@ -233,9 +236,11 @@ def remove_dynamic_background(
     **kwargs,
 ) -> np.ndarray:
     """Correct the dynamic background in a chunk of EBSD patterns.
+
     The correction is performed by subtracting or dividing by a Gaussian
     blurred version of each pattern. Returned pattern intensities are
     rescaled to fill the input data type range.
+
     Parameters
     ----------
     patterns
@@ -258,10 +263,12 @@ def remove_dynamic_background(
     kwargs :
         Keyword arguments passed to the Gaussian blurring function
         passed to `filter_func`.
+
     Returns
     -------
     corrected_patterns : numpy.ndarray
         Dynamic background corrected patterns.
+
     See Also
     --------
     kikuchipy.signals.ebsd.EBSD.remove_dynamic_background
@@ -306,8 +313,10 @@ def get_image_quality(
     normalize: bool = True,
 ) -> np.ndarray:
     """Compute the image quality in a chunk of EBSD patterns.
+
     The image quality is calculated based on the procedure defined by
     Krieger Lassen [Lassen1994]_.
+
     Parameters
     ----------
     patterns
@@ -324,6 +333,7 @@ def get_image_quality(
         Whether to normalize patterns to a mean of zero and standard
         deviation of 1 before calculating the image quality. Default
         is True.
+
     Returns
     -------
     image_quality_chunk : numpy.ndarray

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 from scipy.ndimage import convolve, gaussian_filter
 from skimage import __version__ as skimage_version
+from skimage.util.dtype import dtype_range
 
 from kikuchipy.filters.fft_barnes import _fft_filter
 from kikuchipy.filters.window import Window
@@ -35,6 +36,35 @@ from kikuchipy.signals.util._dask import get_dask_array
 
 
 # Expected output intensities from various image processing methods
+STATIC_SUB_UINT8 = np.array(
+    [[127, 212, 127], [255, 255, 170], [212, 0, 0]], dtype=np.uint8
+)
+STATIC_SUB_SCALEBG_UINT8 = np.array(
+    [[15, 150, 15], [180, 255, 120], [150, 0, 75]], dtype=np.uint8
+)
+STATIC_DIV_UINT8 = np.array(
+    [[127, 191, 127], [223, 255, 159], [191, 31, 0]], dtype=np.uint8
+)
+DYN_CORR_UINT8_SPATIAL_STD2 = np.array(
+    [[170, 215, 181], [255, 221, 188], [221, 32, 0]], dtype=np.uint8
+)
+DYN_CORR_UINT8_SPATIAL_STD1 = np.array(
+    [[120, 197, 156], [255, 241, 223], [226, 0, 9]], dtype=np.uint8
+)
+DYN_CORR_UINT8_FREQUENCY_STD1_TRUNCATE3 = np.array(
+    [[111, 191, 141], [255, 253, 243], [221, 0, 38]], dtype=np.uint8
+)
+DYN_CORR_UINT8_FREQUENCY_STD2_TRUNCATE4 = np.array(
+    [[159, 214, 179], [255, 227, 201], [216, 14, 0]], dtype=np.uint8
+)
+DYN_CORR_UINT16_SPATIAL_STD2 = np.array(
+    [[43928, 55293, 46544], [65535, 56974, 48412], [56975, 8374, 0]],
+    dtype=np.uint16,
+)
+DYN_CORR_UINT8_SPATIAL_STD2_OMAX250 = np.array(
+    [[167, 210, 177], [250, 217, 184], [217, 31, 0]],
+    dtype=np.uint8,
+)
 ADAPT_EQ_UINT8 = np.array([[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8)
 if version.parse(skimage_version) < version.parse("0.17"):  # pragma: no cover
     ADAPT_EQ_UINT8 = np.array(
@@ -161,6 +191,255 @@ class TestRescaleIntensityChunk:
         assert rescaled_patterns.dtype == dtype_out
         assert np.allclose(p1, answer)
         assert not np.allclose(p1, p2, atol=1)
+
+
+class TestRemoveStaticBackgroundChunk:
+    @pytest.mark.parametrize(
+        "operation_func, answer",
+        [
+            (np.subtract, STATIC_SUB_UINT8),
+            (np.divide, STATIC_DIV_UINT8),
+        ],
+    )
+    def test_remove_static_background_chunk(
+        self, dummy_signal, dummy_background, operation_func, answer
+    ):
+        dtype_out = dummy_signal.data.dtype.type
+        dtype_proc = np.float32
+
+        dask_array = get_dask_array(dummy_signal, dtype=dtype_proc)
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_static_background,
+                static_bg=dummy_background.astype(dtype_proc),
+                operation_func=operation_func,
+                dtype_out=dtype_out,
+                dtype=dtype_out,
+            )
+
+            # Check for correct data type and gives expected output intensities
+            assert corrected_patterns.dtype == dtype_out
+            assert isinstance(corrected_patterns, da.Array)
+            assert np.allclose(corrected_patterns[0, 0].compute(), answer)
+
+    def test_remove_static_background_chunk_out_range(
+        self, dummy_signal, dummy_background
+    ):
+        dtype_out = dummy_signal.data.dtype.type
+        dtype_proc = np.float32
+
+        out_range = (0, dtype_range[dtype_out][-1])
+
+        dask_array = get_dask_array(dummy_signal, dtype=dtype_proc)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_static_background,
+                static_bg=dummy_background.astype(dtype_proc),
+                operation_func=np.subtract,
+                dtype_out=dtype_out,
+                out_range=out_range,
+                dtype=dtype_out,
+            )
+
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(corrected_patterns[0, 0].compute(), STATIC_SUB_UINT8)
+
+    def test_remove_static_background_chunk_scalebg(
+        self, dummy_signal, dummy_background
+    ):
+        dtype_out = dummy_signal.data.dtype.type
+        dtype_proc = np.float32
+
+        dask_array = get_dask_array(dummy_signal, dtype=dtype_proc)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_static_background,
+                static_bg=dummy_background.astype(dtype_proc),
+                operation_func=np.subtract,
+                dtype_out=dtype_out,
+                scale_bg=True,
+                dtype=dtype_out,
+            )
+
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(
+                corrected_patterns[0, 0].compute(), STATIC_SUB_SCALEBG_UINT8
+            )
+
+    @pytest.mark.parametrize(
+        "dtype_out, answer",
+        [
+            (np.float32, np.array([[0, 0.6666, 0], [1, 1, 0.3333], [0.6666, -1, -1]])),
+            (np.uint16, np.array([[0, 2, 0], [3, 3, 1], [2, 65535, 65535]])),
+        ],
+    )
+    def test_remove_static_background_chunk_dtype_out(
+        self, dummy_signal, dummy_background, dtype_out, answer
+    ):
+        dummy_signal.data = dummy_signal.data.astype(dtype_out)
+        dummy_background = dummy_background.astype(dtype_out)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = chunk.remove_static_background(
+                patterns=dummy_signal.data,
+                static_bg=dummy_background,
+                operation_func=np.subtract,
+            )
+
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(corrected_patterns[0, 0], answer, atol=1e-4)
+
+
+class TestRemoveDynamicBackgroundChunk:
+    @pytest.mark.parametrize(
+        "std, answer",
+        [(1, DYN_CORR_UINT8_SPATIAL_STD1), (2, DYN_CORR_UINT8_SPATIAL_STD2)],
+    )
+    def test_remove_dynamic_background_spatial(self, dummy_signal, std, answer):
+        dtype_out = dummy_signal.data.dtype.type
+
+        dask_array = get_dask_array(dummy_signal, dtype=np.float32)
+
+        kwargs = {"sigma": std}
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_dynamic_background,
+                filter_func=gaussian_filter,
+                operation_func=np.subtract,
+                dtype_out=dtype_out,
+                dtype=dtype_out,
+                **kwargs,
+            )
+
+            # Check for correct data type and gives expected output intensities
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(corrected_patterns[0, 0].compute(), answer)
+
+    def test_remove_dynamic_background_spatial_uint16(self, dummy_signal):
+        dtype_out = np.uint16
+
+        dask_array = get_dask_array(dummy_signal, dtype=np.float32)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_dynamic_background,
+                filter_func=gaussian_filter,
+                operation_func=np.subtract,
+                dtype_out=dtype_out,
+                dtype=dtype_out,
+                sigma=2,
+            )
+
+            # Check for correct data type and gives expected output intensities
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(
+                corrected_patterns[0, 0].compute(), DYN_CORR_UINT16_SPATIAL_STD2
+            )
+
+    @pytest.mark.parametrize(
+        "std, truncate, answer",
+        [
+            (1, 3, DYN_CORR_UINT8_FREQUENCY_STD1_TRUNCATE3),
+            (2, 4, DYN_CORR_UINT8_FREQUENCY_STD2_TRUNCATE4),
+        ],
+    )
+    def test_remove_dynamic_background_frequency(
+        self, dummy_signal, std, truncate, answer
+    ):
+        dtype_out = dummy_signal.data.dtype.type
+
+        dask_array = get_dask_array(dummy_signal, dtype=np.float32)
+
+        kwargs = {}
+        (
+            kwargs["fft_shape"],
+            kwargs["window_shape"],
+            kwargs["transfer_function"],
+            kwargs["offset_before_fft"],
+            kwargs["offset_after_ifft"],
+        ) = _dynamic_background_frequency_space_setup(
+            pattern_shape=dummy_signal.axes_manager.signal_shape[::-1],
+            std=std,
+            truncate=truncate,
+        )
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_dynamic_background,
+                filter_func=_fft_filter,
+                operation_func=np.subtract,
+                dtype_out=dtype_out,
+                dtype=dtype_out,
+                **kwargs,
+            )
+
+            # Check for correct data type and gives expected output intensities
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(corrected_patterns[0, 0].compute(), answer)
+
+    @pytest.mark.parametrize(
+        "omax, answer",
+        [
+            (255, DYN_CORR_UINT8_SPATIAL_STD2),
+            (250, DYN_CORR_UINT8_SPATIAL_STD2_OMAX250),
+        ],
+    )
+    def test_remove_dynamic_background_out_range(self, dummy_signal, omax, answer):
+        dtype_out = dummy_signal.data.dtype.type
+
+        out_range = (0, omax)
+
+        dask_array = get_dask_array(dummy_signal, dtype=np.float32)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = dask_array.map_blocks(
+                func=chunk.remove_dynamic_background,
+                filter_func=gaussian_filter,
+                operation_func=np.subtract,
+                sigma=2,
+                out_range=out_range,
+                dtype_out=dtype_out,
+                dtype=dtype_out,
+            )
+
+            assert corrected_patterns.dtype == dtype_out
+            assert corrected_patterns.max().compute() == omax
+            assert np.allclose(corrected_patterns[0, 0].compute(), answer)
+
+    @pytest.mark.parametrize(
+        "answer",
+        [
+            np.array(
+                [
+                    [0.3405, 0.6874, 0.4204],
+                    [1, 0.7387, 0.4774],
+                    [0.7387, -0.7444, -1],
+                ],
+                dtype=np.float32,
+            ),
+            np.array(
+                [[0, 1, 1], [2, 1, 0], [1, 65535, 65533]],
+                dtype=np.uint16,
+            ),
+        ],
+    )
+    def test_remove_dynamic_background_dtype_out(self, dummy_signal, answer):
+        dtype_out = answer.dtype
+        dummy_signal.data = dummy_signal.data.astype(dtype_out)
+
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            corrected_patterns = chunk.remove_dynamic_background(
+                patterns=dummy_signal.data,
+                filter_func=gaussian_filter,
+                operation_func=np.subtract,
+                sigma=2,
+            )
+
+            assert corrected_patterns.dtype == dtype_out
+            assert np.allclose(corrected_patterns[0, 0], answer, atol=1e-4)
 
 
 class TestGetDynamicBackgroundChunk:
@@ -338,6 +617,54 @@ class TestAverageNeighbourPatternsChunk:
         # Check for correct data type and gives expected output intensities
         assert averaged_patterns.dtype == dtype_out
         assert np.allclose(averaged_patterns[0, 0].compute(), answer)
+
+
+class TestGetImageQualityChunk:
+    @pytest.mark.parametrize(
+        "normalize, answer",
+        [
+            (
+                True,
+                np.array(
+                    [
+                        [-0.0241, -0.0625, -0.0052],
+                        [-0.0317, -0.0458, -0.0956],
+                        [-0.1253, 0.0120, -0.2385],
+                    ],
+                    dtype=np.float64,
+                ),
+            ),
+            (
+                False,
+                np.array(
+                    [
+                        [0.2694, 0.2926, 0.2299],
+                        [0.2673, 0.1283, 0.2032],
+                        [0.1105, 0.2671, 0.2159],
+                    ],
+                    dtype=np.float64,
+                ),
+            ),
+        ],
+    )
+    def test_get_image_quality_chunk(self, dummy_signal, normalize, answer):
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            iq = chunk.get_image_quality(
+                patterns=dummy_signal.data, normalize=normalize
+            )
+            assert np.allclose(iq, answer, atol=1e-4)
+
+    def test_get_image_quality_chunk_white_noise(self):
+        p = np.random.random((4, 1001, 1001))
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            iq = chunk.get_image_quality(patterns=p)
+            assert np.allclose(iq, 0, atol=1e-2)
+
+    def test_get_image_quality_flat(self):
+        p = np.ones((4, 1001, 1001))
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            iq = chunk.get_image_quality(patterns=p, normalize=False)
+            assert np.allclose(iq, 1, atol=1e-2)
 
 
 class TestFFTFilterChunk:


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Reintroduce the `kikuchipy.pattern.chunk` functions `remove_static_background()`, `remove_dynamic_background()` and `get_image_quality()`, which were removed in #527. Better to deprecate and remove in v0.7.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
