### PR TITLE
Fix nbval path to tutorial notebooks

### DIFF
--- a/.github/workflows/test_documentation_notebooks.yml
+++ b/.github/workflows/test_documentation_notebooks.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Test documentation notebooks
         run: |
-          pytest -v --nbval doc/user_guide doc/examples
+          pytest -v --nbval doc/tutorials --sanitize-with doc/tutorials/tutorials_sanitize.cfg

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,7 @@ Learning resources
 
 .. See: https://sphinx-design.readthedocs.io/en/furo-theme/grids.html
 .. grid:: 2 3 3 3
+    :gutter: 2
 
     .. grid-item-card:: Examples
         :img-top: _static/image/colormap_banners/banner0.png


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fix nbval path to tutorial notebooks.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py` and `.all-contributorsrc` and the table 
      is regenerated.
