### PR TITLE
Allow specifying a color for simulator reflectors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Unreleased
 
 Added
 -----
+- Allow providing a color for simulator reflections when plotting with Matplotlib.
+  (`#599 <https://github.com/pyxem/kikuchipy/pull/599>`_)
 - Passing pseudo-symmetry operators to orientation and orientation/PC EBSD refinement
   methods in order to find the best match among pseudo-symmetric variants.
   (`#598 <https://github.com/pyxem/kikuchipy/pull/598>`_)
@@ -146,6 +148,10 @@ Removed
 
 Fixed
 -----
+- Range of (kinematical) intensities in ``KikuchiPatternSimulator.plot()`` maximizes the
+  strongest reflectors (make black) instead of minimizing the weakest reflectors (make
+  white), which was the previous behavior.
+  (`#599 <https://github.com/pyxem/kikuchipy/pull/599>`_)
 - Inversion of ``signal_mask`` in the normalized cross-correlation and normalized dot
   product metrics is now done internally, to be in line with the docstrings (does not
   affect the use of this parameter and ``metric="ncc"`` or ``metric="ndp"`` in

--- a/doc/user/applications.rst
+++ b/doc/user/applications.rst
@@ -14,7 +14,6 @@ Most of these works are also listed when searching for ``"kikuchipy"`` `on Googl
 
 2023
 ====
-
 - T. Bergh, H. W. Ånes, R. Aune, S. Wenner, R. Holmestad, X. Ren and P. E. Vullum,
   "Intermetallic Phase Layers in Cold Metal Transfer Aluminium-Steel Welds with an
   Al-Si–Mn Filler Alloy," *Materials Transactions* **64(2)** (2023).

--- a/kikuchipy/simulations/kikuchi_pattern_simulator.py
+++ b/kikuchipy/simulations/kikuchi_pattern_simulator.py
@@ -535,9 +535,6 @@ class KikuchiPatternSimulator:
         ref = ref[order].deepcopy()
         color = color[order]
 
-        if kwargs is None:
-            kwargs = {}
-
         if projection == "stereographic":
             kwargs.setdefault("color", color)
             if all(i not in kwargs for i in ["linewidth", "lw"]):

--- a/kikuchipy/simulations/tests/test_kikuchi_pattern_simulator.py
+++ b/kikuchipy/simulations/tests/test_kikuchi_pattern_simulator.py
@@ -18,6 +18,7 @@
 from diffpy.structure import Atom, Lattice, Structure
 from diffsims.crystallography import ReciprocalLatticeVector
 import matplotlib
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 from orix.crystal_map import Phase
@@ -138,7 +139,6 @@ class TestCalculateMasterPattern:
 class TestOnDetector:
     """Test determination of detector coordinates of geometrical
     simulations given a detector and rotation(s).
-
     """
 
     def setup_method(self):
@@ -332,7 +332,7 @@ class TestPlot:
         with pytest.raises(ImportError, match="Pyvista is not installed"):
             _ = self.simulator.plot("spherical", backend="pyvista")
 
-    def test_scaling(self):
+    def test_plot_scaling(self):
         """Intensity scaling works as expected."""
         simulator = self.simulator
 
@@ -356,3 +356,24 @@ class TestPlot:
 
         with pytest.raises(ValueError, match="Unknown `scaling`, options are "):
             _ = simulator.plot(scaling="cubic")
+
+    def test_plot_color(self):
+        """Passing a color works."""
+        simulator = self.simulator
+
+        # Black (default)
+        fig1 = simulator.plot(return_figure=True)
+        colors1 = np.stack([line.get_color() for line in fig1.axes[0].lines])
+        assert colors1.shape[-1] == 4  # RGBA
+        assert np.allclose(colors1[:, :3], [0, 0, 0])
+
+        # Red
+        fig2 = simulator.plot(return_figure=True, color="r", scaling="square")
+        colors2 = np.stack([line.get_color() for line in fig2.axes[0].lines])
+        assert np.allclose(colors2[:, :3], [1, 0, 0])
+
+        # Color of phase
+        simulator.phase.color = "lime"
+        fig3 = simulator.plot(return_figure=True, color="phase")
+        colors3 = np.stack([line.get_color() for line in fig3.axes[0].lines])
+        assert np.allclose(colors3[:, :3], mcolors.to_rgb("lime"))

--- a/kikuchipy/simulations/tests/test_kikuchi_pattern_simulator.py
+++ b/kikuchipy/simulations/tests/test_kikuchi_pattern_simulator.py
@@ -301,26 +301,33 @@ class TestPlot:
 
         simulator = self.simulator
         fig1 = simulator.plot(
-            "spherical", backend="pyvista", return_figure=True, show_plotter=False
+            "spherical",
+            backend="pyvista",
+            return_figure=True,
+            show_plotter=False,
+            scaling=None,
         )
         assert isinstance(fig1, pv.Plotter)
         assert isinstance(fig1.mesh, pv.PolyData)
         assert fig1.mesh.n_cells == simulator.reflectors.size
         assert np.allclose(fig1.mesh.bounds, [-1, 1, -1, 1, -1, 1])
+        assert len(fig1.scalar_bars) == 0
 
         fig2 = simulator.plot("spherical", backend="pyvista", return_figure=True)
         with pytest.raises(RuntimeError, match="This plotter has been closed "):
             fig2.show()
 
         # Add to existing Plotter
-        simulator.plot(
+        fig3 = simulator.plot(
             "spherical",
             backend="pyvista",
             mode="bands",
             show_plotter=False,
             figure=fig1,
+            return_figure=True,
         )
         assert fig1.mesh.n_cells == simulator.reflectors.size * 2
+        assert "|F_hkl|" in fig3.scalar_bars
 
         plt.close("all")
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR enables passing a valid Matplotlib color to color simulator reflectors in `KikuchiPatternSimulator.plot()` when plotting with Matplotlib (not PyVista).

This is useful when you want to plot more than one phase's reflectors in the same (stereographic) plot, coloring one red and one blue, e.g.

Also, contrast with linear or square scaling (of intensities from structure factors) is improved.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from diffsims.crystallography import ReciprocalLatticeVector
>>> import kikuchipy as kp
>>> mp_si = kp.data.si_ebsd_master_pattern(allow_download=True, lazy=True)  # Get Si phase
>>> rlv = ReciprocalLatticeVector(mp_si.phase, hkl=[[1, 1, 1], [2, 2, 0], [4, 0, 0]])
>>> rlv = rlv.symmetrise()
>>> rlv.sanitise_phase()
>>> rlv.calculate_structure_factor()
>>> simulator = kp.simulations.KikuchiPatternSimulator(rlv)
>>> simulator.plot(color="r")
```

![test](https://user-images.githubusercontent.com/12139781/215777656-df44eace-04db-4f7d-b6c2-5732e2b82e44.png)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
