### PR TITLE
Reader of EBSD signal from a directory of EBSD pattern images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 Added
 -----
+- Dependency ``imageio`` needed for reading EBSD patterns in image files.
+  (`#570 <https://github.com/pyxem/kikuchipy/pull/570>`_)
+- Reader of an ``EBSD`` signal from all images in a directory assuming they are of the
+  same shape and data type. (`#570 <https://github.com/pyxem/kikuchipy/pull/570>`_)
 - Reader of an ``EBSD`` signal from EDAX TSL's binary UP1/UP2 file formats.
   (`#569 <https://github.com/pyxem/kikuchipy/pull/569>`_)
 - Ability to project simulate patterns from a master pattern using varying projection

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -171,6 +171,24 @@
     year = {2020},
     pages = {112876}
 }
+@misc{shi2021high,
+    author = {Shi, Qiwei},
+    title = {{High-definition electron diffraction patterns and their indexation results of a single crystal Si wafer}},
+    month = dec,
+    year = 2021,
+    publisher = {Zenodo},
+    doi = {10.5281/zenodo.5803073},
+    url = {https://doi.org/10.5281/zenodo.5803073}
+}
+@misc{shi2022high,
+    author = {Shi, Qiwei},
+    title = {{High-definition electron diffraction patterns and their indexation results of a polycrystal Al-Mg sample}},
+    month = aug,
+    year = 2022,
+    publisher = {Zenodo},
+    doi = {10.5281/zenodo.6990325},
+    url = {https://doi.org/10.5281/zenodo.6990325}
+}
 @article{singh2016orientation,
 	author = {Singh, Saransh and {De Graef}, Marc},
 	doi = {10.1088/0965-0393/24/8/085013},
@@ -205,6 +223,15 @@
 	title = {{High-resolution elastic strain measurement from electron backscatter diffraction patterns: New levels of sensitivity}},
 	volume = {106},
 	year = {2006}
+}
+@misc{wilkinson2018small,
+    author = {Angus Wilkinson and David M Collins},
+    title = {Small EBSD map from annealed ferritic steel},
+    doi = {10.5281/zenodo.1288431},
+    url = {https://doi.org/10.5281/zenodo.1288431},
+    month = jun,
+    publisher = {Zenodo},
+    year = {2018},
 }
 @article{winkelmann2020refined,
 	author = {Winkelmann, Aimo and Nolze, Gert and Cios, Grzegorz and Tokarski, Tomasz and Bała, Piotr},

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -178,7 +178,6 @@
     year = 2021,
     publisher = {Zenodo},
     doi = {10.5281/zenodo.5803073},
-    url = {https://doi.org/10.5281/zenodo.5803073}
 }
 @misc{shi2022high,
     author = {Shi, Qiwei},
@@ -187,7 +186,6 @@
     year = 2022,
     publisher = {Zenodo},
     doi = {10.5281/zenodo.6990325},
-    url = {https://doi.org/10.5281/zenodo.6990325}
 }
 @article{singh2016orientation,
 	author = {Singh, Saransh and {De Graef}, Marc},
@@ -228,7 +226,6 @@
     author = {Angus Wilkinson and David M Collins},
     title = {Small EBSD map from annealed ferritic steel},
     doi = {10.5281/zenodo.1288431},
-    url = {https://doi.org/10.5281/zenodo.1288431},
     month = jun,
     publisher = {Zenodo},
     year = {2018},

--- a/doc/open_datasets.rst
+++ b/doc/open_datasets.rst
@@ -7,7 +7,7 @@ Open datasets
     See the :mod:`~kikuchipy.data` module for small test data sets.
 
 Zipped data sets available via `Zenodo <https://zenodo.org>`_, in this example
-with `record-number` named `data.zip`, can be downloaded:
+with `record-number` named `data.zip`, can be downloaded like this:
 
 .. code-block::
 
@@ -17,5 +17,11 @@ with `record-number` named `data.zip`, can be downloaded:
     ...     filename='./downloaded_data.zip'
     ... )
 
+This is a non-exhaustive list of EBSD datasets openly available on the internet which
+can be read by kikuchipy:
+
+- :cite:`shi2021high`
+- :cite:`shi2022high`
+- :cite:`wilkinson2018small`
 - :cite:`aanes2019electron`
 - :cite:`aanes2022electron`

--- a/doc/tutorials/load_save_data.ipynb
+++ b/doc/tutorials/load_save_data.ipynb
@@ -487,7 +487,7 @@
     "| [NORDIF calibration patterns](#NORDIF-calibration-patterns)             | Yes  | No    |\n",
     "| [Oxford Instruments binary](#Oxford-Instruments-binary)                 | Yes  | No    |\n",
     "| [Oxford Instruments h5ebsd (H5OINA)](#Oxford-Instruments-h5ebsd-H5OINA) | Yes  | No    |\n",
-    "| [Directory of EBSD patterns](#Directory-of-EBSD-patterns)               | Yes  | Yes   |\n",
+    "| [Directory of EBSD patterns](#Directory-of-EBSD-patterns)               | Yes  | No    |\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",

--- a/doc/tutorials/load_save_data.ipynb
+++ b/doc/tutorials/load_save_data.ipynb
@@ -41,12 +41,14 @@
     "# Exchange inline for notebook or qt5 (from pyqt) for interactive plotting\n",
     "%matplotlib inline\n",
     "\n",
-    "import tempfile\n",
     "import dask.array as da\n",
     "import hyperspy.api as hs\n",
+    "import imageio.v3 as iio\n",
     "import kikuchipy as kp\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "import tempfile"
    ]
   },
   {
@@ -485,6 +487,7 @@
     "| [NORDIF calibration patterns](#NORDIF-calibration-patterns)             | Yes  | No    |\n",
     "| [Oxford Instruments binary](#Oxford-Instruments-binary)                 | Yes  | No    |\n",
     "| [Oxford Instruments h5ebsd (H5OINA)](#Oxford-Instruments-h5ebsd-H5OINA) | Yes  | No    |\n",
+    "| [Directory of EBSD patterns](#Directory-of-EBSD-patterns)               | Yes  | Yes   |\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -800,7 +803,7 @@
    "source": [
     "Here, the EDAX binary [file_reader()](../reference/generated/kikuchipy.io.plugins.edax_binary.file_reader.rst) is called.\n",
     "\n",
-    "Files with version 1 has no information on the pattern shape, so we can pass this to the reader in the `nav_shape` parameter"
+    "Files with version 1 has no information on the navigation (map) shape, so we can pass this to the reader in the `nav_shape` parameter"
    ]
   },
   {
@@ -981,6 +984,82 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Directory of EBSD patterns\n",
+    "\n",
+    "Many EBSD patterns in image files in a directory can be read as an `EBSD` signal, assuming all images with that file extension have the same shape and data type. Valid formats are those [supported by imageio](https://imageio.readthedocs.io/en/stable/formats/index.html).\n",
+    "\n",
+    "To demonstrate how the images can be read, we will first write nine patterns to a temporary with their filenames formatted a certain way"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp_dir2 = tempfile.mkdtemp() + \"/\"\n",
+    "s = kp.data.nickel_ebsd_small()\n",
+    "y, x = np.indices(s.axes_manager.navigation_shape[::-1])\n",
+    "y = y.ravel()\n",
+    "x = x.ravel()\n",
+    "s.unfold_navigation_space()\n",
+    "for i in range(s.axes_manager.navigation_size):\n",
+    "    iio.imwrite(temp_dir2 + f\"/pattern_x{x[i]}y{y[i]}.tif\", s.data[i])\n",
+    "\n",
+    "# Print file contents\n",
+    "os.listdir(temp_dir2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If filenames are formatted like this `_x0y0.tif` or `-0-0.png`, we do not have to specify this file name pattern when reading the images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s1 = kp.load(os.path.join(temp_dir2, \"*.tif\"))\n",
+    "s1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here [file_reader()](../reference/generated/kikuchipy.io.plugins.ebsd_directory.file_reader.rst) of this plugin was called.\n",
+    "If filenames are formatted some other way, we have to pass this as a [regular expression](https://docs.python.org/3/library/re.html) to `xy_pattern`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s2 = kp.load(\n",
+    "    os.path.join(temp_dir2, \"*.tif\"),\n",
+    "    xy_pattern=r\"_x(\\d+)y(\\d+).tif\",\n",
+    "    show_progressbar=True,\n",
+    ")\n",
+    "s2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we also printed a progressbar when reading the patterns from file, which can be useful when we want to read a large number of images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## From kikuchipy into other software\n",
     "\n",
     "Patterns saved in the [h5ebsd format](#h5ebsd) can be read by the dictionary indexing and related routines in [EMsoft](https://github.com/EMsoft-org/EMsoft) using the `EMEBSD` reader.\n",
@@ -1106,19 +1185,12 @@
    "outputs": [],
    "source": [
     "# Remove files written to disk in this user guide\n",
-    "import os\n",
-    "\n",
-    "for file in [\n",
-    "    \"patterns.h5\",\n",
-    "    \"patterns_new.h5\",\n",
-    "    \"patterns.dat\",\n",
-    "    \"master_pattern.hspy\",\n",
-    "    \"vbse.tif\",\n",
-    "]:\n",
+    "for file in os.listdir(temp_dir):\n",
     "    os.remove(temp_dir + file)\n",
-    "for i in range(25):\n",
-    "    os.remove(temp_dir + f\"vbse{i}.png\")\n",
-    "os.rmdir(temp_dir)"
+    "for file in os.listdir(temp_dir2):\n",
+    "    os.remove(temp_dir2 + file)\n",
+    "os.rmdir(temp_dir)\n",
+    "os.rmdir(temp_dir2)"
    ]
   }
  ],

--- a/kikuchipy/_util/tests/test_import.py
+++ b/kikuchipy/_util/tests/test_import.py
@@ -282,6 +282,7 @@ class TestImport:
 
         assert dir(kikuchipy.io.plugins) == [
             "bruker_h5ebsd",
+            "ebsd_directory",
             "edax_binary",
             "edax_h5ebsd",
             "emsoft_ebsd",

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -25,6 +25,7 @@ import warnings
 import dask.array as da
 from diffpy.structure import Atom, Lattice, Structure
 import hyperspy.api as hs
+import imageio.v3 as iio
 import matplotlib.pyplot as plt
 import numpy as np
 from orix.crystal_map import CrystalMap, create_coordinate_arrays, Phase, PhaseList
@@ -462,6 +463,29 @@ def ni_small_axes_manager():
             "navigate": navigates[i],
         }
     yield axes_manager
+
+
+@pytest.fixture(params=[("_x{}y{}.tif", (3, 3))])
+def ebsd_directory(tmpdir, request):
+    """Temporary directory with EBSD files as .tif, .png or .bmp files.
+
+    Parameters expected in `request`
+    -------------------------------
+    xy_pattern : str
+    nav_shape : tuple of ints
+    """
+    s = kp.data.nickel_ebsd_small()
+    s.unfold_navigation_space()
+
+    xy_pattern, nav_shape = request.param
+    y, x = np.indices(nav_shape)
+    x = x.ravel()
+    y = y.ravel()
+    for i in range(s.axes_manager.navigation_size):
+        fname = os.path.join(tmpdir, "pattern" + xy_pattern.format(x[i], y[i]))
+        iio.imwrite(fname, s.data[i])
+
+    yield tmpdir
 
 
 # ---------------------- pytest doctest-modules ---------------------- #

--- a/kikuchipy/io/_io.py
+++ b/kikuchipy/io/_io.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+import glob
 import os
 from pathlib import Path
 from typing import List, Optional, Union
@@ -29,6 +30,7 @@ import numpy as np
 import kikuchipy.signals
 from kikuchipy.io.plugins import (
     bruker_h5ebsd,
+    ebsd_directory,
     edax_binary,
     edax_h5ebsd,
     emsoft_ebsd,
@@ -46,6 +48,7 @@ from kikuchipy.io._util import _get_input_bool, _ensure_directory
 
 plugins = [
     bruker_h5ebsd,
+    ebsd_directory,
     edax_binary,
     edax_h5ebsd,
     emsoft_ebsd,
@@ -115,7 +118,13 @@ def load(
     <EBSD, title: patterns My awes0m4 ..., dimensions: (3, 3|60, 60)>
     """
     if not os.path.isfile(filename):
-        raise IOError(f"No filename matches '{filename}'.")
+        is_wildcard = False
+        if isinstance(filename, str):
+            filenames = glob.glob(filename)
+            if len(filenames) > 0:
+                is_wildcard = True
+        if not is_wildcard:
+            raise IOError(f"No filename matches '{filename}'.")
 
     # Find matching reader for file extension
     extension = os.path.splitext(filename)[1][1:]

--- a/kikuchipy/io/plugins/__init__.py
+++ b/kikuchipy/io/plugins/__init__.py
@@ -26,6 +26,7 @@
     :template: custom-module-template.rst
 
     bruker_h5ebsd
+    ebsd_directory
     edax_binary
     edax_h5ebsd
     emsoft_ebsd
@@ -41,6 +42,7 @@
 
 __all__ = [
     "bruker_h5ebsd",
+    "ebsd_directory",
     "edax_binary",
     "edax_h5ebsd",
     "emsoft_ebsd",

--- a/kikuchipy/io/plugins/ebsd_directory.py
+++ b/kikuchipy/io/plugins/ebsd_directory.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+"""Reader of EBSD patterns from a dictionary of images."""
+
 import glob
 import logging
 import os

--- a/kikuchipy/io/plugins/ebsd_directory.py
+++ b/kikuchipy/io/plugins/ebsd_directory.py
@@ -1,0 +1,198 @@
+# Copyright 2019-2022 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import glob
+import logging
+import os
+from pathlib import Path
+import re
+from typing import Dict, List, Optional, Union
+import warnings
+
+import dask
+import dask.array as da
+from dask.diagnostics import ProgressBar
+import imageio.v3 as iio
+import numpy as np
+
+
+__all__ = ["file_reader"]
+
+
+_logger = logging.getLogger(__name__)
+
+
+# Plugin characteristics
+# ----------------------
+format_name = "Directory of EBSD patterns"
+description = "Read support for patterns in image files in a directory"
+full_support = False
+# Recognised file extension
+file_extensions = ["tif", "tiff", "bmp", "png"]
+default_extension = 0
+# Writing capabilities (signal dimensions, navigation dimensions)
+writes = False
+
+
+def file_reader(
+    filename: Union[str, Path],
+    xy_pattern: Optional[str] = None,
+    show_progressbar: Optional[bool] = None,
+    lazy: bool = False,
+) -> List[Dict]:
+    r"""Read all images in a directory, assuming they are electron
+    backscatter diffraction (EBSD) patterns of equal shape and data
+    type.
+
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
+
+    Parameters
+    ----------
+    filename
+        Name of directory with patterns.
+    xy_pattern
+        Regular expression to extract map coordinates from the
+        filenames. If not given, two regular expressions will be tried:
+        assuming (x, y) = (5, 10), "_x5y10.tif" or "-5-10.bmp".
+        Valid ``xy_pattern`` equal to these are ``r"_x(\d+)y(\d+).tif"``
+        and ``r"-(\d+)-(\d+).bmp"``, respectively. If none of these
+        expressions match the first file's name in the directory, a
+        warning is printed and the returned signal will have only one
+        navigation dimension.
+    show_progressbar
+        Whether to show a progressbar when reading the signal into
+        memory when ``lazy=False``.
+    lazy
+        Read the patterns lazily without actually reading them from disk
+        until required. Default is ``False``.
+
+    Returns
+    -------
+    scan
+        Data, axes, metadata and original metadata.
+
+    Warns
+    -----
+    UserWarning
+        If navigation coordinates can not be read from the filenames.
+    UserWarning
+        If there are more detected patterns in the directory than the
+        navigation shape determined from the filenames suggest.
+
+    Notes
+    -----
+    Adapted from https://blog.dask.org/2019/06/20/load-image-data.
+    """
+    # Read all filenames
+    filenames = glob.glob(filename)
+    n_patterns = len(filenames)
+    _logger.info(f"{n_patterns} patterns found in directory")
+    ext = os.path.splitext(filename)[1]
+
+    # Get regex pattern
+    if xy_pattern is None:
+        for p in [rf"_x(\d+)y(\d+){ext}", rf"-(\d+)-(\d+){ext}"]:
+            match = re.search(p, filenames[0])
+            if match is not None:
+                xy_pattern = p
+                break
+
+    if xy_pattern is None:
+        warnings.warn(
+            "Returned signal will have one navigation dimension as coordinates could "
+            "not be read from the file names"
+        )
+        nav_shape = (n_patterns,)
+    else:
+        # Read coordinates of each file
+        fn_idx_sets = dict()
+        xy_coords = np.zeros((n_patterns, 2), dtype=int)
+        for j, fn in enumerate(filenames):
+            for i, idx in enumerate(re.search(xy_pattern, fn).groups()):
+                fn_idx_sets.setdefault(i, set())
+                fn_idx_sets[i].add(int(idx))
+                xy_coords[j, i] = idx
+
+        # Sort indices and determine navigation shape
+        fn_idx_sets = list(map(sorted, fn_idx_sets.values()))
+        nav_shape = tuple(map(len, fn_idx_sets))[::-1]
+
+        if n_patterns != int(np.prod(nav_shape)):
+            warnings.warn(
+                "Returned signal will have one navigation dimension as the number of "
+                f"patterns found in the directory, {n_patterns}, does not match the "
+                f"navigation shape determined from the filenames, {nav_shape}."
+            )
+            nav_shape = (n_patterns,)
+
+    _logger.info(f"Navigation shape is {nav_shape}")
+
+    # Read one pattern
+    sample = iio.imread(filenames[0])
+    sig_shape = sample.shape
+    dtype = sample.dtype
+    _logger.info(f"Sample pattern has shape {sig_shape} and dtype {dtype}")
+
+    # Read all patterns lazily
+    lazy_patterns = [dask.delayed(iio.imread)(fn) for fn in filenames]
+    lazy_patterns = [
+        da.from_delayed(x, shape=sig_shape, dtype=dtype) for x in lazy_patterns
+    ]
+
+    # Concatenate patterns into full dataset
+    if xy_pattern is None or nav_shape == (n_patterns,):
+        data = da.stack(lazy_patterns)
+    else:
+        data = np.empty(nav_shape + (1, 1), dtype=object)
+        for (x, y), pat in zip(xy_coords, lazy_patterns):
+            data[fn_idx_sets[1].index(y), fn_idx_sets[0].index(x), 0, 0] = pat
+        data = da.block(data.tolist())
+
+    if not lazy:
+        pbar = ProgressBar()
+        if show_progressbar:
+            pbar.register()
+        data_np = np.empty(nav_shape + sig_shape, dtype=dtype)
+        data.store(data_np, compute=True)
+        data = data_np
+        try:
+            pbar.unregister()
+        except KeyError:
+            pass
+
+    nav_dim = len(nav_shape)
+    ndim = nav_dim + 2
+
+    units = ["um"] * ndim
+    scales = [1] * ndim
+    axes_names = ["y", "x"][-nav_dim:] + ["dy", "dx"]
+    axes = [
+        {
+            "size": data.shape[i],
+            "index_in_array": i,
+            "name": axes_names[i],
+            "scale": scales[i],
+            "offset": 0.0,
+            "units": units[i],
+        }
+        for i in range(ndim)
+    ]
+    metadata = dict(Signal=dict(signal_type="EBSD", record_by="image"))
+
+    scan = dict(axes=axes, data=data, metadata=metadata)
+
+    return [scan]

--- a/kikuchipy/io/plugins/edax_h5ebsd.py
+++ b/kikuchipy/io/plugins/edax_h5ebsd.py
@@ -172,7 +172,7 @@ def file_reader(
     and an EBSD detector from an EDAX h5ebsd file
     :cite:`jackson2014h5ebsd`.
 
-    Not ment to be used directly; use :func:`~kikuchipy.load`.
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
 
     Parameters
     ----------

--- a/kikuchipy/io/plugins/emsoft_ebsd.py
+++ b/kikuchipy/io/plugins/emsoft_ebsd.py
@@ -63,7 +63,7 @@ def file_reader(
     """Read dynamically simulated electron backscatter diffraction
     patterns from EMsoft's format produced by their EMEBSD.f90 program.
 
-    Not ment to be used directly; use :func:`~kikuchipy.load`.
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
 
     Parameters
     ----------

--- a/kikuchipy/io/plugins/kikuchipy_h5ebsd.py
+++ b/kikuchipy/io/plugins/kikuchipy_h5ebsd.py
@@ -466,7 +466,7 @@ def file_writer(
     :class:`~kikuchipy.signals.LazyEBSD` signal to an existing but not
     open or new h5ebsd file.
 
-    Not ment to be used directly; use
+    Not meant to be used directly; use
     :func:`~kikuchipy.signals.EBSD.save`.
 
     The file is closed after writing.

--- a/kikuchipy/io/plugins/nordif.py
+++ b/kikuchipy/io/plugins/nordif.py
@@ -55,7 +55,7 @@ def file_reader(
 ) -> List[Dict]:
     """Read electron backscatter patterns from a NORDIF data file.
 
-    Not ment to be used directly; use :func:`~kikuchipy.load`.
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
 
     Parameters
     ----------

--- a/kikuchipy/io/plugins/nordif_calibration_patterns.py
+++ b/kikuchipy/io/plugins/nordif_calibration_patterns.py
@@ -49,7 +49,7 @@ def file_reader(filename: Union[str, Path], lazy: bool = False) -> List[dict]:
     """Reader electron backscatter patterns from .bmp files stored in a
     NORDIF project directory, their filenames listed in a text file.
 
-    Not ment to be used directly; use :func:`~kikuchipy.load`.
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
 
     Parameters
     ----------

--- a/kikuchipy/io/plugins/oxford_h5ebsd.py
+++ b/kikuchipy/io/plugins/oxford_h5ebsd.py
@@ -171,7 +171,7 @@ def file_reader(
     and an EBSD detector from an Oxford Instruments h5ebsd (H5OINA) file
     :cite:`jackson2014h5ebsd`.
 
-    Not ment to be used directly; use :func:`~kikuchipy.load`.
+    Not meant to be used directly; use :func:`~kikuchipy.load`.
 
     Parameters
     ----------

--- a/kikuchipy/io/plugins/tests/test_ebsd_directory.py
+++ b/kikuchipy/io/plugins/tests/test_ebsd_directory.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2022 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import imageio.v3 as iio
+import numpy as np
+import pytest
+
+import kikuchipy as kp
+
+
+class TestEBSDDirectory:
+    def test_load(self, ebsd_directory):
+        """Patterns are read correctly."""
+        s_ref = kp.data.nickel_ebsd_small()
+        s = kp.load(os.path.join(ebsd_directory, "*.tif"))
+        assert isinstance(s, kp.signals.EBSD)
+        assert np.allclose(s.data, s_ref.data)
+
+    def test_load_progressbar(self, ebsd_directory, capsys):
+        """Asking for a progressbar works."""
+        _ = kp.load(os.path.join(ebsd_directory, "*.tif"))
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+        _ = kp.load(os.path.join(ebsd_directory, "*.tif"), show_progressbar=True)
+        captured = capsys.readouterr()
+        assert "100% Completed" in captured.out
+
+    def test_load_lazy(self, ebsd_directory):
+        """Lazy loading works."""
+        s_lazy = kp.load(os.path.join(ebsd_directory, "*.tif"), lazy=True)
+        assert isinstance(s_lazy, kp.signals.LazyEBSD)
+
+    @pytest.mark.parametrize(
+        "ebsd_directory, xy_pattern, nav_shape, fname",
+        [
+            (("_x{}y{}.png", (9, 1)), None, (9, 1), "*.png"),
+            (("-{}-{}.tif", (3, 3)), None, (3, 3), "*.tif"),
+            (("-x{}-y{}.bmp", (1, 9)), r"-x(\d+)-y(\d+).bmp", (1, 9), "*.bmp"),
+        ],
+        indirect=["ebsd_directory"],
+    )
+    def test_xy_pattern(self, ebsd_directory, xy_pattern, nav_shape, fname):
+        """Passing various filename patterns work."""
+        s = kp.load(os.path.join(ebsd_directory, fname), xy_pattern=xy_pattern)
+        assert s.data.shape == nav_shape + (60, 60)
+
+    @pytest.mark.parametrize(
+        "ebsd_directory", [("_x{}y{}.tif", (3, 3))], indirect=["ebsd_directory"]
+    )
+    def test_warns_more_patterns(self, ebsd_directory):
+        """Warns when there are more patterns in directory than
+        filenames suggest.
+        """
+        s0 = kp.data.nickel_ebsd_small()
+        iio.imwrite(os.path.join(ebsd_directory, "pattern_x10y50.tif"), s0.data[0, 0])
+
+        with pytest.warns(UserWarning, match="Returned signal will have one "):
+            s = kp.load(os.path.join(ebsd_directory, "*.tif"))
+        assert s.axes_manager.navigation_shape == (10,)
+
+    @pytest.mark.parametrize(
+        "ebsd_directory", [("_xx{}yy{}.tif", (3, 3))], indirect=["ebsd_directory"]
+    )
+    def test_warns_coordinates(self, ebsd_directory):
+        """Warns when navigation coordinates could not be read from
+        filenames.
+        """
+        with pytest.warns(UserWarning, match="Returned signal will have one "):
+            s = kp.load(os.path.join(ebsd_directory, "*.tif"))
+        assert s.axes_manager.navigation_shape == (9,)

--- a/kikuchipy/io/tests/test_io.py
+++ b/kikuchipy/io/tests/test_io.py
@@ -22,10 +22,8 @@ import tempfile
 import numpy as np
 import pytest
 
-from kikuchipy.io._io import load
-from kikuchipy.io.plugins import kikuchipy_h5ebsd
+import kikuchipy as kp
 from kikuchipy.io._io import _assign_signal_subclass, _dict2signal
-from kikuchipy.signals.ebsd import EBSD, LazyEBSD
 
 DIR_PATH = os.path.dirname(__file__)
 KIKUCHIPY_FILE = os.path.join(DIR_PATH, "../../data/kikuchipy_h5ebsd/patterns.h5")
@@ -36,20 +34,20 @@ class TestIO:
     def test_load(self, filename):
         if filename == "im_not_here.h5":
             with pytest.raises(IOError, match="No filename matches"):
-                _ = load(filename)
+                _ = kp.load(filename)
         else:
-            s = load(KIKUCHIPY_FILE)
+            s = kp.load(KIKUCHIPY_FILE)
             with tempfile.TemporaryDirectory() as tmp:
                 file_path = os.path.join(tmp, "supported.h5")
                 s.save(file_path)
                 new_file_path = os.path.join(tmp, filename)
                 os.rename(file_path, new_file_path)
                 with pytest.raises(IOError, match="Could not read"):
-                    _ = load(new_file_path)
+                    _ = kp.load(new_file_path)
             gc.collect()
 
     def test_dict2signal(self):
-        scan_dict = kikuchipy_h5ebsd.file_reader(KIKUCHIPY_FILE)[0]
+        scan_dict = kp.io.plugins.kikuchipy_h5ebsd.file_reader(KIKUCHIPY_FILE)[0]
         scan_dict["metadata"]["Signal"]["record_by"] = "not-image"
         with pytest.raises(ValueError, match="kikuchipy only supports"):
             _ = _dict2signal(scan_dict)
@@ -97,13 +95,13 @@ class TestIO:
                 lazy=lazy,
             )
             if not lazy:
-                assert signal == EBSD
+                assert signal == kp.signals.EBSD
             else:
-                assert signal == LazyEBSD
+                assert signal == kp.signals.LazyEBSD
 
     @pytest.mark.parametrize("extension", ("", ".h4"))
     def test_save_extensions(self, extension):
-        s = load(KIKUCHIPY_FILE)
+        s = kp.load(KIKUCHIPY_FILE)
         with tempfile.TemporaryDirectory() as tmp:
             file_path = os.path.join(tmp, "supported" + extension)
             if extension == "":
@@ -116,13 +114,13 @@ class TestIO:
 
     @pytest.mark.filterwarnings("ignore:Using `set_signal_dimension`")
     def test_save_data_dimensions(self):
-        s = load(KIKUCHIPY_FILE)
+        s = kp.load(KIKUCHIPY_FILE)
         s.axes_manager.set_signal_dimension(3)
         with pytest.raises(ValueError, match="This file format cannot write"):
             s.save()
 
     def test_save_to_existing_file(self, save_path_hdf5):
-        s = load(KIKUCHIPY_FILE)
+        s = kp.load(KIKUCHIPY_FILE)
         s.save(save_path_hdf5)
         with pytest.warns(UserWarning, match="Your terminal does not"):
             s.save(save_path_hdf5, scan_number=2)
@@ -130,4 +128,4 @@ class TestIO:
             s.save(save_path_hdf5, scan_number=2, overwrite="False", add_scan=False)
         s.save(save_path_hdf5, scan_number=2, overwrite=False, add_scan=False)
         with pytest.raises(OSError, match="Scan 'Scan 2' is not among the"):
-            _ = load(save_path_hdf5, scan_group_names="Scan 2")
+            _ = kp.load(save_path_hdf5, scan_group_names="Scan 2")

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
         "diffsims           >= 0.5",
         "hyperspy           >= 1.7.1",
         "h5py               >= 2.10",
+        "imageio",
         "matplotlib         >= 3.3",
         "numba              >= 0.48",
         "numpy              >= 1.19",


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Add reader of an EBSD signal from a directory EBSD pattern images, assuming they all have the same shape and data type, closing #459. This adds a dependency on `imageio` (which HyperSpy already has).

The navigation/map shape is attempted read from the filenames, possibly specified in a regular expression passed to `xy_pattern`, like `r"-x(\d+)y(\d+).tif"`, and if this does not work, the returned signal will have one navigation dimension.

You might find this reader useful, @IMBalENce.

Note that no metadata is read from the image files.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> dir_data = "/home/hakon/directory_with_patterns/"
>>> import os
>>> os.listdir(dir_data)
['pattern_x0y1.bmp',
 'pattern_x0y2.bmp',
 'pattern_x1y1.bmp',
 'pattern_x1y0.bmp',
 'pattern_x1y2.bmp',
 'pattern_x0y0.bmp',
 'pattern_x2y0.bmp',
 'pattern_x2y1.bmp',
 'pattern_x2y2.bmp']
>>> import kikuchipy as kp
>>> s = kp.load(os.path.join(dir_data, "*.bmp"))
>>> s
<EBSD, title: patterns , dimensions: (3, 3|60, 60)>
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py` and `.all-contributorsrc` and the table 
      is regenerated.
