### PR TITLE
Fix541

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,18 @@ best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Contributors to each release are listed in alphabetical order by first name. List
 entries are sorted in descending chronological order.
 
+0.6.1 (2022-06-17)
+==================
+
+Contributors
+------------
+- Håkon Wiik Ånes
+
+Fixed
+-----
+- Incorrect filtering of zone axes labels in geometrical simulations.
+  (`#544 <https://github.com/pyxem/kikuchipy/pull/544>`_)
+
 0.6.0 (2022-06-16)
 ==================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -248,6 +248,11 @@ with the current API, we run a scheduled GitHub Action every Monday morning whic
 that the notebooks run OK and that they produce the same output now as when they were
 last executed. We use `nbval <https://nbval.readthedocs.io/en/latest/>`_ for this.
 
+The user guide notebooks can be run interactively in the browser with the help of
+Binder. When creating a server from the kikuchipy source code, Binder installs the
+packages listed in the environment.yml configuration file, which must include all doc
+dependencies listed in setup.py necessary to run the notebooks.
+
 Deprecations
 ============
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,8 @@
 name: doc-dependencies-for-binder
 channels:
   - conda-forge
-#  - javascript
 dependencies:
-  - nodejs=16
-#  - python=3.9
+  - python=3.9
   - pip
   - pip:
       - --editable .[doc,viz]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: doc-dependencies-for-binder
+channels:
+  - conda-forge
+#  - javascript
+dependencies:
+  - nodejs=16
+#  - python=3.9
+  - pip
+  - pip:
+      - --editable .[doc,viz]

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -35,4 +35,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.6.0"
+version = "0.6.1"

--- a/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -662,7 +662,6 @@ class GeometricalKikuchiPatternSimulation:
         """
         za = self._zone_axes
         za_labels = za.vector.coordinates.round(0).astype(np.int64)
-        za_labels = za_labels[za.within_r_gnomonic[index]]
         za_labels_str = np.array2string(za_labels, threshold=za_labels.size)
         za_labels_list = re.sub("[][ ]", "", za_labels_str[1:-1]).split("\n")
         xy = self.zone_axes_coordinates(index, coordinates, exclude_nan=False)


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fix #541 and bump release version to 0.6.1 for a patch release. A config file for Binder is added, but it won't be possible to run PyVista on Binder yet (see #543).

I'll release this right away.

#### Progress of the PR
- [n/] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to .all-contributorsrc and the table is regenerated.
