### PR TITLE
Make Dask chunking tests independent of Dask version

### DIFF
--- a/kikuchipy/signals/util/tests/test_dask.py
+++ b/kikuchipy/signals/util/tests/test_dask.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
 import dask.array as da
 import numpy as np
 import pytest
@@ -37,51 +35,71 @@ class TestDask:
 
     def test_chunk_shape(self):
         s = LazyEBSD(da.zeros((32, 32, 256, 256), dtype=np.uint16))
-        chunks = get_chunking(s, chunk_shape=16)
-        assert chunks == ((16, 16), (16, 16), (256,), (256,))
+        assert get_chunking(s, chunk_shape=16) == da.core.normalize_chunks(
+            chunks={0: 16, 1: 16, 2: -1, 3: -1},
+            limit=30e6,
+            shape=s.data.shape,
+            dtype=s.data.dtype,
+        )
 
-    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python >= 3.8")
     def test_chunk_bytes(self):
         s = LazyEBSD(da.zeros((32, 32, 256, 256), dtype=np.uint16))
-        chunks = get_chunking(s, chunk_bytes=15e6)
-        assert chunks == ((10, 10, 10, 2), (10, 10, 10, 2), (256,), (256,))
+        assert get_chunking(s, chunk_bytes=15e6) == da.core.normalize_chunks(
+            chunks={0: "auto", 1: "auto", 2: -1, 3: -1},
+            limit=15e6,
+            shape=s.data.shape,
+            dtype=s.data.dtype,
+        )
 
-    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python >= 3.8")
     def test_get_chunking_dtype(self):
         s = LazyEBSD(da.zeros((32, 32, 256, 256), dtype=np.uint8))
-        chunks0 = get_chunking(s, dtype=np.float32)
-        chunks1 = get_chunking(s)
-        assert chunks0 == ((10, 10, 10, 2), (10, 10, 10, 2), (256,), (256,))
-        assert chunks1 == ((21, 11), (21, 11), (256,), (256,))
+        assert get_chunking(s) == da.core.normalize_chunks(
+            chunks={0: "auto", 1: "auto", 2: -1, 3: -1},
+            limit=30e6,
+            shape=s.data.shape,
+            dtype=s.data.dtype,
+        )
+        assert get_chunking(s, dtype=np.float32) == da.core.normalize_chunks(
+            chunks={0: "auto", 1: "auto", 2: -1, 3: -1},
+            limit=30e6,
+            shape=s.data.shape,
+            dtype=np.dtype("float32"),
+        )
 
-    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python >= 3.8")
     @pytest.mark.parametrize(
-        "shape, nav_dim, sig_dim, dtype, desired_chunks",
+        "shape, nav_dim, sig_dim, dtype",
         [
             (
                 (32, 32, 256, 256),
                 2,
                 2,
-                np.uint16,
-                ((15, 15, 2), (15, 15, 2), (256,), (256,)),
+                np.dtype("uint16"),
             ),
-            ((32, 32, 256, 256), 2, 2, np.uint8, ((21, 11), (21, 11), (256,), (256,))),
+            ((32, 32, 256, 256), 2, 2, np.dtype("uint8")),
         ],
     )
-    def test_get_chunking_no_signal(
-        self, shape, nav_dim, sig_dim, dtype, desired_chunks
-    ):
+    def test_get_chunking_no_signal(self, shape, nav_dim, sig_dim, dtype):
         chunks = get_chunking(
             data_shape=shape, nav_dim=nav_dim, sig_dim=sig_dim, dtype=dtype
         )
-        assert chunks == desired_chunks
+        assert chunks == da.core.normalize_chunks(
+            chunks={0: "auto", 1: "auto", 2: -1, 3: -1},
+            limit=30e6,
+            shape=shape,
+            dtype=dtype,
+        )
 
     def test_get_dask_array(self):
         s = EBSD((255 * np.random.rand(10, 10, 120, 120)).astype(np.uint8))
         dask_array = get_dask_array(s, chunk_shape=8)
-        assert dask_array.chunksize == (8, 8, 120, 120)
+        assert dask_array.chunks == da.core.normalize_chunks(
+            chunks={0: 8, 1: 8, 2: -1, 3: -1},
+            limit=30e6,
+            shape=s.data.shape,
+            dtype=s.data.dtype,
+        )
 
-        # Make data lazy
+        # Make data lazy (chunk size is kept)
         s.data = dask_array.rechunk((5, 5, 120, 120))
         dask_array = get_dask_array(s)
         assert dask_array.chunksize == (5, 5, 120, 120)
@@ -91,8 +109,8 @@ class TestDask:
         array_out0 = get_dask_array(s)
         array_out1 = get_dask_array(s, chunk_bytes="25KiB")
         array_out2 = get_dask_array(s, chunk_bytes=30e3)
-        assert array_out0.chunksize != array_out1.chunksize
-        assert array_out1.chunksize == array_out2.chunksize
+        assert array_out0.chunks != array_out1.chunks
+        assert array_out1.chunks == array_out2.chunks
 
     def test_rechunk_learning_results(self):
         data = da.from_array(np.random.rand(10, 100, 100, 5).astype(np.float32))


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This makes the Dask chunking tests independent of Dask version by comparing returned chunks to chunks created with direct calls to `dask.array.core.normalize_chunks()` instead of hard-coded chunks, as suggested by @ericpre in #567.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py` and `.all-contributorsrc` and the table 
      is regenerated.
