### PR TITLE
Fix reading of Oxford Instruments binary .ebsp files of version 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -148,6 +148,8 @@ Removed
 
 Fixed
 -----
+- Oxford Instruments .ebsp files of version 4 can now be read.
+  (`#602 <https://github.com/pyxem/kikuchipy/pull/602>`_)
 - When loading EBSD patterns from H5OINA files, the detector tilt and binning are
   available in the returned signal's ``detector`` attribute.
   (`#600 <https://github.com/pyxem/kikuchipy/pull/600>`_)

--- a/kikuchipy/conftest.py
+++ b/kikuchipy/conftest.py
@@ -344,7 +344,7 @@ def oxford_binary_file(tmpdir, request):
     fname = tmpdir.join("dummy_oxford_file.ebsp")
     f = open(fname, mode="w")
 
-    if ver != 0:
+    if ver > 0:
         np.array(-ver, dtype=np.int64).tofile(f)
 
     pattern_header_size = 16
@@ -366,8 +366,11 @@ def oxford_binary_file(tmpdir, request):
     pattern_starts = np.arange(n_patterns, dtype=np.int64)
     pattern_starts *= pattern_header_size + n_bytes + pattern_footer_size
     pattern_starts += n_patterns * 8
-    if ver != 0:
+    if ver in [1, 2, 3]:
         pattern_starts += 8
+    elif ver > 3:
+        np.array(0, dtype=np.uint8).tofile(f)
+        pattern_starts += 9
 
     pattern_starts = np.roll(pattern_starts, shift=1)
     if not all_present:

--- a/kikuchipy/io/plugins/tests/test_oxford_binary.py
+++ b/kikuchipy/io/plugins/tests/test_oxford_binary.py
@@ -92,6 +92,7 @@ class TestOxfordBinaryReader:
             (((2, 3), (60, 60), np.uint8, 2, False, True), 2, (2, 3)),
             (((2, 3), (60, 60), np.uint16, 1, False, True), 1, (2, 3)),
             (((2, 3), (60, 60), np.uint8, 0, False, True), 0, (6,)),
+            (((2, 3), (60, 60), np.uint8, 4, False, True), 4, (2, 3)),
         ],
         indirect=["oxford_binary_file"],
     )


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This fix ensures Oxford Instruments' binary .ebsp files of version 4 can be read by skipping an extra byte (uint8) after the file version. When accounting for this extra byte, patterns are read correctly as before. This fixes #591.

Thanks to @drowenhorst-nrl for this insight.

I don't know what this extra byte is, but it is 0 (when read as uint8) in the file I have access to.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
