### PR TITLE
Force rechunking of 2D pattern array before EBSD refinement

### DIFF
--- a/benchmarks/indexing/test_refinement.py
+++ b/benchmarks/indexing/test_refinement.py
@@ -101,7 +101,7 @@ def test_refine_pc(benchmark):
         navigation_mask=nav_mask1,
     )
 
-    scores_ref, detector_ref = benchmark(
+    _, detector_ref, _ = benchmark(
         s.refine_projection_center,
         xmap=xmap,
         detector=detector,

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -2950,9 +2950,16 @@ class EBSD(KikuchipySignal2D):
             signal_mask = ~signal_mask.ravel()
             patterns = patterns[:, signal_mask]
 
-        if (patterns.chunksize == patterns.shape) and rechunk:
+        if patterns.shape[0] == patterns.chunksize[0] and not rechunk:
+            pass
+        else:
             if chunk_kwargs is None:
-                chunk_kwargs = dict(chunk_shape=16, chunk_bytes=None)
+                chunk_kwargs = {}
+            if "chunk_shape" not in chunk_kwargs:
+                chunk_shape = patterns.chunksize[0]
+                if chunk_shape == patterns.shape[0]:
+                    chunk_shape = 64
+                chunk_kwargs["chunk_shape"] = chunk_shape
             chunks = get_chunking(
                 data_shape=patterns.shape,
                 nav_dim=1,


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fixes #594.

This fix is not listed in the changelog since it is internal.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
