### PR TITLE
Fix default EBSD.detector attribute shape when detector is not passed upon initialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -148,6 +148,8 @@ Removed
 
 Fixed
 -----
+- Default ``EBSD.detector.shape`` is now correct when a detector is not passed upon
+  initialization. (`#603 <https://github.com/pyxem/kikuchipy/pull/603>`_)
 - Oxford Instruments .ebsp files of version 4 can now be read.
   (`#602 <https://github.com/pyxem/kikuchipy/pull/602>`_)
 - When loading EBSD patterns from H5OINA files, the detector tilt and binning are

--- a/kikuchipy/data/bruker_h5ebsd/create_bruker_h5ebsd_file.py
+++ b/kikuchipy/data/bruker_h5ebsd/create_bruker_h5ebsd_file.py
@@ -31,14 +31,14 @@ import kikuchipy as kp
 
 
 s = kp.data.nickel_ebsd_small()
-ny, nx = s.axes_manager.navigation_shape[::-1]
+ny, nx = s._navigation_shape_rc
 n = ny * nx
-sy, sx = s.axes_manager.signal_shape[::-1]
+sy, sx = s._signal_shape_rc
 
 dir_data = os.path.abspath(os.path.dirname(__file__))
 
 
-## File with no region of interest (ROI)
+# --- File with no region of interest (ROI)
 f1 = File(os.path.join(dir_data, "patterns.h5"), mode="w")
 
 # Top group
@@ -141,7 +141,7 @@ sem.create_dataset("SEM ZOffset", dtype=float, data=0)
 f1.close()
 
 
-## File with rectangular ROI (SEM group under EBSD group as well)
+# --- File with rectangular ROI (SEM group under EBSD group as well)
 f2 = File(os.path.join(dir_data, "patterns_roi.h5"), mode="w")
 
 # Top group
@@ -253,7 +253,7 @@ sem.create_dataset("ZOffset", dtype=float, data=0)
 f2.close()
 
 
-## File with non-rectangular ROI (SEM group under EBSD group as well)
+# --- File with non-rectangular ROI (SEM group under EBSD group as well)
 f3 = File(os.path.join(dir_data, "patterns_roi_nonrectangular.h5"), mode="w")
 
 # Top group

--- a/kikuchipy/data/emsoft_ebsd_master_pattern/convert_emsoft_ebsd_masterpattern_file_uint8_gzip.py
+++ b/kikuchipy/data/emsoft_ebsd_master_pattern/convert_emsoft_ebsd_masterpattern_file_uint8_gzip.py
@@ -54,10 +54,10 @@ f = File(os.path.join(datadir, phase, fname))
 orig_data = kp.io.plugins.h5ebsd.hdf5group2dict(group=f["/"], recursive=True)
 
 # Overwrite master patterns in original data
-lp_shape = (1, 1) + mp_lp.axes_manager.signal_shape[::-1]
+lp_shape = (1, 1) + mp_lp._signal_shape_rc
 orig_data["EMData"]["EBSDmaster"]["mLPNH"] = mp_lp.inav[0].data.reshape(lp_shape)
 orig_data["EMData"]["EBSDmaster"]["mLPSH"] = mp_lp.inav[1].data.reshape(lp_shape)
-sp_shape = (1,) + mp_sp.axes_manager.signal_shape[::-1]
+sp_shape = (1,) + mp_sp._signal_shape_rc
 orig_data["EMData"]["EBSDmaster"]["masterSPNH"] = mp_sp.inav[0].data.reshape(sp_shape)
 orig_data["EMData"]["EBSDmaster"]["masterSPSH"] = mp_sp.inav[1].data.reshape(sp_shape)
 

--- a/kikuchipy/data/oxford_h5ebsd/create_oxford_h5ebsd_file.py
+++ b/kikuchipy/data/oxford_h5ebsd/create_oxford_h5ebsd_file.py
@@ -37,9 +37,9 @@ rot = Rotation([grain1, grain2, grain2, grain1, grain2, grain2, grain1, grain2, 
 euler = rot.to_euler()
 
 s = kp.data.nickel_ebsd_small()
-ny, nx = s.axes_manager.navigation_shape[::-1]
+ny, nx = s._navigation_shape_rc
 n = ny * nx
-sy, sx = s.axes_manager.signal_shape[::-1]
+sy, sx = s._signal_shape_rc
 dx = s.axes_manager["x"].scale
 
 dir_data = os.path.abspath(os.path.dirname(__file__))

--- a/kikuchipy/draw/tests/test_navigators.py
+++ b/kikuchipy/draw/tests/test_navigators.py
@@ -24,7 +24,7 @@ import kikuchipy as kp
 
 def test_get_rgb_navigator():
     s = kp.data.nickel_ebsd_small(lazy=True).inav[:2, :3]
-    nav_shape = s.axes_manager.navigation_shape[::-1]
+    nav_shape = s._navigation_shape_rc
     image = np.random.random(np.prod(nav_shape) * 3).reshape(nav_shape + (3,))
 
     s_rgb8 = kp.draw.get_rgb_navigator(image, dtype=np.uint8)

--- a/kikuchipy/generators/virtual_bse_generator.py
+++ b/kikuchipy/generators/virtual_bse_generator.py
@@ -154,9 +154,7 @@ class VirtualBSEGenerator:
             if isinstance(rois, tuple) or hasattr(rois, "__iter__") is False:
                 rois = (rois,)
 
-            image = np.zeros(
-                self.signal.axes_manager.navigation_shape[::-1], dtype=np.float64
-            )
+            image = np.zeros(self.signal._navigation_shape_rc, dtype=np.float64)
             for roi in rois:
                 if isinstance(roi, tuple):
                     roi = self.roi_from_grid(roi)

--- a/kikuchipy/indexing/tests/test_dictionary_indexing.py
+++ b/kikuchipy/indexing/tests/test_dictionary_indexing.py
@@ -164,7 +164,7 @@ class TestDictionaryIndexing:
 
     def test_dictionary_indexing_navigation_mask(self, dummy_signal):
         s = dummy_signal
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         nav_size = int(np.prod(nav_shape))
         s_dict = kp.signals.EBSD(dummy_signal.data.reshape(nav_size, 3, 3))
         s_dict.axes_manager[0].name = "x"

--- a/kikuchipy/indexing/tests/test_ebsd_refinement.py
+++ b/kikuchipy/indexing/tests/test_ebsd_refinement.py
@@ -90,7 +90,7 @@ class TestEBSDRefine(EBSDRefineTestSetup):
     ):
         s = ebsd_with_axes_and_random_data
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
         with pytest.raises(ValueError, match=error_msg):
@@ -101,10 +101,10 @@ class TestEBSDRefine(EBSDRefineTestSetup):
     def test_refine_raises(self, dummy_signal, get_single_phase_xmap):
         s = dummy_signal
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        detector = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        detector = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         refine_kwargs = dict(master_pattern=self.mp, energy=20, detector=detector)
 
         with pytest.raises(ValueError, match="Method 'a' not in the list of supported"):
@@ -123,11 +123,11 @@ class TestEBSDRefine(EBSDRefineTestSetup):
     def test_refine_signal_mask(self, dummy_signal, get_single_phase_xmap):
         s = dummy_signal
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         ref_kw = dict(
             xmap=xmap,
             master_pattern=self.mp,
@@ -137,7 +137,7 @@ class TestEBSDRefine(EBSDRefineTestSetup):
             method_kwargs=dict(method="Nelder-Mead", options=dict(maxfev=10)),
         )
         xmap_ref_no_mask = s.refine_orientation(**ref_kw)
-        signal_mask = np.zeros(s.axes_manager.signal_shape[::-1], dtype=bool)
+        signal_mask = np.zeros(s._signal_shape_rc, dtype=bool)
         signal_mask[0, 0] = 1  # Mask away upper left pixel
 
         xmap_ref_mask = s.refine_orientation(signal_mask=signal_mask, **ref_kw)
@@ -193,7 +193,7 @@ class TestEBSDRefine(EBSDRefineTestSetup):
         """
         s = ebsd_with_axes_and_random_data
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -214,13 +214,13 @@ class TestEBSDRefine(EBSDRefineTestSetup):
         self, dummy_signal, get_single_phase_xmap
     ):  # pragma: no cover
         s = dummy_signal
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
         with pytest.raises(ImportError, match="Package `nlopt`, required for method "):
             _ = s.refine_orientation_projection_center(
@@ -236,13 +236,13 @@ class TestEBSDRefine(EBSDRefineTestSetup):
         self, dummy_signal, get_single_phase_xmap
     ):
         s = dummy_signal
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
         with pytest.raises(
             ValueError, match="The initial step must be a single number"
@@ -396,7 +396,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
     ):
         s = ebsd_with_axes_and_random_data
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -454,7 +454,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
     ):
         s = ebsd_with_axes_and_random_data
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -480,10 +480,10 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
     ):
         s = dummy_signal
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
         dask_arr = s.refine_orientation(
             xmap=xmap,
@@ -527,9 +527,9 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = ebsd_with_axes_and_random_data
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -552,7 +552,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
         xmap_ref = s.refine_orientation(
             xmap=s.xmap,
@@ -573,7 +573,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
 
         xmap_ref = s.refine_orientation(
@@ -595,7 +595,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
 
         rot_ps = Rotation.from_axes_angles([[0, 0, 1], [0, 0, -1]], np.deg2rad(30))
@@ -625,7 +625,7 @@ class TestEBSDRefineOrientation(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
 
         rot_ps = Rotation.from_axes_angles([[0, 0, 1], [0, 0, -1]], np.deg2rad(30))
@@ -698,7 +698,7 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = ebsd_with_axes_and_random_data
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
@@ -765,7 +765,7 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = ebsd_with_axes_and_random_data
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
@@ -823,9 +823,9 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = ebsd_with_axes_and_random_data
-        detector = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        detector = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -851,10 +851,10 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
     ):
         s = dummy_signal
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
         dask_arr = s.refine_projection_center(
             xmap=xmap,
@@ -886,13 +886,13 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = dummy_signal
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         method_kwargs.update(dict(options=dict(maxfev=10)))
         signal_mask = np.zeros(det.shape, dtype=bool)
 
@@ -929,13 +929,13 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):  # pragma: no cover
         s = dummy_signal
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         xmap = get_single_phase_xmap(
             nav_shape=nav_shape,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         signal_mask = np.zeros(det.shape, dtype=bool)
 
         xmap_ref, det_ref = s.refine_orientation_projection_center(
@@ -984,9 +984,9 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         get_single_phase_xmap,
     ):
         s = dummy_signal
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
@@ -1010,11 +1010,11 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
     ):
         s = dummy_signal
         xmap = get_single_phase_xmap(
-            nav_shape=s.axes_manager.navigation_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
             rotations_per_point=1,
             step_sizes=tuple(a.scale for a in s.axes_manager.navigation_axes)[::-1],
         )
-        det = kp.detectors.EBSDDetector(shape=s.axes_manager.signal_shape[::-1])
+        det = kp.detectors.EBSDDetector(shape=s._signal_shape_rc)
 
         dask_array = s.refine_orientation_projection_center(
             xmap=xmap,
@@ -1034,7 +1034,7 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
 
         rot_ps = Rotation.from_axes_angles([[0, 0, 1], [0, 0, -1]], np.deg2rad(30))
@@ -1064,7 +1064,7 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         s = self.nickel_ebsd_small
 
         energy = 20
-        signal_mask = kp.filters.Window("circular", s.axes_manager.signal_shape[::-1])
+        signal_mask = kp.filters.Window("circular", s._signal_shape_rc)
         signal_mask = ~signal_mask.astype(bool)
 
         rot_ps = Rotation.from_axes_angles([[0, 0, 1], [0, 0, -1]], np.deg2rad(30))

--- a/kikuchipy/io/plugins/tests/test_edax_binary.py
+++ b/kikuchipy/io/plugins/tests/test_edax_binary.py
@@ -89,4 +89,4 @@ class TestEDAXBinaryReader:
     def test_nav_shape_up2_not_hex(self, edax_binary_file):
         """Test navigation shape when not hex."""
         s = kp.load(edax_binary_file.name)
-        assert s.axes_manager.navigation_shape[::-1] == (2, 3)
+        assert s._navigation_shape_rc == (2, 3)

--- a/kikuchipy/io/plugins/tests/test_oxford_binary.py
+++ b/kikuchipy/io/plugins/tests/test_oxford_binary.py
@@ -99,7 +99,7 @@ class TestOxfordBinaryReader:
     def test_versions(self, oxford_binary_file, ver, desired_nav_shape):
         """Ensure that versions 0, 1 and > 1 can be read."""
         s = kp.load(oxford_binary_file.name)
-        assert s.axes_manager.navigation_shape[::-1] == desired_nav_shape
+        assert s._navigation_shape_rc == desired_nav_shape
         if ver > 0:
             assert s.original_metadata.has_item("beam_x")
             assert s.original_metadata.has_item("beam_y")

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -219,7 +219,7 @@ class TestGetDynamicBackgroundChunk:
             kwargs["offset_before_fft"],
             kwargs["offset_after_ifft"],
         ) = _dynamic_background_frequency_space_setup(
-            pattern_shape=dummy_signal.axes_manager.signal_shape[::-1],
+            pattern_shape=dummy_signal._signal_shape_rc,
             std=std,
             truncate=4.0,
         )
@@ -262,7 +262,7 @@ class TestGetDynamicBackgroundChunk:
             kwargs["offset_before_fft"],
             kwargs["offset_after_ifft"],
         ) = _dynamic_background_frequency_space_setup(
-            pattern_shape=dummy_signal.axes_manager.signal_shape[::-1],
+            pattern_shape=dummy_signal._signal_shape_rc,
             std=2,
             truncate=4.0,
         )

--- a/kikuchipy/signals/_kikuchi_master_pattern.py
+++ b/kikuchipy/signals/_kikuchi_master_pattern.py
@@ -152,7 +152,7 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
             raise NotImplementedError("Only implemented for non-lazy signals")
 
         # Set up square arrays
-        sig_shape = self.axes_manager.signal_shape[::-1]
+        sig_shape = self._signal_shape_rc
         arr = np.linspace(-1, 1, sig_shape[0], dtype=np.float64)
         x_lambert, y_lambert = np.meshgrid(arr, arr)
         x_lambert_flat = x_lambert.ravel()

--- a/kikuchipy/signals/_kikuchipy_signal.py
+++ b/kikuchipy/signals/_kikuchipy_signal.py
@@ -63,6 +63,16 @@ class KikuchipySignal2D(Signal2D):
 
     _custom_attributes = []
 
+    @property
+    def _signal_shape_rc(self) -> tuple:
+        """Return the signal's signal shape as (row, column)."""
+        return self.axes_manager.signal_shape[::-1]
+
+    @property
+    def _navigation_shape_rc(self) -> tuple:
+        """Return the signal's navigation shape as (row, column)."""
+        return self.axes_manager.navigation_shape[::-1]
+
     def rescale_intensity(
         self,
         relative: bool = False,

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -175,7 +175,7 @@ class EBSD(KikuchipySignal2D):
         self._detector = kwargs.get(
             "detector",
             EBSDDetector(
-                shape=self.axes_manager.signal_shape,
+                shape=self._signal_shape_rc,
                 px_size=self.axes_manager.signal_axes[0].scale,
             ),
         )
@@ -183,6 +183,16 @@ class EBSD(KikuchipySignal2D):
         self._xmap = kwargs.get("xmap")
 
     # ---------------------- Custom attributes ----------------------- #
+
+    @property
+    def _signal_shape_rc(self) -> tuple:
+        """Return the signal's signal shape as (row, column)."""
+        return self.axes_manager.signal_shape[::-1]
+
+    @property
+    def _navigation_shape_rc(self) -> tuple:
+        """Return the signal's navigation shape as (row, column)."""
+        return self.axes_manager.navigation_shape[::-1]
 
     @property
     def detector(self) -> EBSDDetector:

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -185,16 +185,6 @@ class EBSD(KikuchipySignal2D):
     # ---------------------- Custom attributes ----------------------- #
 
     @property
-    def _signal_shape_rc(self) -> tuple:
-        """Return the signal's signal shape as (row, column)."""
-        return self.axes_manager.signal_shape[::-1]
-
-    @property
-    def _navigation_shape_rc(self) -> tuple:
-        """Return the signal's navigation shape as (row, column)."""
-        return self.axes_manager.navigation_shape[::-1]
-
-    @property
     def detector(self) -> EBSDDetector:
         """Return or set the detector describing the EBSD
         detector-sample geometry.
@@ -210,8 +200,8 @@ class EBSD(KikuchipySignal2D):
     def detector(self, value: EBSDDetector):
         if _detector_is_compatible_with_signal(
             detector=value,
-            nav_shape=self.axes_manager.navigation_shape[::-1],
-            sig_shape=self.axes_manager.signal_shape[::-1],
+            nav_shape=self._navigation_shape_rc,
+            sig_shape=self._signal_shape_rc,
             raise_if_not=True,
         ):
             self._detector = value
@@ -252,7 +242,7 @@ class EBSD(KikuchipySignal2D):
     def static_background(self, value: Union[np.ndarray, da.Array]):
         if value.dtype != self.data.dtype:
             warnings.warn("Background pattern has different data type from patterns")
-        if value.shape != self.axes_manager.signal_shape[::-1]:
+        if value.shape != self._signal_shape_rc:
             warnings.warn("Background pattern has different shape from patterns")
         self._static_background = value
 
@@ -511,7 +501,7 @@ class EBSD(KikuchipySignal2D):
                 f"Static background dtype_out {static_bg.dtype} is not the same as "
                 f"pattern dtype_out {dtype_out}"
             )
-        pat_shape = self.axes_manager.signal_shape[::-1]  # xy -> ij
+        pat_shape = self._signal_shape_rc  # xy -> ij
         bg_shape = static_bg.shape
         if bg_shape != pat_shape:
             raise ValueError(
@@ -609,7 +599,7 @@ class EBSD(KikuchipySignal2D):
                 kwargs["offset_before_fft"],
                 kwargs["offset_after_ifft"],
             ) = _dynamic_background_frequency_space_setup(
-                pattern_shape=self.axes_manager.signal_shape[::-1],
+                pattern_shape=self._signal_shape_rc,
                 std=std,
                 truncate=truncate,
             )
@@ -693,7 +683,7 @@ class EBSD(KikuchipySignal2D):
                 kwargs["offset_before_fft"],
                 kwargs["offset_after_ifft"],
             ) = _dynamic_background_frequency_space_setup(
-                pattern_shape=self.axes_manager.signal_shape[::-1],
+                pattern_shape=self._signal_shape_rc,
                 std=std,
                 truncate=truncate,
             )
@@ -931,7 +921,7 @@ class EBSD(KikuchipySignal2D):
                 kwargs["offset_before_fft"],
                 kwargs["offset_after_ifft"],
             ) = _fft_filter_setup(
-                image_shape=self.axes_manager.signal_shape[::-1],
+                image_shape=self._signal_shape_rc,
                 window=transfer_function,
             )
         else:
@@ -1018,7 +1008,7 @@ class EBSD(KikuchipySignal2D):
         else:
             averaging_window = Window(window=window, shape=window_shape, **kwargs)
 
-        nav_shape = self.axes_manager.navigation_shape[::-1]
+        nav_shape = self._navigation_shape_rc
         window_shape = averaging_window.shape
         if window_shape in [(1,), (1, 1)]:
             # Do nothing if a window of shape (1,) or (1, 1) is passed
@@ -1440,7 +1430,7 @@ class EBSD(KikuchipySignal2D):
             boundary="none",
         )
         chunks = get_chunking(
-            data_shape=self.axes_manager.navigation_shape[::-1],
+            data_shape=self._navigation_shape_rc,
             nav_dim=nav_dim,
             sig_dim=0,
             dtype=dtype_out,
@@ -2825,11 +2815,11 @@ class EBSD(KikuchipySignal2D):
 
         # Update attributes
         if new is None:  # pragma: no cover
-            new_nav_shape = self.axes_manager.navigation_shape[::-1]
-            new_sig_shape = self.axes_manager.signal_shape[::-1]
+            new_nav_shape = self._navigation_shape_rc
+            new_sig_shape = self._signal_shape_rc
         else:
-            new_nav_shape = new.axes_manager.navigation_shape[::-1]
-            new_sig_shape = new.axes_manager.signal_shape[::-1]
+            new_nav_shape = new._navigation_shape_rc
+            new_sig_shape = new._signal_shape_rc
         if params["isNavigation"]:
             props = _update_custom_attributes(
                 props, nav_slices=slices, new_nav_shape=new_nav_shape

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -89,7 +89,7 @@ class TestEBSDXmapProperty:
 
     def test_set_xmap(self, get_single_phase_xmap):
         s = kp.data.nickel_ebsd_large(lazy=True)
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         step_sizes = (1.5, 1.5)
 
         # Should succeed
@@ -154,7 +154,7 @@ class TestEBSDDetectorProperty:
 
     def test_set_detector(self):
         s = kp.data.nickel_ebsd_small(lazy=True)
-        sig_shape = s.axes_manager.signal_shape[::-1]
+        sig_shape = s._signal_shape_rc
 
         # Success
         detector_good = kp.detectors.EBSDDetector(shape=sig_shape)
@@ -185,8 +185,8 @@ class TestEBSDDetectorProperty:
         s = kp.signals.EBSD(np.ones(signal_nav_shape + (5, 5), dtype=int))
         func_kwargs = dict(
             detector=detector,
-            nav_shape=s.axes_manager.navigation_shape[::-1],
-            sig_shape=s.axes_manager.signal_shape[::-1],
+            nav_shape=s._navigation_shape_rc,
+            sig_shape=s._signal_shape_rc,
         )
         assert (
             kp.signals.util._detector._detector_is_compatible_with_signal(**func_kwargs)
@@ -200,12 +200,12 @@ class TestEBSDDetectorProperty:
 
     def test_detector_shape(self):
         s1 = kp.signals.EBSD(np.ones((1, 2, 3, 4)))
-        assert s1.data.shape == (1, 2, 3, 4)
-        assert s1.detector.shape == (3, 4)
+        assert s1._navigation_shape_rc == (1, 2)
+        assert s1.detector.shape == s1._signal_shape_rc == (3, 4)
 
         s2 = kp.signals.EBSD(np.ones((1, 2, 4, 3)))
-        assert s2.data.shape == (1, 2, 4, 3)
-        assert s2.detector.shape == (4, 3)
+        assert s2._navigation_shape_rc == (1, 2)
+        assert s2.detector.shape == s2._signal_shape_rc == (4, 3)
 
 
 class TestStaticBackgroundProperty:
@@ -228,7 +228,7 @@ class TestStaticBackgroundProperty:
 
     def test_set_background(self):
         s = kp.data.nickel_ebsd_small(lazy=True)
-        sig_shape = s.axes_manager.signal_shape[::-1]
+        sig_shape = s._signal_shape_rc
         # Success
         bg_good = np.arange(np.prod(sig_shape), dtype=s.data.dtype).reshape(sig_shape)
         s.static_background = bg_good
@@ -1963,7 +1963,7 @@ class TestExtractGrid:
         assert np.allclose(s.static_background, s2.static_background)
         assert s2.detector.navigation_shape == (4, 5)
 
-        nav_shape = s.axes_manager.navigation_shape[::-1]
+        nav_shape = s._navigation_shape_rc
         idx, spacing = kp.signals.util.grid_indices(
             (4, 5), nav_shape, return_spacing=True
         )

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -198,6 +198,15 @@ class TestEBSDDetectorProperty:
                     raise_if_not=True, **func_kwargs
                 )
 
+    def test_detector_shape(self):
+        s1 = kp.signals.EBSD(np.ones((1, 2, 3, 4)))
+        assert s1.data.shape == (1, 2, 3, 4)
+        assert s1.detector.shape == (3, 4)
+
+        s2 = kp.signals.EBSD(np.ones((1, 2, 4, 3)))
+        assert s2.data.shape == (1, 2, 4, 3)
+        assert s2.detector.shape == (4, 3)
+
 
 class TestStaticBackgroundProperty:
     def test_background_carry_over_from_deepcopy(self, dummy_signal):

--- a/kikuchipy/signals/tests/test_ebsd_master_pattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_master_pattern.py
@@ -336,7 +336,7 @@ class TestProjectFromLambert:
         )
 
         sim1 = mp.get_patterns(rotations=rot1, detector=det1)
-        assert sim1.axes_manager.navigation_shape[::-1] == nav_shape
+        assert sim1._navigation_shape_rc == nav_shape
         assert not np.allclose(sim1.data[0, 0], sim1.data[0, 1])
 
         # 1D navigation shape, multiple PCs
@@ -350,7 +350,7 @@ class TestProjectFromLambert:
         # 2D navigation shape, single PC
         det2.pc = det2.pc[0]
         sim3 = mp.get_patterns(rot1, det2)
-        assert sim3.axes_manager.navigation_shape[::-1] == nav_shape
+        assert sim3._navigation_shape_rc == nav_shape
         assert np.allclose(sim1.data[0, 0], sim3.data[0, 0])
 
     def test_get_patterns_navigation_shape_raises(self):


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fix default EBSD.detector attribute shape when detector is not passed upon initialization.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> import kikuchipy as kp
>>> s = kp.signals.EBSD(np.ones((1, 2, 3, 4))
>>> s.detector.shape
(3, 4)  # (4, 3) before this fix (ouch!)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
