### PR TITLE
Add saving and loading an EBSD detector to/from a text file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Unreleased
 
 Added
 -----
+- Saving and loading of an ``EBSDDetector``.
+  (`#595 <https://github.com/pyxem/kikuchipy/pull/595>`_)
 - EBSD refinement methods now return the number of function evaluations.
   (`#593 <https://github.com/pyxem/kikuchipy/pull/593>`_)
 - Which points in a crystal map to refine can be controlled by passing a navigation


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR adds saving and loading an EBSD detector to/from a text file using NumPy's `loadtxt()`. The method `EBSDDetector.save()` saves to file, while the classmethod `EBSDDetector.load()` returns an `EBSDDetector` from a text file.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> det = kp.detectors.EBSDDetector(shape=(60, 60), pc=[0.3, 0.2, 0.6])
>>> det
EBSDDetector (60, 60), px_size 1 um, binning 1, tilt 0, azimuthal 0, pc (0.3, 0.2, 0.6)
>>> fname = "det.txt"
>>> det.save(fname, convention="tsl", fmt="%.5f")
>>> header = []
>>> with open(fname, mode="r") as f:
>>>     for line in f.readlines():
>>>         if line.startswith("#"):
>>>             header.append(line)
>>>         else:
>>>             break
>>> header
['# EBSDDetector\n',
 '#   shape: (60, 60)\n',
 '#   px_size: 1\n',
 '#   binning: 1\n',
 '#   tilt: 0 deg\n',
 '#   azimuthal: 0 deg\n',
 '#   sample_tilt: 70 deg\n',
 '#   convention: tsl\n',
 '#   navigation_shape: (1,)\n',
 '# \n',
 '# kikuchipy version: 0.8.dev0\n',
 '# Time: 2023-01-23 13:04:34\n',
 '# \n',
 '# Column names: PCx, PCy, PCz\n']
>>> det2 = kp.detectors.EBSDDetector.load(fname)
>>> det2
EBSDDetector (60, 60), px_size 1 um, binning 1, tilt 0, azimuthal 0, pc (0.3, 0.2, 0.6)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
