### PR TITLE
Fix test documentation notebooks

### DIFF
--- a/.github/workflows/test_documentation_notebooks.yml
+++ b/.github/workflows/test_documentation_notebooks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install package and dependencies
         shell: bash
         run: |
-          pip install -U -e .'[tests,viz]'
+          pip install -U -e .'[doc,tests,viz]'
           pip install nbval
 
       - name: Test documentation notebooks

--- a/doc/tutorials/tutorials_sanitize.cfg
+++ b/doc/tutorials/tutorials_sanitize.cfg
@@ -1,15 +1,25 @@
+# See https://docs.python.org/3/library/re.html
+
 [regex1]
 regex: (?<=Completed \| )\d+\.\d* \w+
 replace: TIME
+# Example: [#] | 100% Completed | 303.49 ms -> [#] | 100% Completed | TIME
 
 [regex2]
 regex: \d+ (?=patterns/s)
 replace: N_PATTERNS
+# Example: 1 patterns/s -> N_PATTERNS patterns/s
 
 [regex3]
 regex: \d+ (?=comparisons/s)
 replace: N_COMPARISONS
+# Example: 1 comparisons/s -> N_COMPARISONS comparisons/s
 
 [regex4]
 regex: ^100%(.*)it/s\]$
 replace: TQDM_PROGRESSBAR
+
+[regex5]
+regex: (?<=Figure size )\d+x\d+.\d+
+replace: FIGURE_SIZE
+# Example: Figure size 640x408.116 -> Figure size FIGURE_SIZE


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR ensures `nbval` sanitizes cell outputs like `Figure size 100x200.300` to `Figure size FIGURE_SIZE` and that it runs with doc dependencies. This should handle the final failures in the weekly checking of tutorial notebooks (see [log](https://github.com/pyxem/kikuchipy/runs/7946007943?check_suite_focus=true)).

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py` and `.all-contributorsrc` and the table 
      is regenerated.
