### PR TITLE
Allow pseudo-symmetry operators in ori and ori/PC refinement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Unreleased
 
 Added
 -----
+- Passing pseudo-symmetry operators to orientation and orientation/PC EBSD refinement
+  methods in order to find the best match among pseudo-symmetric variants.
+  (`#598 <https://github.com/pyxem/kikuchipy/pull/598>`_)
 - Saving and loading of an ``EBSDDetector``.
   (`#595 <https://github.com/pyxem/kikuchipy/pull/595>`_)
 - EBSD refinement methods now return the number of function evaluations.

--- a/doc/user/applications.rst
+++ b/doc/user/applications.rst
@@ -12,10 +12,18 @@ If you think your work should be listed here, please raise an issue `on GitHub
 Most of these works are also listed when searching for ``"kikuchipy"`` `on Google Scholar
 <https://scholar.google.com/scholar?hl=no&as_sdt=0%2C5&q=%22kikuchipy%22&btnG=>`__.
 
+2023
+====
+
+- T. Bergh, H. W. Ånes, R. Aune, S. Wenner, R. Holmestad, X. Ren and P. E. Vullum,
+  "Intermetallic Phase Layers in Cold Metal Transfer Aluminium-Steel Welds with an
+  Al-Si–Mn Filler Alloy," *Materials Transactions* **64(2)** (2023).
+  https://doi.org/10.2320/matertrans.MT-LA2022046.
+
 2022
 ====
 
-- H. W. Ånes, A. T. J. van Helvoort, and K. Marthinsen, "Orientation dependent pinning
+- H. W. Ånes, A. T. J. van Helvoort and K. Marthinsen, "Orientation dependent pinning
   of (sub)grains by dispersoids during recovery and recrystallization in an Al-Mn
   alloy," *arXiv:2212.03527* (2022).
   https://doi.org/10.48550/arXiv.2212.03527.
@@ -23,11 +31,11 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
   Properties of Wire Arc Additive Manufacturing of Inconel 625," *Metals* **12(11)**
   (2022).
   https://doi.org/10.3390/met12111867
-- H. W. Ånes, A. T. J. van Helvoort, and K. Marthinsen, "Correlated subgrain and
+- H. W. Ånes, A. T. J. van Helvoort and K. Marthinsen, "Correlated subgrain and
   particle analysis of a recovered Al-Mn alloy by directly combining EBSD and
   backscatter electron imaging," *Materials Characterization* **193** (2022).
   https://doi.org/10.1016/j.matchar.2022.112228.
-- J. Schultheiß, F. Xue, E. Roede, H. W. Ånes, F. H. Danmo, S. M. Selbach, L.-Q. Chen,
+- J. Schultheiß, F. Xue, E. Roede, H. W. Ånes, F. H. Danmo, S. M. Selbach, L.-Q. Chen
   and D. Meier, "Confinement-driven inverse domain scaling in polycrystalline ErMnO3,"
   *Advanced Materials*, 2203449 (2022).
   https://doi.org/10.1002/adma.202203449.
@@ -35,7 +43,7 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
 2021
 ====
 
-- O. M. Akselsen, R. Bjørge, H. W. Ånes, X. Ren, and B. Nyhus, "Effect of Sigma Phase in
+- O. M. Akselsen, R. Bjørge, H. W. Ånes, X. Ren and B. Nyhus, "Effect of Sigma Phase in
   Wire Arc Additive Manufacturing of Superduplex Stainless Steel," *Metals* **11(12)**
   (2021).
   https://doi.org/10.3390/met11122045.
@@ -43,11 +51,11 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
 2020
 ====
 
-- B. E. Sørensen, J. Hjelen, H. W. Ånes, and T. Breivik, "Recent features in EBSD,
+- B. E. Sørensen, J. Hjelen, H. W. Ånes and T. Breivik, "Recent features in EBSD,
   including new trapezoidal correction for multi-mapping," In *IOP Conference Series:
   Materials Science and Engineering*, volume **891** IOP Publishing (2020).
   https://doi.org/10.1088/1757-899X/891/1/012021.
-- H. W. Ånes, J. Hjelen, B. E. Sørensen, A. T. J. van Helvoort, and K. Marthinsen,
+- H. W. Ånes, J. Hjelen, B. E. Sørensen, A. T. J. van Helvoort and K. Marthinsen,
   "Processing and indexing of electron backscatter patterns using open-source software,"
   In *IOP Conference Series: Materials Science and Engineering*, volume **891** IOP
   Publishing (2020).

--- a/doc/user/bibliography.bib
+++ b/doc/user/bibliography.bib
@@ -1,3 +1,13 @@
+@article{bergh2023intermetallic,
+  author  = {Tina Bergh and Håkon Wiik Ånes and Ragnhild Aune and Sigurd Wenner and Randi Holmestad and Xiaobo Ren and Per Erik Vullum},
+  title   = {Intermetallic Phase Layers in Cold Metal Transfer Aluminium-Steel Welds with an Al–Si–Mn Filler Alloy},
+  doi     = {10.2320/matertrans.MT-LA2022046},
+  number  = {2},
+  pages   = {352-359},
+  volume  = {64},
+  journal = {MATERIALS TRANSACTIONS},
+  year    = {2023},
+}
 @article{brewick2019nlpar,
 	author = {Brewick, Patrick T. and Wright, Stuart I. and Rowenhorst, David J.},
 	doi = {10.1016/j.ultramic.2019.02.013},

--- a/kikuchipy/_rotation/__init__.py
+++ b/kikuchipy/_rotation/__init__.py
@@ -162,7 +162,7 @@ def _rotate_vector(rotation: np.ndarray, vector: np.ndarray) -> np.ndarray:
     bd = b * d
     cd = c * d
 
-    rotated_vector = np.zeros(vector.shape)
+    rotated_vector = np.zeros(vector.shape, dtype=np.float64)
     rotated_vector[:, 0] = (aa + bb - cc - dd) * x + 2 * ((ac + bd) * z + (bc - ad) * y)
     rotated_vector[:, 1] = (aa - bb + cc - dd) * y + 2 * ((ad + bc) * x + (cd - ab) * z)
     rotated_vector[:, 2] = (aa - bb - cc + dd) * z + 2 * ((ab + cd) * y + (bd - ac) * x)

--- a/kikuchipy/indexing/_refinement/_objective_functions.py
+++ b/kikuchipy/indexing/_refinement/_objective_functions.py
@@ -20,9 +20,6 @@ projection centers by optimizing the similarity between experimental
 and simulated patterns.
 """
 
-from typing import Tuple
-
-from numba import njit
 import numpy as np
 
 from kikuchipy.indexing.similarity_metrics._normalized_cross_correlation import (

--- a/kikuchipy/indexing/_refinement/_objective_functions.py
+++ b/kikuchipy/indexing/_refinement/_objective_functions.py
@@ -20,6 +20,9 @@ projection centers by optimizing the similarity between experimental
 and simulated patterns.
 """
 
+from typing import Tuple
+
+from numba import njit
 import numpy as np
 
 from kikuchipy.indexing.similarity_metrics._normalized_cross_correlation import (

--- a/kikuchipy/indexing/_refinement/_refinement.py
+++ b/kikuchipy/indexing/_refinement/_refinement.py
@@ -964,16 +964,16 @@ class _RefinementSetup:
 
         # Relevant projection centers as a Dask array of shape
         # (navigation size, 1, n variables)
-        self.unique_pc = detector.navigation_size != 1 and self.nav_size > 1
-        dtype = np.float64
+        self.unique_pc = detector.navigation_size > 1
         if self.unique_pc:
             # Patterns have been initially indexed with varying PCs, so
             # we use these as the starting point for every pattern
-            pc = detector.pc_flattened[points_to_refine].astype(dtype)
+            pc = detector.pc_flattened[points_to_refine]
         else:
             # Patterns have been initially indexed with the same PC, so
             # we use this as the starting point for every pattern
-            pc = np.full((int(points_to_refine.sum()), 3), detector.pc[0], dtype=dtype)
+            pc = np.full((int(points_to_refine.sum()), 3), detector.pc[0])
+        pc = pc.astype(np.float64)
         pc = np.expand_dims(pc, 1)  # Pseudo-symmetry operator axis
         self.pc_array = da.from_array(pc, chunks=self.chunks)
 

--- a/kikuchipy/indexing/_refinement/_solvers.py
+++ b/kikuchipy/indexing/_refinement/_solvers.py
@@ -85,7 +85,11 @@ def _refine_orientation_solver_scipy(
     tilt: Optional[float] = None,
     azimuthal: Optional[float] = None,
     sample_tilt: Optional[float] = None,
-) -> Tuple[float, int, float, float, float]:
+    n_pseudo_symmetry_ops: int = 0,
+) -> Union[
+    Tuple[float, int, float, float, float],
+    Tuple[float, int, int, float, float, float],
+]:
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the orientation
     (Rodrigues-Frank vector) used in the projection.
@@ -139,6 +143,8 @@ def _refine_orientation_solver_scipy(
     sample_tilt
         Sample tilt from horizontal in degrees. Must be passed if
         ``direction_cosines`` is not given.
+    n_pseudo_symmetry_ops
+        Number of pseudo-symmetry operators. Default is 0.
 
     Returns
     -------
@@ -167,35 +173,74 @@ def _refine_orientation_solver_scipy(
     params = (pattern,) + (direction_cosines,) + fixed_parameters + (squared_norm,)
     method_name = method.__name__
 
-    if method_name == "minimize":
-        if trust_region_passed:
-            method_kwargs["bounds"] = bounds
-        res = method(
-            fun=_refine_orientation_objective_function,
-            x0=rotation,
-            args=params,
-            **method_kwargs,
-        )
-    elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
-        res = method(
-            func=_refine_orientation_objective_function,
-            args=params,
-            bounds=bounds,
-            **method_kwargs,
-        )
-    else:  # Is always "basinhopping", due to prior check of method name
-        method_kwargs["minimizer_kwargs"].update(args=params)
-        res = method(
-            func=_refine_orientation_objective_function,
-            x0=rotation,
-            **method_kwargs,
-        )
+    if n_pseudo_symmetry_ops == 0:
+        if method_name == "minimize":
+            if trust_region_passed:
+                method_kwargs["bounds"] = bounds[0]
+            res = method(
+                fun=_refine_orientation_objective_function,
+                x0=rotation[0],
+                args=params,
+                **method_kwargs,
+            )
+        elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
+            res = method(
+                func=_refine_orientation_objective_function,
+                args=params,
+                bounds=bounds[0],
+                **method_kwargs,
+            )
+        else:  # Is always "basinhopping", due to prior check of method name
+            method_kwargs["minimizer_kwargs"].update(args=params)
+            res = method(
+                func=_refine_orientation_objective_function,
+                x0=rotation[0],
+                **method_kwargs,
+            )
 
-    ncc = 1 - res.fun
-    num_evals = res.nfev
-    phi1, Phi, phi2 = res.x
+        ncc = 1 - res.fun
+        num_evals = res.nfev
+        phi1, Phi, phi2 = res.x
 
-    return ncc, num_evals, phi1, Phi, phi2
+        return ncc, num_evals, phi1, Phi, phi2
+    else:
+        res_list = []
+        for i in range(n_pseudo_symmetry_ops + 1):
+            if method_name == "minimize":
+                if trust_region_passed:
+                    method_kwargs["bounds"] = bounds[i]
+                res = method(
+                    fun=_refine_orientation_objective_function,
+                    x0=rotation[i],
+                    args=params,
+                    **method_kwargs,
+                )
+            elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
+                res = method(
+                    func=_refine_orientation_objective_function,
+                    args=params,
+                    bounds=bounds[i],
+                    **method_kwargs,
+                )
+            else:  # Is always "basinhopping", due to prior check of method name
+                method_kwargs["minimizer_kwargs"].update(args=params)
+                res = method(
+                    func=_refine_orientation_objective_function,
+                    x0=rotation[i],
+                    **method_kwargs,
+                )
+
+            res_list.append(res)
+
+        ncc_all = [1 - res.fun for res in res_list]
+        best_idx = int(np.argmax(ncc_all))
+
+        best_res = res_list[best_idx]
+        ncc = ncc_all[best_idx]
+        num_evals = best_res.nfev
+        phi1, Phi, phi2 = best_res.x
+
+        return ncc, num_evals, phi1, Phi, phi2, best_idx
 
 
 def _refine_pc_solver_scipy(
@@ -290,7 +335,11 @@ def _refine_orientation_pc_solver_scipy(
     method_kwargs: dict,
     fixed_parameters: tuple,
     trust_region_passed: bool,
-) -> Tuple[float, int, float, float, float, float, float, float]:
+    n_pseudo_symmetry_ops: int = 0,
+) -> Union[
+    Tuple[float, int, float, float, float, float, float, float],
+    Tuple[float, int, int, float, float, float, float, float, float],
+]:
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the orientation and
     projection center (PC) parameters used in the projection.
@@ -328,41 +377,81 @@ def _refine_orientation_pc_solver_scipy(
         Optimized orientation (Euler angles) in radians.
     pcx_refined, pcy_refined, pcz_refined
         Optimized PC parameters in the Bruker convention.
+    best_idx
     """
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     params = (pattern,) + fixed_parameters + (squared_norm,)
     method_name = method.__name__
 
-    if method_name == "minimize":
-        if trust_region_passed:
-            method_kwargs["bounds"] = bounds
-        res = method(
-            fun=_refine_orientation_pc_objective_function,
-            x0=rot_pc,
-            args=params,
-            **method_kwargs,
-        )
-    elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
-        res = method(
-            func=_refine_orientation_pc_objective_function,
-            args=params,
-            bounds=bounds,
-            **method_kwargs,
-        )
-    else:  # Is always "basinhopping", due to prior check of method name
-        method_kwargs["minimizer_kwargs"].update(args=params)
-        res = method(
-            func=_refine_orientation_pc_objective_function,
-            x0=rot_pc,
-            **method_kwargs,
-        )
+    if n_pseudo_symmetry_ops == 0:
+        if method_name == "minimize":
+            if trust_region_passed:
+                method_kwargs["bounds"] = bounds[0]
+            res = method(
+                fun=_refine_orientation_pc_objective_function,
+                x0=rot_pc[0],
+                args=params,
+                **method_kwargs,
+            )
+        elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
+            res = method(
+                func=_refine_orientation_pc_objective_function,
+                args=params,
+                bounds=bounds[0],
+                **method_kwargs,
+            )
+        else:  # Is always "basinhopping", due to prior check of method name
+            method_kwargs["minimizer_kwargs"].update(args=params)
+            res = method(
+                func=_refine_orientation_pc_objective_function,
+                x0=rot_pc[0],
+                **method_kwargs,
+            )
 
-    ncc = 1 - res.fun
-    phi1, Phi, phi2, pcx, pcy, pcz = res.x
-    num_evals = res.nfev
+        ncc = 1 - res.fun
+        phi1, Phi, phi2, pcx, pcy, pcz = res.x
+        num_evals = res.nfev
 
-    return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz
+        return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz
+    else:
+        res_list = []
+        for i in range(n_pseudo_symmetry_ops + 1):
+            if method_name == "minimize":
+                if trust_region_passed:
+                    method_kwargs["bounds"] = bounds[i]
+                res = method(
+                    fun=_refine_orientation_pc_objective_function,
+                    x0=rot_pc[i],
+                    args=params,
+                    **method_kwargs,
+                )
+            elif SUPPORTED_OPTIMIZATION_METHODS[method_name]["supports_bounds"]:
+                res = method(
+                    func=_refine_orientation_pc_objective_function,
+                    args=params,
+                    bounds=bounds[i],
+                    **method_kwargs,
+                )
+            else:  # Is always "basinhopping", due to prior check of method name
+                method_kwargs["minimizer_kwargs"].update(args=params)
+                res = method(
+                    func=_refine_orientation_pc_objective_function,
+                    x0=rot_pc[i],
+                    **method_kwargs,
+                )
+
+            res_list.append(res)
+
+        ncc_all = [1 - res.fun for res in res_list]
+        best_idx = int(np.argmax(ncc_all))
+
+        best_res = res_list[best_idx]
+        ncc = ncc_all[best_idx]
+        num_evals = best_res.nfev
+        phi1, Phi, phi2, pcx, pcy, pcz = best_res.x
+
+        return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz, best_idx
 
 
 # --------------------------- NLopt solvers -------------------------- #
@@ -387,7 +476,7 @@ def _refine_orientation_solver_nlopt(
     tilt: Optional[float] = None,
     azimuthal: Optional[float] = None,
     sample_tilt: Optional[float] = None,
-    n_ps_operators: int = 0,
+    n_pseudo_symmetry_ops: int = 0,
 ) -> Union[
     Tuple[float, int, float, float, float],
     Tuple[float, int, int, float, float, float],
@@ -415,22 +504,22 @@ def _refine_orientation_solver_nlopt(
         lambda x, grad: _refine_orientation_objective_function(x, *params)
     )
 
-    if n_ps_operators == 0:
+    if n_pseudo_symmetry_ops == 0:
         if trust_region_passed:
-            opt.set_lower_bounds(lower_bounds[:, 0])
-            opt.set_upper_bounds(upper_bounds[:, 0])
+            opt.set_lower_bounds(lower_bounds[0])
+            opt.set_upper_bounds(upper_bounds[0])
 
-        phi1, Phi, phi2 = opt.optimize(rotation[:, 0])
+        phi1, Phi, phi2 = opt.optimize(rotation[0])
         ncc = 1 - opt.last_optimum_value()
         num_evals = opt.get_numevals()
 
         return ncc, num_evals, phi1, Phi, phi2
     else:
-        n_rotations = n_ps_operators + 1
-        eu_all = np.zeros((n_rotations, 3), dtype=np.float64)
-        ncc_inv_all = np.zeros(n_rotations, dtype=np.float64)
-        num_evals_all = np.zeros(n_rotations, dtype=np.int64)
-        for i in range(n_rotations):
+        n_rot = n_pseudo_symmetry_ops + 1
+        eu_all = np.zeros((n_rot, 3), dtype=np.float64)
+        ncc_inv_all = np.zeros(n_rot, dtype=np.float64)
+        num_evals_all = np.zeros(n_rot, dtype=np.int32)
+        for i in range(n_rot):
             if trust_region_passed:
                 opt.set_lower_bounds(lower_bounds[i])
                 opt.set_upper_bounds(upper_bounds[i])
@@ -487,24 +576,47 @@ def _refine_orientation_pc_solver_nlopt(
     rescale: bool,
     fixed_parameters: tuple,
     trust_region_passed: bool,
-) -> Tuple[float, int, float, float, float, float, float, float]:
+    n_pseudo_symmetry_ops: int = 0,
+) -> Union[
+    Tuple[float, int, float, float, float, float, float, float],
+    Tuple[float, int, int, float, float, float, float, float, float],
+]:
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     # Combine tuple of fixed parameters passed to the objective function
     params = (pattern,) + fixed_parameters + (squared_norm,)
 
-    # Prepare NLopt optimizer
-    if trust_region_passed:
-        opt.set_lower_bounds(lower_bounds)
-        opt.set_upper_bounds(upper_bounds)
     opt.set_min_objective(
         lambda x, grad: _refine_orientation_pc_objective_function(x, *params)
     )
 
-    # Run optimization and extract optimized Euler angles and PC values
-    # and the optimized normalized cross-correlation (NCC) score
-    phi1, Phi, phi2, pcx, pcy, pcz = opt.optimize(rot_pc)
-    ncc = 1 - opt.last_optimum_value()
-    num_evals = opt.get_numevals()
+    if n_pseudo_symmetry_ops == 0:
+        if trust_region_passed:
+            opt.set_lower_bounds(lower_bounds[0])
+            opt.set_upper_bounds(upper_bounds[0])
 
-    return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz
+        phi1, Phi, phi2, pcx, pcy, pcz = opt.optimize(rot_pc[0])
+        ncc = 1 - opt.last_optimum_value()
+        num_evals = opt.get_numevals()
+
+        return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz
+    else:
+        n_rot = n_pseudo_symmetry_ops + 1
+        eu_pc_all = np.zeros((n_rot, 6), dtype=np.float64)
+        ncc_inv_all = np.zeros(n_rot, dtype=np.float64)
+        num_evals_all = np.zeros(n_rot, dtype=np.int32)
+        for i in range(n_rot):
+            if trust_region_passed:
+                opt.set_lower_bounds(lower_bounds[i])
+                opt.set_upper_bounds(upper_bounds[i])
+
+            eu_pc_all[i] = opt.optimize(rot_pc[i])
+            ncc_inv_all[i] = opt.last_optimum_value()
+            num_evals_all[i] = opt.get_numevals()
+
+        best_idx = int(np.argmin(ncc_inv_all))
+        ncc = 1 - ncc_inv_all[best_idx]
+        num_evals = num_evals_all[best_idx]
+        phi1, Phi, phi2, pcx, pcy, pcz = eu_pc_all[best_idx]
+
+        return ncc, num_evals, phi1, Phi, phi2, pcx, pcy, pcz, best_idx

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -1970,7 +1970,7 @@ class EBSD(KikuchipySignal2D):
         energy: Union[int, float],
         navigation_mask: Optional[np.ndarray] = None,
         signal_mask: Optional[np.ndarray] = None,
-        rotations_ps: Optional[Rotation] = None,
+        pseudo_symmetry_ops: Optional[Rotation] = None,
         method: Optional[str] = "minimize",
         method_kwargs: Optional[dict] = None,
         trust_region: Union[tuple, list, np.ndarray, None] = None,
@@ -2038,15 +2038,15 @@ class EBSD(KikuchipySignal2D):
             (equal to ``False``, i.e. pixels to *mask out* are
             ``True``). The mask must be of equal shape to the signal's
             signal shape. If not given, all pixels are used.
-        rotations_ps
+        pseudo_symmetry_ops
             Pseudo-symmetry operators as rotations. If given, each
             map point will be refined using the map orientation and the
             orientation after applying each operator. The chosen
-            solution is the one with the highest score. If two operators
-            are given, each map point is refined three times. If given,
-            the returned crystal map will have a property array with the
-            operator index giving the best score, with 0 meaning the
-            original map point gave the best score.
+            solution is the one with the highest score. E.g. if two
+            operators are given, each map point is refined three times.
+            If given, the returned crystal map will have a property
+            array with the operator index giving the best score, with 0
+            meaning the original map point gave the best score.
         method
             Name of the :mod:`scipy.optimize` or *NLopt* optimization
             method, among ``"minimize"``, ``"differential_evolution"``,
@@ -2108,9 +2108,9 @@ class EBSD(KikuchipySignal2D):
             orientations, NCC scores in a ``"scores"`` property, the
             number of function evaluations in a ``"num_evals"``
             property and which pseudo-symmetry operator gave the best
-            score if ``rotations_ps`` is given is returned.. If
+            score if ``pseudo_symmetry_ops`` is given is returned.. If
             ``compute=False``, a dask array of navigation size + (5,)
-            (or (6,) if ``rotations_ps`` is passed) is returned, to be
+            (or (6,) if ``pseudo_symmetry_ops`` is passed) is returned, to be
             computed later. See
             :func:`~kikuchipy.indexing.compute_refine_orientation_results`.
             Each navigation point in the data has the optimized score,
@@ -2154,7 +2154,7 @@ class EBSD(KikuchipySignal2D):
             signal_mask=signal_mask,
             trust_region=trust_region,
             rtol=rtol,
-            rotations_ps=rotations_ps,
+            pseudo_symmetry_ops=pseudo_symmetry_ops,
             method=method,
             method_kwargs=method_kwargs,
             initial_step=initial_step,
@@ -2356,6 +2356,7 @@ class EBSD(KikuchipySignal2D):
         energy: Union[int, float],
         navigation_mask: Optional[np.ndarray] = None,
         signal_mask: Optional[np.ndarray] = None,
+        pseudo_symmetry_ops: Optional[Rotation] = None,
         method: Optional[str] = "minimize",
         method_kwargs: Optional[dict] = None,
         trust_region: Union[tuple, list, np.ndarray, None] = None,
@@ -2425,6 +2426,15 @@ class EBSD(KikuchipySignal2D):
             (equal to ``False``, i.e. pixels to *mask out* are
             ``True``). The mask must be of equal shape to the signal's
             signal shape. If not given, all pixels are used.
+        pseudo_symmetry_ops
+            Pseudo-symmetry operators as rotations. If given, each
+            map point will be refined using the map orientation and the
+            orientation after applying each operator. The chosen
+            solution is the one with the highest score. E.g. if two
+            operators are given, each map point is refined three times.
+            If given, the returned crystal map will have a property
+            array with the operator index giving the best score, with 0
+            meaning the original map point gave the best score.
         method
             Name of the :mod:`scipy.optimize` or *NLopt* optimization
             method, among ``"minimize"``, ``"differential_evolution"``,
@@ -2484,14 +2494,20 @@ class EBSD(KikuchipySignal2D):
         Returns
         -------
         out
-            Crystal map with refined orientations and a new EBSD
-            detector instance with the refined PCs, if ``compute=True``.
-            If ``compute=False``, a dask array of navigation size + (7,)
-            is returned, to be computed later. See
+            If ``compute=True``, a crystal map with refined
+            orientations, NCC scores in a ``"scores"`` property, the
+            number of function evaluations in a ``"num_evals"``
+            property and which pseudo-symmetry operator gave the best
+            score if ``pseudo_symmetry_ops`` is given is returned, as
+            well as a new EBSD detector with the refined PCs. If
+            ``compute=False``, a dask array of navigation size + (8,)
+            (or (9,) if ``pseudo_symmetry_ops`` is passed) is returned,
+            to be computed later. See
             :func:`~kikuchipy.indexing.compute_refine_orientation_projection_center_results`.
-            Each navigation point has the score, the number of function
-            evaulations, the three Euler angles in radians, and the
-            three PC parameters in element 0, 1, 2, 3, 4, 5, 6 and 7,
+            Each navigation point in the data has the score, the number
+            of function evaluations, the three Euler angles in radians,
+            the three PC parameters and potentially the pseudo-symmetry
+            operator index in element 0, 1, 2, 3, 4, 5, 6, 7, 8 and 9,
             respectively.
 
         See Also
@@ -2540,6 +2556,7 @@ class EBSD(KikuchipySignal2D):
             trust_region=trust_region,
             initial_step=initial_step,
             rtol=rtol,
+            pseudo_symmetry_ops=pseudo_symmetry_ops,
             maxeval=maxeval,
             compute=compute,
             navigation_mask=navigation_mask,
@@ -2940,7 +2957,8 @@ class EBSD(KikuchipySignal2D):
         Returns
         -------
         patterns
-            2D Dask array.
+            3D Dask array (last axis is for potential pseudo-symmetry
+            operators in the rotations array).
         signal_mask
             1D NumPy array with points to use in refinement equal to
             ``True``.
@@ -2957,7 +2975,7 @@ class EBSD(KikuchipySignal2D):
         patterns = patterns.reshape((am.navigation_size, am.signal_size))
 
         if not points_to_refine.all():
-            patterns = patterns[points_to_refine]
+            patterns = patterns[points_to_refine, :]
 
         if signal_mask is None:
             signal_mask = np.ones(self.axes_manager.signal_size, dtype=bool)
@@ -2983,6 +3001,9 @@ class EBSD(KikuchipySignal2D):
                 **chunk_kwargs,
             )
             patterns = patterns.rechunk(chunks)
+
+        # Add axis for pseudo-symmetry operators in rotations array
+        patterns = patterns[:, np.newaxis, :]
 
         return patterns, signal_mask
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -11,10 +11,10 @@ sphinx:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
-    nodejs: "16"
+    python: "3.10"
+    nodejs: "19"
   # See https://docs.pyvista.org/user-guide/jupyter/panel.html#configuration-considerations.
   # These packages are needed by PyVista/panel to render 3D plots from
   # RTD's server.

--- a/setup.py
+++ b/setup.py
@@ -44,39 +44,39 @@ with open("kikuchipy/release.py") as fid:
 extra_feature_requirements = {
     "doc": [
         # TODO: Remove once https://github.com/pyxem/kikuchipy/issues/566 is resolved
-        "ipywidgets                 <= 7.7.1",
+        "ipywidgets                     <= 7.7.1",
         "memory_profiler",
-        "nbsphinx                   >= 0.7",
+        "nbsphinx                       >= 0.7",
         "numpydoc",
         "nlopt",
         "panel",  # Used in the docs by PyVista
         "pydata-sphinx-theme",
-        "pyebsdindex                >= 0.1.1",
+        "pyebsdindex                    >= 0.1.1",
         "pyvista",
-        "sphinx                     >= 3.0.2",
-        "sphinx-codeautolink[ipython]",
-        "sphinx-copybutton          >= 0.2.5",
+        "sphinx                         >= 3.0.2",
+        "sphinx-codeautolink[ipython]   < 0.14",
+        "sphinx-copybutton              >= 0.2.5",
         "sphinx-design",
-        "sphinx-gallery             < 0.11",
-        "sphinxcontrib-bibtex       >= 1.0",
+        "sphinx-gallery                 < 0.11",
+        "sphinxcontrib-bibtex           >= 1.0",
     ],
     "tests": [
-        "coverage                   >= 5.0",
+        "coverage                       >= 5.0",
         "numpydoc",
-        "pytest                     >= 5.4",
+        "pytest                         >= 5.4",
         "pytest-benchmark",
-        "pytest-cov                 >= 2.8.1",
+        "pytest-cov                     >= 2.8.1",
         "pytest-xdist",
     ],
     "all": [
-        "matplotlib                 >= 3.5",
+        "matplotlib                     >= 3.5",
         "nlopt",
-        "pyebsdindex                >= 0.1.1",
+        "pyebsdindex                    >= 0.1.1",
         "pyvista",
     ],
     # TODO: Remove this option in release 0.9
     "viz": [
-        "matplotlib                 >= 3.5",
+        "matplotlib                     >= 3.5",
         "pyvista",
     ],
 }


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
After dictionary indexing of the sigma phase (4/mmm) in a super duplex steel in (120, 120) patterns binned to (40, 40) with an average angular step size of 1.4 degrees in the dictionary, I discovered that some areas were indexed with two or three orientations. The two-three orientations apparently alternated at random within these areas. Although quite noisy, inspection of the unbinned patterns convinced me that the areas have a continuous orientation. Using no binning in dictionary indexing did not solve the problem. Turns out the two-three orientations in many such areas were all related by a 30 deg <001> misorientation. Refining all areas with the initial best match in the dictionary as well as the two pseudo-symmetry orientations found by applying the 30 deg <00 +/- 1> operators showed that one of these three orientations were always the best match within an area, instead of the two-three orientations provided by dictionary indexing.

This PR adds a `pseudo_symmetry_ops` parameter to `EBSD.refine_orientation()` and `EBSD.refine_orientation_projection_center()` where one or more `Rotation` can be passed. When refining each orientation, these operators are applied to each initial guess of the orientation, and the best match from these two or more refinements for each point is returned as the refined solution.

Note that the refinement time scales with the number of pseudo-symmetry operators given. Passing two operators e.g. results in refinement taking three times as long as when no operators are given.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
No tutorial or example is added showing this feature for the time being, but I hope to add one in a couple of months.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
