### PR TITLE
Add calib. pat. coords. and area/ROI shapes to NORDIF calib. pat. original metadata

### DIFF
--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -20,7 +20,6 @@ from numbers import Number
 import os
 from packaging import version
 import tempfile
-import warnings
 
 import dask.array as da
 from diffpy.structure import Atom, Lattice, Structure
@@ -40,9 +39,6 @@ if kp._pyvista_installed:
 
     pv.OFF_SCREEN = True
     pv.global_theme.interactive = False
-
-
-warnings.filterwarnings("always", category=DeprecationWarning)
 
 
 # ------------------------- Helper functions ------------------------- #

--- a/kikuchipy/data/nordif/Setting_bad3.txt
+++ b/kikuchipy/data/nordif/Setting_bad3.txt
@@ -1,0 +1,92 @@
+[NORDIF]		
+Software version	3.1.2	
+		
+[Microscope]		
+Manufacturer	Hitachi	
+Model	SU-6600	
+Magnification	200	#
+Scan direction	Direct	
+Accelerating voltage	20	kV
+Working distance	24.7	mm
+Tilt angle	70	�
+		
+[Signal voltages]		
+Minimum	0.0	V
+Maximum	1.0	V
+		
+[Deflection voltages]		
+Minimum	-5.5	V
+Maximum	5.5	V
+		
+[Electron image]		
+Frame rate	0.25	fps
+Resolutio	1000x1000	px
+Rotation	0	�
+Flip x-axis	False	
+Flip y-axis	False	
+Calibration factor	7273	�m/V
+Tilt axis	x-axis	
+		
+[Aspect ratio]		
+X-axis	1.000	
+Y-axis	1.000	
+		
+[EBSD detector]		
+Model	UF1100	
+Port position	90	
+Jumbo frames	False	
+		
+[Detector angles]		
+Euler 1	0	�
+Euler 2	0	�
+Euler 3	0	�
+Azimuthal	0	�
+Elevation	0	�
+		
+[Acquisition settings]		
+Frame rate	202	fps
+Resolution	60x60	px
+Exposure time	3500	�s
+Gain	0	
+		
+[Calibration settings]		
+Frame rate	10	fps
+Resolution	60x60	px
+Exposure time	99950	�s
+Gain	8	
+		
+[Specimen]		
+Name	Ni	
+Mounting	1. ND||EB TD||TA	
+		
+[Phase 1]		
+Name		
+Pearson S.T.		
+IT		
+		
+[Phase 2]		
+Name		
+Pearson S.T.		
+IT		
+		
+[Region of interest]		
+		
+[Area]		
+To	89.200 (223)	�m (px)
+Left	60.384 (152)	�m (px)
+Width	4.500 (11)	�m (px)
+Height	4.500 (11)	�m (px)
+Step size	1.000	�m
+Number of samples	3x3	#
+Scan time	00:02:28	
+		
+[Points of interest]		
+		
+[Acquisition patterns]		
+Acquisition (507,500)	507,500	px
+Acquisition (393,501)	393,501	px
+Acquisition (440,448)	440,448	px
+		
+[Calibration patterns]		
+Calibration (425,447)	425,447	px
+Calibration (294,532)	294,532	px

--- a/kikuchipy/io/plugins/edax_h5ebsd.py
+++ b/kikuchipy/io/plugins/edax_h5ebsd.py
@@ -96,7 +96,7 @@ class EDAXH5EBSDReader(H5EBSDReader):
         """
         hd = _hdf5group2dict(group["EBSD/Header"], recursive=True)
         if "SEM-PRIAS Images" in group.keys():
-            sd = _hdf5group2dict(group["SEM-PRIAS Images"])
+            sd = _hdf5group2dict(group["SEM-PRIAS Images/Header"])
         else:
             sd = {}
 
@@ -117,7 +117,7 @@ class EDAXH5EBSDReader(H5EBSDReader):
             "Acquisition_instrument": {
                 "SEM": {
                     "working_distance": hd.get("Working Distance"),
-                    "magnification": sd.get("Header", {}).get("Mag"),
+                    "magnification": sd.get("Mag"),
                 },
             },
             "General": {"original_filename": fname, "title": title},

--- a/kikuchipy/io/plugins/nordif.py
+++ b/kikuchipy/io/plugins/nordif.py
@@ -17,6 +17,7 @@
 
 """Reader and writer of EBSD patterns from a NORDIF binary file."""
 
+import logging
 import os
 from pathlib import Path
 import re
@@ -32,6 +33,7 @@ from kikuchipy.detectors import EBSDDetector
 
 __all__ = ["file_reader", "file_writer"]
 
+_logger = logging.getLogger(__name__)
 
 # Plugin characteristics
 # ----------------------
@@ -100,7 +102,7 @@ def file_reader(
         setting_file = os.path.join(folder, "Setting.txt")
     setting_file_exists = os.path.isfile(setting_file)
     if setting_file_exists:
-        md, omd, scan_size_file, detector_dict = get_settings_from_file(setting_file)
+        md, omd, scan_size_file, detector_dict = _get_settings_from_file(setting_file)
         if not scan_size:
             scan_size = (scan_size_file["nx"], scan_size_file["ny"])
         if not pattern_size:
@@ -210,7 +212,7 @@ def file_reader(
     return [scan]
 
 
-def get_settings_from_file(
+def _get_settings_from_file(
     filename: str, pattern_type: str = "acquisition"
 ) -> Tuple[dict, dict, dict, dict]:
     """Return metadata with parameters from NORDIF setting file.
@@ -240,9 +242,11 @@ def get_settings_from_file(
     # Get line numbers of setting blocks
     blocks = {
         "[Microscope]": -1,
+        "[Electron image]": -1,
         "[Detector angles]": -1,
         f"[{pattern_type.capitalize()} settings]": -1,
         "[Area]": -1,
+        "[Calibration patterns]": -1,
     }
     for i, line in enumerate(content):
         for block in blocks:
@@ -254,11 +258,11 @@ def get_settings_from_file(
     l_area = blocks["[Area]"]
 
     # Create metadata and original metadata structures
-    beam_energy = get_string(content, "Accelerating voltage\t(.*)\tkV", l_mic + 5, f)
-    mic_manufacturer = get_string(content, "Manufacturer\t(.*)\t", l_mic + 1, f)
-    mic_model = get_string(content, "Model\t(.*)\t", l_mic + 2, f)
-    mag = get_string(content, "Magnification\t(.*)\t#", l_mic + 3, f)
-    wd = get_string(content, "Working distance\t(.*)\tmm", l_mic + 6, f)
+    beam_energy = _get_string(content, "Accelerating voltage\t(.*)\tkV", l_mic + 5, f)
+    mic_manufacturer = _get_string(content, "Manufacturer\t(.*)\t", l_mic + 1, f)
+    mic_model = _get_string(content, "Model\t(.*)\t", l_mic + 2, f)
+    mag = _get_string(content, "Magnification\t(.*)\t#", l_mic + 3, f)
+    wd = _get_string(content, "Working distance\t(.*)\tmm", l_mic + 6, f)
     md = {
         "Acquisition_instrument": {
             "SEM": {
@@ -272,11 +276,11 @@ def get_settings_from_file(
     omd = {"nordif_header": content}
 
     # Get scan size values
-    num_samp = get_string(content, "Number of samples\t(.*)\t#", l_area + 6, f)
+    num_samp = _get_string(content, "Number of samples\t(.*)\t#", l_area + 6, f)
     ny, nx = [int(i) for i in num_samp.split("x")]
-    pattern_size = get_string(content, "Resolution\t(.*)\tpx", l_acq + 2, f)
+    pattern_size = _get_string(content, "Resolution\t(.*)\tpx", l_acq + 2, f)
     sx, sy = [int(i) for i in pattern_size.split("x")]
-    step_size = float(get_string(content, "Step size\t(.*)\t", l_area + 5, f))
+    step_size = float(_get_string(content, "Step size\t(.*)\t", l_area + 5, f))
     scan_size = {
         "ny": ny,
         "nx": nx,
@@ -289,15 +293,27 @@ def get_settings_from_file(
     # Detector
     detector = {
         "shape": (sy, sx),
-        "sample_tilt": float(get_string(content, "Tilt angle\t(.*)\t", l_mic + 7, f)),
-        "tilt": float(get_string(content, "Elevation\t(.*)\t", l_ang + 5, f)),
-        "azimuthal": float(get_string(content, "Azimuthal\t(.*)\t", l_ang + 4, f)),
+        "sample_tilt": float(_get_string(content, "Tilt angle\t(.*)\t", l_mic + 7, f)),
+        "tilt": -float(_get_string(content, "Elevation\t(.*)\t", l_ang + 5, f)),
+        "azimuthal": float(_get_string(content, "Azimuthal\t(.*)\t", l_ang + 4, f)),
     }
+
+    if pattern_type == "calibration":
+        omd = _get_calibration_pattern_settings(
+            filename=filename,
+            content=content,
+            blocks=blocks,
+            omd=omd,
+            l_area=l_area,
+            step_size=step_size,
+            ny=ny,
+            nx=nx,
+        )
 
     return md, omd, scan_size, detector
 
 
-def get_string(content: list, expression: str, line_no: int, file) -> str:
+def _get_string(content: list, expression: str, line_no: int, file) -> str:
     """Get relevant part of string using regular expression.
 
     Parameters
@@ -346,3 +362,101 @@ def file_writer(filename: str, signal: Union["EBSD", "LazyEBSD"]):
         else:
             for pattern in signal._iterate_signal():
                 pattern.flatten().tofile(f)
+
+
+def _get_calibration_pattern_settings(
+    filename: str,
+    content: list,
+    blocks: dict,
+    omd: dict,
+    l_area: int,
+    step_size: float,
+    ny: int,
+    nx: int,
+) -> dict:
+    l_cal = blocks["[Calibration patterns]"]
+    err = "No calibration patterns found in settings file"
+    if l_cal == -1:
+        raise ValueError(err)
+
+    # Read required calibration coordinates in the area region of
+    # interest
+    rc = []
+    for line in content[l_cal + 1 :]:
+        match = re.search(r"Calibration \((.*)\)", line)
+        try:
+            match = match.group(1)
+            match = match.split(",")
+            rc.append(tuple(map(int, match))[::-1])
+        except AttributeError:
+            pass
+    if len(rc) == 0:
+        raise ValueError(err)
+    rc = np.array(rc)
+    omd["calibration_patterns"] = {"indices": rc}
+
+    # Read width and height of area and ROI in area. This is added
+    # to the original metadata as it is only required if we want to
+    # know the sample position of each calibration pattern, e.g.
+    # when fitting a plane to projection centers found from the
+    # patterns.
+    l_img = blocks["[Electron image]"]
+    img_string = re.search("(?<=Resolution)(.*)", content[l_img + 2])
+    if img_string is not None:
+        area_shape_match = re.findall(r"\d+", img_string.group())
+        if len(area_shape_match) == 2:
+            omd["area"] = {"shape": tuple(map(int, area_shape_match[::-1]))}
+    else:
+        omd["area"] = {"shape": None}
+        _logger.debug("Could not read area (electron image) shape")
+
+    keys = [
+        "top",
+        "left",
+        "width",
+        "height",
+        "width_scaled",
+    ]
+    roi = dict(zip(keys, len(keys) * [0]))
+    for i, k in enumerate(keys[:4]):
+        pattern = r"(?<=" + k.capitalize() + r")(.*)"
+        match = re.search(pattern, content[l_area + i + 1])
+        if match is not None:
+            matches = re.findall(r"\d+", match.group())
+            roi[k] = int(matches[2])
+            if k == "width":
+                roi[k + "_scaled"] = float(f"{matches[0]}.{matches[1]}")
+        else:
+            _logger.debug(f"Could not read area ROI '{k.capitalize()}'")
+    omd["roi"] = {
+        "origin": (roi["top"], roi["left"]),
+        "shape": (roi["height"], roi["width"]),
+    }
+    if roi["width_scaled"] != 0:
+        factor = step_size * roi["width"] / roi["width_scaled"]
+
+        def scale(x, return_tuple: bool = False):
+            x_out = np.round(np.asarray(x) / factor).astype(int)
+            if return_tuple:
+                x_out = tuple(x_out)
+            return x_out
+
+        omd["calibration_patterns"]["indices_scaled"] = scale(rc)
+        omd["area"]["shape_scaled"] = scale(omd["area"]["shape"], True)
+        omd["roi"]["origin_scaled"] = scale(omd["roi"]["origin"], True)
+        omd["roi"]["shape_scaled"] = scale(omd["roi"]["shape"], True)
+
+        if omd["roi"]["shape_scaled"] != (ny, nx):
+            _logger.debug(
+                f"Number of samples {(ny, nx)} differs from the one calculated from"
+                f" area/ROI shapes {omd['roi']['shape_scaled']}"
+            )
+
+    # Try to read area overview image
+    filename_img = os.path.join(os.path.dirname(filename), "Area.bmp")
+    try:
+        omd["area_image"] = imread(filename_img)
+    except FileNotFoundError:
+        _logger.debug("No area image found")
+
+    return omd

--- a/kikuchipy/io/plugins/nordif_calibration_patterns.py
+++ b/kikuchipy/io/plugins/nordif_calibration_patterns.py
@@ -19,7 +19,6 @@
 
 import os
 from pathlib import Path
-import re
 from typing import List, Tuple, Union
 import warnings
 

--- a/kikuchipy/io/plugins/oxford_binary.py
+++ b/kikuchipy/io/plugins/oxford_binary.py
@@ -99,8 +99,8 @@ class OxfordBinaryFileReader:
     """
 
     # Header for each pattern in the file
-    pattern_header_size = 16
-    pattern_header_dtype = [
+    pattern_header_size: int = 16
+    pattern_header_dtype: list = [
         ("is_compressed", np.int32, (1,)),
         ("nrows", np.int32, (1,)),
         ("ncols", np.int32, (1,)),
@@ -188,7 +188,7 @@ class OxfordBinaryFileReader:
     @property
     def n_patterns_present(self) -> int:
         """Number of patterns actually stored in the file."""
-        return np.sum(self.pattern_is_present)
+        return int(np.sum(self.pattern_is_present))
 
     @property
     def pattern_order(self) -> np.ndarray:
@@ -249,7 +249,7 @@ class OxfordBinaryFileReader:
         return np.memmap(
             self.file.name,
             dtype=file_dtype,
-            shape=self.n_patterns_present,
+            shape=(self.n_patterns_present,),
             mode="r",
             offset=self.first_pattern_position,
         )
@@ -299,8 +299,8 @@ class OxfordBinaryFileReader:
     def get_pattern_starts(self) -> np.ndarray:
         """Return the file byte positions of each pattern.
 
-        Parameters
-        ----------
+        Returns
+        -------
         pattern_starts
             Integer array of file byte positions.
         """
@@ -313,6 +313,11 @@ class OxfordBinaryFileReader:
 
         Parameters
         ----------
+        offset
+            File byte pattern start of the pattern of interest.
+
+        Returns
+        -------
         footer_dtype
             Format of each pattern footer as a list of tuples with a
             field name, data type and size. The format depends on the
@@ -379,7 +384,7 @@ class OxfordBinaryFileReader:
 
         return data
 
-    def get_single_pattern_footer(self, offset: int) -> tuple:
+    def get_single_pattern_footer(self, offset: int) -> np.ndarray:
         """Return a single pattern footer with pattern beam positions.
 
         Parameters
@@ -390,8 +395,7 @@ class OxfordBinaryFileReader:
         Returns
         -------
         footer
-            The format of this depends on the file
-            :attr:`~self.version`.
+            The format of this depends on the file :attr:`version`.
         """
         self.file.seek(offset + self.pattern_header_size + self.n_bytes)
         return np.fromfile(self.file, dtype=self.pattern_footer_dtype, count=1)
@@ -490,9 +494,9 @@ class OxfordBinaryFileReader:
             file_order=order,
         )
         if "beam_y" in self.memmap.dtype.names:
-            om["beam_y"] = beam_y = self.memmap["beam_y"][..., 0][order]
+            om["beam_y"] = self.memmap["beam_y"][..., 0][order]
         if "beam_x" in self.memmap.dtype.names:
-            om["beam_x"] = beam_x = self.memmap["beam_x"][..., 0][order]
+            om["beam_x"] = self.memmap["beam_x"][..., 0][order]
 
         scan = dict(
             axes=axes,

--- a/kikuchipy/io/plugins/tests/test_nordif.py
+++ b/kikuchipy/io/plugins/tests/test_nordif.py
@@ -34,7 +34,7 @@ import pytest
 from kikuchipy.conftest import assert_dictionary
 from kikuchipy.detectors import EBSDDetector
 from kikuchipy.io._io import load
-from kikuchipy.io.plugins.nordif import get_settings_from_file, get_string
+from kikuchipy.io.plugins.nordif import _get_settings_from_file, _get_string
 from kikuchipy.signals.ebsd import EBSD
 
 DIR_PATH = os.path.dirname(__file__)
@@ -203,7 +203,7 @@ def save_path_nordif():
 
 class TestNORDIF:
     def test_get_settings_from_file(self):
-        settings = get_settings_from_file(SETTING_FILE)
+        settings = _get_settings_from_file(SETTING_FILE)
         answers = [METADATA, ORIGINAL_METADATA, SCAN_SIZE_FILE, DETECTOR]
         assert len(settings) == len(answers)
         for setting_read, answer in zip(settings, answers):
@@ -215,13 +215,13 @@ class TestNORDIF:
         content = f.read().splitlines()
         exp = "Tilt angle\t(.*)\t"
         if correct:
-            sample_tilt = get_string(
+            sample_tilt = _get_string(
                 content=content, expression=exp, line_no=line_no, file=f
             )
             assert sample_tilt == "70"
         else:
             with pytest.warns(UserWarning):
-                sample_tilt = get_string(
+                sample_tilt = _get_string(
                     content=content, expression=exp, line_no=line_no, file=f
                 )
             assert sample_tilt == ""

--- a/kikuchipy/io/plugins/tests/test_nordif_calibration_patterns.py
+++ b/kikuchipy/io/plugins/tests/test_nordif_calibration_patterns.py
@@ -16,39 +16,85 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from pathlib import Path
 
 from matplotlib.pyplot import imread
 import numpy as np
 import pytest
 
 import kikuchipy as kp
-from kikuchipy.io.plugins.nordif_calibration_patterns import _get_coordinates
 
 
-DIR_PATH = os.path.dirname(__file__)
-NORDIF_DIR = os.path.join(DIR_PATH, "../../../data/nordif")
-BG_FILE = os.path.join(NORDIF_DIR, "Background acquisition pattern.bmp")
+DIR_PATH = Path(os.path.dirname(__file__))
+NORDIF_DIR = DIR_PATH / "../../../data/nordif"
+BG_FILE = NORDIF_DIR / "Background acquisition pattern.bmp"
 
 
 class TestNORDIFCalibrationPatterns:
-    def test_read(self):
-        s = kp.load(os.path.join(NORDIF_DIR, "Setting.txt"))
+    def test_read(self, caplog):
+        caplog.set_level("DEBUG", logger="kikuchipy")
+
+        s = kp.load(NORDIF_DIR / "Setting.txt")
         assert s.data.shape == (2, 60, 60)
         assert np.allclose(s.static_background, imread(BG_FILE))
         assert isinstance(s.detector, kp.detectors.EBSDDetector)
         assert s.detector.shape == s.data.shape[1:]
         assert s.detector.sample_tilt == 70
 
+        # Calibration specific original metadata
+        omd = s.original_metadata.as_dictionary()
+        # Calibration pattern indices
+        assert np.allclose(
+            omd["calibration_patterns"]["indices"], [[447, 425], [532, 294]]
+        )
+        assert np.allclose(
+            omd["calibration_patterns"]["indices_scaled"], [[122, 116], [145, 80]]
+        )
+        # Area
+        assert omd["area"]["shape"] == (1000, 1000)
+        assert omd["area"]["shape_scaled"] == (273, 273)
+        # ROI within area
+        assert omd["roi"]["origin"] == (223, 152)
+        assert omd["roi"]["shape"] == (11, 11)
+        assert omd["roi"]["origin_scaled"] == (61, 41)
+        assert omd["roi"]["shape_scaled"] == (3, 3)
+        # Area image
+        assert "area_image" not in omd
+        record = caplog.records[0]
+        assert (record.levelname, record.message) == ("DEBUG", "No area image found")
+
     @pytest.mark.parametrize("setting_file", ["Setting_bad1.txt", "Setting_bad2.txt"])
-    def test_get_coordinates_raises(self, setting_file):
+    def test_no_patterns_raises(self, setting_file):
         with pytest.raises(ValueError, match="No calibration patterns found"):
-            _ = _get_coordinates(os.path.join(NORDIF_DIR, setting_file))
+            _ = kp.load(NORDIF_DIR / setting_file)
 
     def test_background_file_not_found(self):
         fname_orig = "Background calibration pattern.bmp"
-        file_orig = os.path.join(NORDIF_DIR, fname_orig)
-        file_new = os.path.join(NORDIF_DIR, file_orig + ".bak")
+        file_orig = NORDIF_DIR / fname_orig
+        file_new = NORDIF_DIR / (fname_orig + ".bak")
         os.rename(file_orig, file_new)
         with pytest.warns(UserWarning, match="Could not read static"):
-            _ = kp.load(os.path.join(NORDIF_DIR, "Setting.txt"))
+            _ = kp.load(NORDIF_DIR / "Setting.txt")
         os.rename(file_new, file_orig)
+
+    def test_logs_incorrect_shapes(self, caplog):
+        caplog.set_level("DEBUG", logger="kikuchipy")
+
+        s = kp.load(NORDIF_DIR / "Setting_bad3.txt")
+        omd = s.original_metadata.as_dictionary()
+
+        assert omd["area"]["shape"] is None
+        assert "area_image" not in omd
+
+        assert len(caplog.records) == 4
+        for record, message in zip(
+            caplog.records,
+            [
+                "Could not read area (electron image) shape",
+                "Could not read area ROI 'Top'",
+                "Number of samples (3, 3) differs from the one calculated from area/ROI shapes (4, 4)",
+                "No area image found",
+            ],
+        ):
+            assert record.levelname == "DEBUG"
+            assert record.message == message


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR adds the following information to the `original_metadata` of a returned EBSD signal with NORDIF calibration patterns (reading of a Setting.txt file):
* Calibration pattern coordinates
* Shapes of area (electron image) and region of interest (ROI)
* Area (electron) image

The coordinates and shapes are given both in terms of pixels in the area image and in terms of the actual navigation shape of the ROI.

This information is required to fit a plane of projection centers (PCs) to selected PCs determined from the calibration patterns. 

Other change(s):
* Magnification is read correctly from EDAX h5ebsd files.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> s = kp.data.ni_gain0_calibration(allow_download=True)  # or kp.load("Setting.txt")
>>> s
<EBSD, title: Calibration patterns, dimensions: (9|480, 480)>
>>> s.original_metadata.as_dictionary()  # "nordif_header" entry is omitted
{'calibration_patterns': {'indices': array([[447, 425],
         [532, 294],
         [543, 573],
         [378, 596],
         [369, 308],
         [632, 171],
         [668, 704],
         [269, 696],
         [247, 152]]),
  'indices_scaled': array([[119, 113],
         [142,  78],
         [145, 153],
         [101, 159],
         [ 98,  82],
         [169,  46],
         [178, 188],
         [ 72, 186],
         [ 66,  41]])},
 'area': {'shape': (1000, 1000), 'shape_scaled': (267, 267)},
 'roi': {'origin': (185, 73),
  'shape': (558, 750),
  'origin_scaled': (49, 19),
  'shape_scaled': (149, 200)},
 'area_image': array([[144, 120, 165, ..., 255, 255, 252],
        [250, 222, 203, ..., 255, 255, 255],
        [255, 219, 186, ..., 249, 252, 255],
        ...,
        [120, 110, 116, ..., 121, 119, 118],
        [122,  99, 112, ..., 117, 127, 132],
        [122, 108, 121, ..., 112, 118, 122]], dtype=uint8)}
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
