### PR TITLE
Add option to return new (possibly lazy) signal instead of operating inplace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,12 @@ jobs:
       - uses: psf/black@stable
 
       - name: Install Black with Jupyter extension
-        run: pip install black[jupyter]
+        run: |
+          pip install black[jupyter]
 
       - name: Check code style of Jupyter notebooks
-        run: black --diff --line-length 77 doc/tutorials/*.ipynb
+        run: |
+          black --diff --line-length 77 doc/tutorials/*.ipynb
 
   # Make sure all necessary files are included in a release
   manifest:
@@ -36,12 +38,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install manifix
+        run: |
+          pip install manifix
 
       - name: Check MANIFEST.in file
-        run: python setup.py manifix
+        run: |
+          python setup.py manifix
 
   tests:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Unreleased
 
 Added
 -----
+- Option to return a new signal (lazy or not) instead of operating inplace is added to
+  many methods in all classes via ``inplace`` and ``lazy_output`` boolean parameters.
+  (`#605 <https://github.com/pyxem/kikuchipy/pull/605>`_)
+- Lazy version of the ``VirtualBSEImage`` class.
+  (`#605 <https://github.com/pyxem/kikuchipy/pull/605>`_)
 - Allow providing a color for simulator reflections when plotting with Matplotlib.
   (`#599 <https://github.com/pyxem/kikuchipy/pull/599>`_)
 - Passing pseudo-symmetry operators to orientation and orientation/PC EBSD refinement

--- a/doc/tutorials/feature_maps.ipynb
+++ b/doc/tutorials/feature_maps.ipynb
@@ -424,7 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/geometrical_ebsd_simulations.ipynb
+++ b/doc/tutorials/geometrical_ebsd_simulations.ipynb
@@ -479,7 +479,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/hough_indexing.ipynb
+++ b/doc/tutorials/hough_indexing.ipynb
@@ -691,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/kinematical_ebsd_simulations.ipynb
+++ b/doc/tutorials/kinematical_ebsd_simulations.ipynb
@@ -156,7 +156,7 @@
    "id": "1f747220-22bf-42d4-8af6-088684e3869b",
    "metadata": {},
    "source": [
-    "Sanitise `phase`"
+    "Sanitise `phase` by completing the unit cell"
    ]
   },
   {
@@ -819,7 +819,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/doc/tutorials/load_save_data.ipynb
+++ b/doc/tutorials/load_save_data.ipynb
@@ -42,6 +42,7 @@
     "%matplotlib inline\n",
     "\n",
     "import os\n",
+    "from pathlib import Path\n",
     "import tempfile\n",
     "\n",
     "import dask.array as da\n",
@@ -59,9 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datadir = \"../../kikuchipy/data/\"\n",
+    "datadir = Path(\"../../kikuchipy/data\")\n",
     "nordif_ebsd = \"nordif/Pattern.dat\"\n",
-    "s = kp.load(datadir + nordif_ebsd)\n",
+    "s = kp.load(datadir / nordif_ebsd)\n",
     "s"
    ]
   },
@@ -81,7 +82,7 @@
     "emsoft_master_pattern = (\n",
     "    \"emsoft_ebsd_master_pattern/ni_mc_mp_20kv_uint8_gzip_opts9.h5\"\n",
     ")\n",
-    "s_mp = kp.load(filename=datadir + emsoft_master_pattern)\n",
+    "s_mp = kp.load(datadir / emsoft_master_pattern)\n",
     "s_mp"
    ]
   },
@@ -100,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_lazy = kp.load(datadir + nordif_ebsd, lazy=True)\n",
+    "s_lazy = kp.load(datadir / nordif_ebsd, lazy=True)\n",
     "print(s_lazy)\n",
     "s_lazy.data"
    ]
@@ -395,8 +396,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_dir = tempfile.mkdtemp() + \"/\"\n",
-    "s.save(temp_dir + \"patterns\")"
+    "temp_dir = Path(tempfile.mkdtemp())\n",
+    "s.save(temp_dir / \"patterns\")"
    ]
   },
   {
@@ -430,7 +431,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s.save(temp_dir + \"patterns.dat\")"
+    "s.save(temp_dir / \"patterns.dat\")"
    ]
   },
   {
@@ -446,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_hs.save(temp_dir + \"master_pattern.hspy\")\n",
+    "s_hs.save(temp_dir / \"master_pattern.hspy\")\n",
     "s_hs"
    ]
   },
@@ -464,7 +465,7 @@
    "outputs": [],
    "source": [
     "s_mp2 = hs.load(\n",
-    "    temp_dir + \"master_pattern.hspy\", signal_type=\"EBSDMasterPattern\"\n",
+    "    temp_dir / \"master_pattern.hspy\", signal_type=\"EBSDMasterPattern\"\n",
     ")\n",
     "s_mp2"
    ]
@@ -533,7 +534,7 @@
    "outputs": [],
    "source": [
     "emsoft_ebsd = \"emsoft_ebsd/simulated_ebsd.h5\"  # Dummy data set\n",
-    "s_sim = kp.load(filename=datadir + emsoft_ebsd)\n",
+    "s_sim = kp.load(datadir / emsoft_ebsd)\n",
     "s_sim"
    ]
   },
@@ -551,7 +552,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_sim2 = kp.load(filename=datadir + emsoft_ebsd, scan_size=(2, 5))\n",
+    "s_sim2 = kp.load(datadir / emsoft_ebsd, scan_size=(2, 5))\n",
     "print(s_sim2)\n",
     "print(s_sim2.data.shape)"
    ]
@@ -578,7 +579,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_mp = kp.load(filename=datadir + emsoft_master_pattern)\n",
+    "s_mp = kp.load(datadir / emsoft_master_pattern)\n",
     "\n",
     "print(s_mp)\n",
     "print(s_mp.projection)\n",
@@ -606,7 +607,7 @@
    "outputs": [],
    "source": [
     "s_mp = kp.load(\n",
-    "    datadir + emsoft_master_pattern,\n",
+    "    datadir / emsoft_master_pattern,\n",
     "    projection=\"lambert\",\n",
     "    hemisphere=\"both\",\n",
     "    energy=20,\n",
@@ -642,9 +643,7 @@
    "outputs": [],
    "source": [
     "# Load a dummy pattern\n",
-    "s_mp = kp.load(\n",
-    "    filename=datadir + \"emsoft_ecp_master_pattern/ecp_master_pattern.h5\"\n",
-    ")\n",
+    "s_mp = kp.load(datadir / \"emsoft_ecp_master_pattern/ecp_master_pattern.h5\")\n",
     "\n",
     "print(s_mp)\n",
     "print(s_mp.projection)\n",
@@ -675,9 +674,7 @@
    "outputs": [],
    "source": [
     "# Load a dummy pattern\n",
-    "s_mp = kp.load(\n",
-    "    filename=datadir + \"emsoft_tkd_master_pattern/tkd_master_pattern.h5\"\n",
-    ")\n",
+    "s_mp = kp.load(datadir / \"emsoft_tkd_master_pattern/tkd_master_pattern.h5\")\n",
     "\n",
     "print(s_mp)\n",
     "print(s_mp.projection)\n",
@@ -715,7 +712,7 @@
    "source": [
     "kikuchipy_ebsd = \"kikuchipy_h5ebsd/patterns.h5\"\n",
     "s1, s2 = kp.load(\n",
-    "    filename=datadir + kikuchipy_ebsd, scan_group_names=[\"Scan 1\", \"Scan 2\"]\n",
+    "    datadir / kikuchipy_ebsd, scan_group_names=[\"Scan 1\", \"Scan 2\"]\n",
     ")\n",
     "print(s1)\n",
     "print(s2)"
@@ -735,7 +732,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1 = kp.load(filename=datadir + kikuchipy_ebsd, scan_group_names=\"Scan 1\")\n",
+    "s1 = kp.load(datadir / kikuchipy_ebsd, scan_group_names=\"Scan 1\")\n",
     "s1"
    ]
   },
@@ -756,11 +753,11 @@
    "outputs": [],
    "source": [
     "new_file = \"patterns_new.h5\"\n",
-    "s1.save(temp_dir + new_file, scan_number=1)\n",
-    "s2.save(filename=temp_dir + new_file, add_scan=True, scan_number=2)\n",
+    "s1.save(temp_dir / new_file, scan_number=1)\n",
+    "s2.save(temp_dir / new_file, add_scan=True, scan_number=2)\n",
     "\n",
     "s1_new, s2_new = kp.load(\n",
-    "    filename=temp_dir + new_file, scan_group_names=[\"Scan 1\", \"Scan 2\"]\n",
+    "    temp_dir / new_file, scan_group_names=[\"Scan 1\", \"Scan 2\"]\n",
     ")\n",
     "print(s1_new)\n",
     "print(s2_new)"
@@ -817,8 +814,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edax_binary_path = datadir + \"edax_binary/\"  # Directory with dummy signals\n",
-    "s_edax = kp.load(edax_binary_path + \"edax_binary.up1\")\n",
+    "edax_binary_path = datadir / \"edax_binary/\"  # Directory with dummy signals\n",
+    "s_edax = kp.load(edax_binary_path / \"edax_binary.up1\")\n",
     "s_edax"
    ]
   },
@@ -837,7 +834,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_edax2 = kp.load(edax_binary_path + \"edax_binary.up1\", nav_shape=(3, 3))\n",
+    "s_edax2 = kp.load(edax_binary_path / \"edax_binary.up1\", nav_shape=(3, 3))\n",
     "s_edax2"
    ]
   },
@@ -854,7 +851,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_edax3 = kp.load(edax_binary_path + \"edax_binary.up2\")\n",
+    "s_edax3 = kp.load(edax_binary_path / \"edax_binary.up2\")\n",
     "s_edax3"
    ]
   },
@@ -877,8 +874,7 @@
    "outputs": [],
    "source": [
     "s_nordif = kp.load(\n",
-    "    filename=datadir + nordif_ebsd,\n",
-    "    setting_file=datadir + \"nordif/Setting.txt\",\n",
+    "    datadir / nordif_ebsd, setting_file=datadir / \"nordif/Setting.txt\"\n",
     ")\n",
     "s_nordif"
    ]
@@ -898,7 +894,7 @@
    "outputs": [],
    "source": [
     "s_nordif = kp.load(\n",
-    "    filename=datadir + nordif_ebsd, scan_size=(1, 9), pattern_size=(60, 60)\n",
+    "    datadir / nordif_ebsd, scan_size=(1, 9), pattern_size=(60, 60)\n",
     ")\n",
     "s_nordif"
    ]
@@ -942,7 +938,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_nordif_cal = kp.load(filename=datadir + \"nordif/Setting.txt\")\n",
+    "s_nordif_cal = kp.load(datadir / \"nordif/Setting.txt\")\n",
     "s_nordif_cal"
    ]
   },
@@ -975,8 +971,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oxford_binary_path = datadir + \"oxford_binary/\"\n",
-    "s_oxford = kp.load(filename=oxford_binary_path + \"patterns.ebsp\")\n",
+    "oxford_binary_path = datadir / \"oxford_binary\"\n",
+    "s_oxford = kp.load(oxford_binary_path / \"patterns.ebsp\")\n",
     "s_oxford"
    ]
   },
@@ -1041,14 +1037,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_dir2 = tempfile.mkdtemp() + \"/\"\n",
+    "temp_dir2 = Path(tempfile.mkdtemp())\n",
     "s = kp.data.nickel_ebsd_small()\n",
     "y, x = np.indices(s.axes_manager.navigation_shape[::-1])\n",
     "y = y.ravel()\n",
     "x = x.ravel()\n",
     "s.unfold_navigation_space()\n",
     "for i in range(s.axes_manager.navigation_size):\n",
-    "    iio.imwrite(temp_dir2 + f\"/pattern_x{x[i]}y{y[i]}.tif\", s.data[i])\n",
+    "    iio.imwrite(temp_dir2 / f\"pattern_x{x[i]}y{y[i]}.tif\", s.data[i])\n",
     "\n",
     "# Print file contents\n",
     "os.listdir(temp_dir2)"
@@ -1067,7 +1063,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1 = kp.load(os.path.join(temp_dir2, \"*.tif\"))\n",
+    "s1 = kp.load(temp_dir2 / \"*.tif\")\n",
     "s1"
    ]
   },
@@ -1086,7 +1082,7 @@
    "outputs": [],
    "source": [
     "s2 = kp.load(\n",
-    "    os.path.join(temp_dir2, \"*.tif\"),\n",
+    "    temp_dir2 / \"*.tif\",\n",
     "    xy_pattern=r\"_x(\\d+)y(\\d+).tif\",\n",
     "    show_progressbar=True,\n",
     ")\n",
@@ -1127,7 +1123,7 @@
    "source": [
     "import h5py\n",
     "\n",
-    "with h5py.File(datadir + kikuchipy_ebsd, mode=\"r\") as f:\n",
+    "with h5py.File(datadir / kikuchipy_ebsd, mode=\"r\") as f:\n",
     "    dset = f[\"Scan 2/EBSD/Data/patterns\"]\n",
     "    print(dset)\n",
     "    patterns = dset[()]\n",
@@ -1183,7 +1179,7 @@
    "outputs": [],
    "source": [
     "vbse_fname = \"vbse.tif\"\n",
-    "vbse.save(temp_dir + vbse_fname)  # Easily read into e.g. ImageJ"
+    "vbse.save(temp_dir / vbse_fname)  # Easily read into e.g. ImageJ"
    ]
   },
   {
@@ -1201,7 +1197,7 @@
    "source": [
     "nav_size = vbse.axes_manager.navigation_size\n",
     "for i in range(nav_size):\n",
-    "    plt.imsave(temp_dir + f\"vbse{i}.png\", vbse.inav[i].data)"
+    "    plt.imsave(temp_dir / f\"vbse{i}.png\", vbse.inav[i].data)"
    ]
   },
   {
@@ -1217,7 +1213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vbse2 = hs.load(temp_dir + vbse_fname, signal_type=\"VirtualBSEImage\")\n",
+    "vbse2 = hs.load(temp_dir / vbse_fname, signal_type=\"VirtualBSEImage\")\n",
     "vbse2"
    ]
   },
@@ -1231,9 +1227,9 @@
    "source": [
     "# Remove files written to disk in this user guide\n",
     "for file in os.listdir(temp_dir):\n",
-    "    os.remove(temp_dir + file)\n",
+    "    os.remove(temp_dir / file)\n",
     "for file in os.listdir(temp_dir2):\n",
-    "    os.remove(temp_dir2 + file)\n",
+    "    os.remove(temp_dir2 / file)\n",
     "os.rmdir(temp_dir)\n",
     "os.rmdir(temp_dir2)"
    ]
@@ -1255,7 +1251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/doc/tutorials/mandm2021_sunday_short_course.ipynb
+++ b/doc/tutorials/mandm2021_sunday_short_course.ipynb
@@ -1814,7 +1814,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/multivariate_analysis.ipynb
+++ b/doc/tutorials/multivariate_analysis.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s.average_neighbour_patterns(window=\"gaussian\", window_shape=(3, 3), std=2)"
+    "s.average_neighbour_patterns(window=\"gaussian\", std=2)"
    ]
   },
   {
@@ -349,7 +349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pattern_matching.ipynb
+++ b/doc/tutorials/pattern_matching.ipynb
@@ -1748,7 +1748,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pattern_processing.ipynb
+++ b/doc/tutorials/pattern_processing.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "source": [
     "Most methods operate inplace (indicated in their docstrings), meaning they overwrite the patterns in the EBSD signal.\n",
-    "If we instead want to keep the original signal and operate on a new signal, we can create a [deepcopy()](../reference/generated/kikuchipy.signals.EBSD.deepcopy.rst) of the original signal"
+    "If we instead want to keep the original signal and operate on a new signal, we can either create a [deepcopy()](../reference/generated/kikuchipy.signals.EBSD.deepcopy.rst) of the original signal..."
    ]
   },
   {
@@ -69,6 +69,13 @@
    "source": [
     "s2 = s.deepcopy()\n",
     "np.may_share_memory(s.data, s2.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... or pass `inplace=False` to return a new signal and keep the original signal unaffected (new in version 0.8)."
    ]
   },
   {
@@ -130,7 +137,7 @@
    },
    "outputs": [],
    "source": [
-    "s2.remove_static_background()\n",
+    "s2 = s.remove_static_background(inplace=False)\n",
     "\n",
     "plot_pattern_processing(\n",
     "    [s.inav[0, 0].data, s2.inav[0, 0].data], [\"Raw\", \"Static\"]\n",
@@ -165,12 +172,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3 = s2.deepcopy()\n",
-    "s3.remove_dynamic_background(\n",
+    "s3 = s2.remove_dynamic_background(\n",
     "    operation=\"subtract\",  # Default\n",
     "    filter_domain=\"frequency\",  # Default\n",
     "    std=8,  # Default is 1/8 of the pattern width\n",
     "    truncate=4,  # Default\n",
+    "    inplace=False,\n",
     ")\n",
     "\n",
     "plot_pattern_processing(\n",
@@ -223,8 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s4 = s3.deepcopy()\n",
-    "s4.average_neighbour_patterns(window=\"gaussian\", std=1)\n",
+    "s4 = s3.average_neighbour_patterns(window=\"gaussian\", std=1, inplace=False)\n",
     "\n",
     "plot_pattern_processing(\n",
     "    [s3.inav[0, 0].data, s4.inav[0, 0].data],\n",
@@ -324,8 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s6 = s3.deepcopy()\n",
-    "s6.adaptive_histogram_equalization(kernel_size=(15, 15))\n",
+    "s6 = s3.adaptive_histogram_equalization(kernel_size=(15, 15), inplace=False)\n",
     "\n",
     "plot_pattern_processing(\n",
     "    [s3.inav[0, 0].data, s6.inav[0, 0].data],\n",
@@ -393,9 +398,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s7 = s3.deepcopy()\n",
-    "s7.fft_filter(\n",
-    "    transfer_function=w_low * w_high, function_domain=\"frequency\", shift=True\n",
+    "s7 = s3.fft_filter(\n",
+    "    transfer_function=w_low * w_high,\n",
+    "    function_domain=\"frequency\",\n",
+    "    shift=True,\n",
+    "    inplace=False,\n",
     ")\n",
     "\n",
     "plot_pattern_processing(\n",
@@ -422,7 +429,6 @@
     "from scipy.ndimage import correlate\n",
     "\n",
     "\n",
-    "s8 = s3.deepcopy()\n",
     "# fmt: off\n",
     "w_laplacian = np.array([\n",
     "    [-1, -1, -1],\n",
@@ -430,7 +436,9 @@
     "    [-1, -1, -1]\n",
     "])\n",
     "# fmt: on\n",
-    "s8.fft_filter(transfer_function=w_laplacian, function_domain=\"spatial\")\n",
+    "s8 = s3.fft_filter(\n",
+    "    transfer_function=w_laplacian, function_domain=\"spatial\", inplace=False\n",
+    ")\n",
     "\n",
     "\n",
     "p_filt = correlate(\n",
@@ -575,8 +583,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s10 = s3.inav[0, 0].deepcopy()\n",
-    "print(s10.data.min(), s10.data.max())"
+    "print(s3.inav[0, 0].data.min(), s3.inav[0, 0].data.max())"
    ]
   },
   {
@@ -585,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s10.rescale_intensity(out_range=(10, 245))\n",
+    "s10 = s3.inav[0, 0].rescale_intensity(out_range=(10, 245), inplace=False)\n",
     "print(s10.data.min(), s10.data.max())"
    ]
   },
@@ -634,8 +641,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s11 = s3.inav[0, 0].deepcopy()\n",
-    "np.mean(s11.data)"
+    "np.mean(s3.inav[0, 0].data)"
    ]
   },
   {
@@ -644,8 +650,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# s11.change_dtype(np.float32)  # Or pass `dtype_out` as below\n",
-    "s11.normalize_intensity(num_std=1, dtype_out=np.float32)\n",
+    "s11 = s3.inav[0, 0].normalize_intensity(num_std=1, dtype_out=np.float32, inplace=False)\n",
     "np.mean(s11.data)"
    ]
   },
@@ -678,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pc_calibration_moving_screen_technique.ipynb
+++ b/doc/tutorials/pc_calibration_moving_screen_technique.ipynb
@@ -409,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pc_extrapolate_plane.ipynb
+++ b/doc/tutorials/pc_extrapolate_plane.ipynb
@@ -1300,7 +1300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pc_fit_plane.ipynb
+++ b/doc/tutorials/pc_fit_plane.ipynb
@@ -1394,7 +1394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/pc_orientation_dependence.ipynb
+++ b/doc/tutorials/pc_orientation_dependence.ipynb
@@ -1633,7 +1633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/reference_frames.ipynb
+++ b/doc/tutorials/reference_frames.ipynb
@@ -183,7 +183,7 @@
     "det = kp.detectors.EBSDDetector(\n",
     "    shape=s.axes_manager.signal_shape[::-1],\n",
     "    pc=[0.4221, 0.2179, 0.4954],\n",
-    "    px_size=70,  # microns\n",
+    "    px_size=70,  # Microns\n",
     "    binning=8,\n",
     "    tilt=0,\n",
     "    sample_tilt=70,\n",
@@ -756,7 +756,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/virtual_backscatter_electron_imaging.ipynb
+++ b/doc/tutorials/virtual_backscatter_electron_imaging.ipynb
@@ -48,7 +48,9 @@
     "# Exchange inline for notebook or qt5 (from pyqt) for interactive plotting\n",
     "%matplotlib inline\n",
     "\n",
+    "from pathlib import Path\n",
     "import tempfile\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -112,8 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_dir = tempfile.mkdtemp() + \"/\"\n",
-    "plt.imsave(temp_dir + \"vbse1.png\", arr=vbse.data)"
+    "temp_dir = Path(tempfile.mkdtemp())\n",
+    "plt.imsave(temp_dir / \"vbse1.png\", arr=vbse.data)"
    ]
   },
   {
@@ -281,9 +283,8 @@
    "source": [
     "fig, ax = plt.subplots(nrows=3, ncols=3, figsize=(20, 20))\n",
     "for idx in np.ndindex(vbse_imgs.axes_manager.navigation_shape[::-1]):\n",
-    "    hs_idx = idx[\n",
-    "        ::-1\n",
-    "    ]  # HyperSpy uses (col, row) instead of NumPy's (row, col)\n",
+    "    # HyperSpy uses (col, row) instead of NumPy's (row, col)\n",
+    "    hs_idx = idx[::-1]\n",
     "    ax[idx].imshow(vbse_imgs.inav[hs_idx].data, cmap=\"gray\")\n",
     "    ax[idx].axis(\"off\")\n",
     "fig.tight_layout(w_pad=0.5, h_pad=-24)"
@@ -376,7 +377,7 @@
     "# Remove files written to disk in this user guide\n",
     "import os\n",
     "\n",
-    "os.remove(temp_dir + \"vbse1.png\")\n",
+    "os.remove(temp_dir / \"vbse1.png\")\n",
     "os.rmdir(temp_dir)"
    ]
   }
@@ -397,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/visualizing_patterns.ipynb
+++ b/doc/tutorials/visualizing_patterns.ipynb
@@ -292,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/pattern_processing/dynamic_background_correction.py
+++ b/examples/pattern_processing/dynamic_background_correction.py
@@ -19,10 +19,8 @@ import kikuchipy as kp
 s = kp.data.nickel_ebsd_small()
 print(s.static_background)
 
-# Keep original for comparison and remove static and dynamic background
 s.remove_static_background()
-s2 = s.deepcopy()
-s2.remove_dynamic_background()
+s2 = s.remove_dynamic_background(inplace=False)
 
 # Plot pattern before and after correction and the intensity histograms
 patterns = [s.inav[0, 0].data, s2.inav[0, 0].data]

--- a/examples/pattern_processing/pattern_binning.py
+++ b/examples/pattern_processing/pattern_binning.py
@@ -14,7 +14,6 @@ This example shows how to bin :class:`~kikuchipy.signals.EBSD` patterns using
 
 import hyperspy.api as hs
 import kikuchipy as kp
-import numpy as np
 
 
 s = kp.data.silicon_ebsd_moving_screen_in(allow_download=True, show_progressbar=False)
@@ -29,8 +28,7 @@ print(s.detector)
 # pattern intensity). Note how the :attr:`~kikuchipy.signals.EBSD.static_background` and
 # :attr:`~kikuchipy.signals.EBSD.detector` attributes are updated.
 
-s2 = s.deepcopy()
-s2.downsample(8)
+s2 = s.downsample(8, inplace=False)
 _ = hs.plot.plot_images([s, s2], axes_decor="off", tight_layout=True, label=None)
 print(s2.static_background.shape)
 print(s2.detector)

--- a/examples/pattern_processing/static_background_correction.py
+++ b/examples/pattern_processing/static_background_correction.py
@@ -19,9 +19,7 @@ import kikuchipy as kp
 s = kp.data.nickel_ebsd_small()
 print(s.static_background)
 
-# Keep original for comparison and remove background
-s2 = s.deepcopy()
-s2.remove_static_background()
+s2 = s.remove_static_background(inplace=False)
 
 # Plot pattern before and after correction and the intensity histograms
 patterns = [s.inav[0, 0].data, s2.inav[0, 0].data]

--- a/kikuchipy/_util/tests/test_import.py
+++ b/kikuchipy/_util/tests/test_import.py
@@ -326,6 +326,7 @@ class TestImport:
             "LazyEBSD",
             "LazyEBSDMasterPattern",
             "LazyECPMasterPattern",
+            "LazyVirtualBSEImage",
             "VirtualBSEImage",
             "util",
         ]

--- a/kikuchipy/generators/tests/test_virtual_bse_generator.py
+++ b/kikuchipy/generators/tests/test_virtual_bse_generator.py
@@ -141,6 +141,10 @@ class TestGetImagesFromGrid:
         assert all([vbse_sig_axes[i].name == s_nav_axes[i].name for i in range(2)])
         assert all([vbse_sig_axes[i].units == s_nav_axes[i].units for i in range(2)])
 
+    def test_get_images_lazy(self, dummy_signal):
+        vbse_gen = VirtualBSEGenerator(dummy_signal.as_lazy())
+        vbse_img = vbse_gen.get_images_from_grid()
+
 
 class TestGetRGBImage:
     def test_get_rgb_image_rois(self):

--- a/kikuchipy/hyperspy_extension.yaml
+++ b/kikuchipy/hyperspy_extension.yaml
@@ -59,6 +59,12 @@ signals:
     dtype: real
     lazy: True
     module: kikuchipy.signals.ecp_master_pattern
+  LazyVirtualBSEImage:
+    signal_type: VirtualBSEImage
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: kikuchipy.signals.virtual_bse_image
   VirtualBSEImage:
     signal_type: VirtualBSEImage
     signal_type_aliases:

--- a/kikuchipy/io/_io.py
+++ b/kikuchipy/io/_io.py
@@ -117,12 +117,13 @@ def load(
     >>> s
     <EBSD, title: patterns Scan 1, dimensions: (3, 3|60, 60)>
     """
+    filename = str(filename)
+
     if not os.path.isfile(filename):
         is_wildcard = False
-        if isinstance(filename, str):
-            filenames = glob.glob(filename)
-            if len(filenames) > 0:
-                is_wildcard = True
+        filenames = glob.glob(filename)
+        if len(filenames) > 0:
+            is_wildcard = True
         if not is_wildcard:
             raise IOError(f"No filename matches '{filename}'.")
 
@@ -363,7 +364,7 @@ def _assign_signal_subclass(
 
 
 def _save(
-    filename: str,
+    filename: Union[str, Path],
     signal,
     overwrite: Optional[bool] = None,
     add_scan: Optional[bool] = None,
@@ -388,6 +389,8 @@ def _save(
     **kwargs :
         Keyword arguments passed to the writer.
     """
+    filename = str(filename)
+
     ext = os.path.splitext(filename)[1][1:]
     if ext == "":  # Will write to kikuchipy's h5ebsd format
         ext = "h5"

--- a/kikuchipy/pattern/chunk.py
+++ b/kikuchipy/pattern/chunk.py
@@ -33,65 +33,6 @@ from kikuchipy.filters.window import Window
 from kikuchipy.pattern._pattern import _rescale_with_min_max
 
 
-def rescale_intensity(
-    patterns: Union[np.ndarray, da.Array],
-    in_range: Union[None, Tuple[int, int], Tuple[float, float]] = None,
-    out_range: Union[None, Tuple[int, int], Tuple[float, float]] = None,
-    dtype_out: Union[
-        str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-    ] = None,
-    percentiles: Union[None, Tuple[int, int], Tuple[float, float]] = None,
-) -> Union[np.ndarray, da.Array]:
-    """Rescale pattern intensities in a chunk of EBSD patterns.
-
-    Chunk max./min. intensity is determined from `out_range` or the
-    data type range of :class:`numpy.dtype` passed to `dtype_out`.
-
-    Parameters
-    ----------
-    patterns
-        EBSD patterns.
-    in_range
-        Min./max. intensity of input patterns. If None (default),
-        `in_range` is set to pattern min./max. Contrast stretching is
-        performed when `in_range` is set to a narrower intensity range
-        than the input patterns.
-    out_range
-        Min./max. intensity of output patterns. If None (default),
-        `out_range` is set to `dtype_out` min./max according to
-        `skimage.util.dtype.dtype_range`.
-    dtype_out
-        Data type of rescaled patterns. If None (default), it is set to
-        the same data type as the input patterns.
-    percentiles
-        Disregard intensities outside these percentiles. Calculated
-        per pattern. Must be None if `in_range` is passed (default
-        is None).
-
-    Returns
-    -------
-    rescaled_patterns : numpy.ndarray
-        Rescaled patterns.
-    """
-    dtype_out = np.dtype(dtype_out)
-    rescaled_patterns = np.empty_like(patterns, dtype=dtype_out)
-
-    for nav_idx in np.ndindex(patterns.shape[:-2]):
-        pattern = patterns[nav_idx]
-
-        if percentiles is not None:
-            in_range = np.percentile(pattern, q=percentiles)
-
-        rescaled_patterns[nav_idx] = pattern_processing.rescale_intensity(
-            pattern=pattern,
-            in_range=in_range,
-            out_range=out_range,
-            dtype_out=dtype_out,
-        )
-
-    return rescaled_patterns
-
-
 def get_dynamic_background(
     patterns: Union[np.ndarray, da.Array],
     filter_func: Union[gaussian_filter, barnes.fft_filter],
@@ -237,57 +178,6 @@ def fft_filter(
         )
 
     return filtered_patterns
-
-
-def normalize_intensity(
-    patterns: Union[np.ndarray, da.Array],
-    num_std: int = 1,
-    divide_by_square_root: bool = False,
-    dtype_out: Union[str, np.dtype, type, None] = None,
-) -> np.ndarray:
-    """Normalize intensities in a chunk of EBSD patterns to a mean of
-    zero with a given standard deviation.
-
-    Parameters
-    ----------
-    patterns
-        Patterns to normalize the intensity in.
-    num_std
-        Number of standard deviations of the output intensities. Default
-        is 1.
-    divide_by_square_root
-        Whether to divide output intensities by the square root of the
-        pattern size. Default is False.
-    dtype_out
-        Data type of normalized patterns. If None (default), the input
-        patterns' data type is used.
-
-    Returns
-    -------
-    normalized_patterns
-        Normalized patterns.
-
-    Notes
-    -----
-    Data type should always be changed to floating point, e.g.
-    ``"float32"`` with :meth:`numpy.ndarray.astype`, before normalizing
-    the intensities.
-    """
-    if dtype_out is None:
-        dtype_out = patterns.dtype
-    else:
-        dtype_out = np.dtype(dtype_out)
-
-    normalized_patterns = np.empty_like(patterns, dtype=dtype_out)
-
-    for nav_idx in np.ndindex(patterns.shape[:-2]):
-        normalized_patterns[nav_idx] = pattern_processing.normalize_intensity(
-            pattern=patterns[nav_idx],
-            num_std=num_std,
-            divide_by_square_root=divide_by_square_root,
-        )
-
-    return normalized_patterns
 
 
 def _average_neighbour_patterns(

--- a/kikuchipy/pattern/tests/test_pattern.py
+++ b/kikuchipy/pattern/tests/test_pattern.py
@@ -35,6 +35,7 @@ from kikuchipy.pattern._pattern import (
     _downsample2d,
     _dynamic_background_frequency_space_setup,
     _get_image_quality_numba,
+    _normalize_intensity,
     _remove_background_subtract,
     _remove_background_divide,
     _remove_static_background_subtract,
@@ -507,12 +508,25 @@ class TestNormalizeIntensityPattern:
         self, dummy_signal, num_std, divide_by_square_root, answer
     ):
         p = dummy_signal.inav[0, 0].data.astype(np.float32)
-        p2 = normalize_intensity.py_func(
+
+        # Numba function
+        p2 = _normalize_intensity(
             pattern=p, num_std=num_std, divide_by_square_root=divide_by_square_root
         )
-
         assert np.allclose(np.mean(p2), 0, atol=1e-6)
         assert np.allclose(p2, answer, atol=1e-4)
+
+        # Python function
+        p3 = _normalize_intensity.py_func(
+            pattern=p, num_std=num_std, divide_by_square_root=divide_by_square_root
+        )
+        assert np.allclose(np.mean(p3), 0, atol=1e-6)
+        assert np.allclose(p3, answer, atol=1e-4)
+
+    def test_normalize_intensity_pattern_dtype(self, dummy_signal):
+        p = dummy_signal.inav[0, 0].data.astype(np.float32)
+        p2 = normalize_intensity(p, dtype_out=np.float64)
+        assert p2.dtype == np.float64
 
 
 class TestDownsample:

--- a/kikuchipy/signals/__init__.py
+++ b/kikuchipy/signals/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "LazyEBSD",
     "LazyEBSDMasterPattern",
     "LazyECPMasterPattern",
+    "LazyVirtualBSEImage",
     "VirtualBSEImage",
     "util",
 ]
@@ -53,6 +54,7 @@ def __getattr__(name):
         "LazyEBSD": "ebsd",
         "LazyEBSDMasterPattern": "ebsd_master_pattern",
         "LazyECPMasterPattern": "ecp_master_pattern",
+        "LazyVirtualBSEImage": "virtual_bse_image",
         "VirtualBSEImage": "virtual_bse_image",
     }
     if name in __all__:

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -431,12 +431,16 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         divide_by_square_root: bool = False,
         dtype_out: Union[str, np.dtype, type, None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().normalize_intensity(
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        return super().normalize_intensity(
             num_std=num_std,
             divide_by_square_root=divide_by_square_root,
             dtype_out=dtype_out,
             show_progressbar=show_progressbar,
+            inplace=inplace,
+            lazy_output=lazy_output,
         )
 
     def rescale_intensity(
@@ -449,14 +453,18 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         ] = None,
         percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().rescale_intensity(
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        return super().rescale_intensity(
             relative=relative,
             in_range=in_range,
             out_range=out_range,
             dtype_out=dtype_out,
             percentiles=percentiles,
             show_progressbar=show_progressbar,
+            inplace=inplace,
+            lazy_output=lazy_output,
         )
 
     # --- Inherited methods from Signal2D overwritten. If the inherited

--- a/kikuchipy/signals/ecp_master_pattern.py
+++ b/kikuchipy/signals/ecp_master_pattern.py
@@ -115,12 +115,16 @@ class ECPMasterPattern(KikuchiMasterPattern):
         divide_by_square_root: bool = False,
         dtype_out: Union[str, np.dtype, type, None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().normalize_intensity(
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        return super().normalize_intensity(
             num_std=num_std,
             divide_by_square_root=divide_by_square_root,
             dtype_out=dtype_out,
             show_progressbar=show_progressbar,
+            inplace=inplace,
+            lazy_output=lazy_output,
         )
 
     def rescale_intensity(
@@ -133,14 +137,18 @@ class ECPMasterPattern(KikuchiMasterPattern):
         ] = None,
         percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().rescale_intensity(
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        return super().rescale_intensity(
             relative=relative,
             in_range=in_range,
             out_range=out_range,
             dtype_out=dtype_out,
             percentiles=percentiles,
             show_progressbar=show_progressbar,
+            inplace=inplace,
+            lazy_output=lazy_output,
         )
 
     # --- Inherited methods from Signal2D overwritten

--- a/kikuchipy/signals/tests/test_ebsd_master_pattern.py
+++ b/kikuchipy/signals/tests/test_ebsd_master_pattern.py
@@ -633,3 +633,71 @@ class TestIntensityScaling:
         mp.change_dtype("float32")
         mp.normalize_intensity()
         assert np.allclose([mp.data.min(), mp.data.max()], [-1.33, 5.93], atol=1e-2)
+
+    def test_rescale_intensity_inplace(self):
+        mp = nickel_ebsd_master_pattern_small()
+
+        # Current signal is unaffected
+        mp2 = mp.deepcopy()
+        mp3 = mp.normalize_intensity(inplace=False)
+        assert isinstance(mp3, kp.signals.EBSDMasterPattern)
+        assert np.allclose(mp2.data, mp.data)
+
+        # Operating on current signal gives same result as output
+        mp.normalize_intensity()
+        assert np.allclose(mp3.data, mp.data)
+
+        # Operating on lazy signal returns lazy signal
+        mp4 = mp2.as_lazy()
+        mp5 = mp4.normalize_intensity(inplace=False)
+        assert isinstance(mp5, kp.signals.LazyEBSDMasterPattern)
+        mp5.compute()
+        assert np.allclose(mp5.data, mp.data)
+
+    def test_rescale_intensity_lazy_output(self):
+        mp = nickel_ebsd_master_pattern_small()
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = mp.normalize_intensity(lazy_output=True)
+
+        mp2 = mp.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(mp2, kp.signals.LazyEBSDMasterPattern)
+
+        mp3 = mp.as_lazy()
+        mp4 = mp3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(mp4, kp.signals.EBSDMasterPattern)
+
+    def test_normalize_intensity_inplace(self):
+        mp = nickel_ebsd_master_pattern_small()
+
+        # Current signal is unaffected
+        mp2 = mp.deepcopy()
+        mp3 = mp.normalize_intensity(inplace=False)
+        assert isinstance(mp3, kp.signals.EBSDMasterPattern)
+        assert np.allclose(mp2.data, mp.data)
+
+        # Operating on current signal gives same result as output
+        mp.normalize_intensity()
+        assert np.allclose(mp3.data, mp.data)
+
+        # Operating on lazy signal returns lazy signal
+        mp4 = mp2.as_lazy()
+        mp5 = mp4.normalize_intensity(inplace=False)
+        assert isinstance(mp5, kp.signals.LazyEBSDMasterPattern)
+        mp5.compute()
+        assert np.allclose(mp5.data, mp.data)
+
+    def test_normalize_intensity_lazy_output(self):
+        mp = nickel_ebsd_master_pattern_small()
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = mp.normalize_intensity(lazy_output=True)
+
+        mp2 = mp.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(mp2, kp.signals.LazyEBSDMasterPattern)
+
+        mp3 = mp.as_lazy()
+        mp4 = mp3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(mp4, kp.signals.EBSDMasterPattern)

--- a/kikuchipy/signals/tests/test_ecp_master_pattern.py
+++ b/kikuchipy/signals/tests/test_ecp_master_pattern.py
@@ -111,3 +111,71 @@ class TestECPMasterPattern:
         # deepcopy()
         s3 = s.deepcopy()
         assert not np.may_share_memory(s.data, s3.data)
+
+    def test_rescale_intensity_inplace(self):
+        mp = kp.load(ECP_FILE)
+
+        # Current signal is unaffected
+        mp2 = mp.deepcopy()
+        mp3 = mp.normalize_intensity(inplace=False)
+        assert isinstance(mp3, kp.signals.ECPMasterPattern)
+        assert np.allclose(mp2.data, mp.data)
+
+        # Operating on current signal gives same result as output
+        mp.normalize_intensity()
+        assert np.allclose(mp3.data, mp.data)
+
+        # Operating on lazy signal returns lazy signal
+        mp4 = mp2.as_lazy()
+        mp5 = mp4.normalize_intensity(inplace=False)
+        assert isinstance(mp5, kp.signals.LazyECPMasterPattern)
+        mp5.compute()
+        assert np.allclose(mp5.data, mp.data)
+
+    def test_rescale_intensity_lazy_output(self):
+        mp = kp.load(ECP_FILE)
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = mp.normalize_intensity(lazy_output=True)
+
+        mp2 = mp.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(mp2, kp.signals.LazyECPMasterPattern)
+
+        mp3 = mp.as_lazy()
+        mp4 = mp3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(mp4, kp.signals.ECPMasterPattern)
+
+    def test_normalize_intensity_inplace(self):
+        mp = kp.load(ECP_FILE)
+
+        # Current signal is unaffected
+        mp2 = mp.deepcopy()
+        mp3 = mp.normalize_intensity(inplace=False)
+        assert isinstance(mp3, kp.signals.ECPMasterPattern)
+        assert np.allclose(mp2.data, mp.data)
+
+        # Operating on current signal gives same result as output
+        mp.normalize_intensity()
+        assert np.allclose(mp3.data, mp.data)
+
+        # Operating on lazy signal returns lazy signal
+        mp4 = mp2.as_lazy()
+        mp5 = mp4.normalize_intensity(inplace=False)
+        assert isinstance(mp5, kp.signals.LazyECPMasterPattern)
+        mp5.compute()
+        assert np.allclose(mp5.data, mp.data)
+
+    def test_normalize_intensity_lazy_output(self):
+        mp = kp.load(ECP_FILE)
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = mp.normalize_intensity(lazy_output=True)
+
+        mp2 = mp.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(mp2, kp.signals.LazyECPMasterPattern)
+
+        mp3 = mp.as_lazy()
+        mp4 = mp3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(mp4, kp.signals.ECPMasterPattern)

--- a/kikuchipy/signals/tests/test_virtual_bse_image.py
+++ b/kikuchipy/signals/tests/test_virtual_bse_image.py
@@ -15,22 +15,100 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
 import pytest
 
-from kikuchipy.generators import VirtualBSEGenerator
+import kikuchipy as kp
 
 
 class TestVirtualBSEImage:
     def test_rescale_rgb_raises(self, dummy_signal):
-        vbse_gen = VirtualBSEGenerator(dummy_signal)
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
         vbse_gen.grid_shape = (3, 3)
         rgb = vbse_gen.get_rgb_image(r=(0, 0), g=(0, 1), b=(1, 0))
         with pytest.raises(NotImplementedError):
             rgb.rescale_intensity()
 
     def test_normalize_rgb_raises(self, dummy_signal):
-        vbse_gen = VirtualBSEGenerator(dummy_signal)
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
         vbse_gen.grid_shape = (3, 3)
         rgb = vbse_gen.get_rgb_image(r=(0, 0), g=(0, 1), b=(1, 0))
         with pytest.raises(NotImplementedError):
             rgb.normalize_intensity()
+
+    def test_rescale_intensity_inplace(self, dummy_signal):
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        vbse_img = vbse_gen.get_images_from_grid()
+
+        # Current signal is unaffected
+        vbse_img2 = vbse_img.deepcopy()
+        vbse_img3 = vbse_img.normalize_intensity(inplace=False)
+        assert isinstance(vbse_img3, kp.signals.VirtualBSEImage)
+        assert np.allclose(vbse_img2.data, vbse_img.data)
+
+        # Operating on current signal gives same result as output
+        vbse_img.normalize_intensity()
+        assert np.allclose(vbse_img3.data, vbse_img.data)
+
+        # Operating on lazy signal returns lazy signal
+        mp4 = vbse_img2.as_lazy()
+        mp5 = mp4.normalize_intensity(inplace=False)
+        assert isinstance(mp5, kp.signals.LazyVirtualBSEImage)
+        mp5.compute()
+        assert np.allclose(mp5.data, vbse_img.data)
+
+    def test_rescale_intensity_lazy_output(self, dummy_signal):
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        vbse_img = vbse_gen.get_images_from_grid()
+
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = vbse_img.normalize_intensity(lazy_output=True)
+
+        vbse_img2 = vbse_img.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(vbse_img2, kp.signals.LazyVirtualBSEImage)
+
+        vbse_img3 = vbse_img.as_lazy()
+        vbse_img4 = vbse_img3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(vbse_img4, kp.signals.VirtualBSEImage)
+
+    def test_normalize_intensity_inplace(self, dummy_signal):
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        vbse_img = vbse_gen.get_images_from_grid()
+
+        # Current signal is unaffected
+        vbse_img2 = vbse_img.deepcopy()
+        vbse_img3 = vbse_img.normalize_intensity(inplace=False)
+        assert isinstance(vbse_img3, kp.signals.VirtualBSEImage)
+        assert np.allclose(vbse_img2.data, vbse_img.data)
+
+        # Operating on current signal gives same result as output
+        vbse_img.normalize_intensity()
+        assert np.allclose(vbse_img3.data, vbse_img.data)
+
+        # Operating on lazy signal returns lazy signal
+        vbse_img4 = vbse_img2.as_lazy()
+        vbse_img5 = vbse_img4.normalize_intensity(inplace=False)
+        assert isinstance(vbse_img5, kp.signals.LazyVirtualBSEImage)
+        vbse_img5.compute()
+        assert np.allclose(vbse_img5.data, vbse_img.data)
+
+    def test_normalize_intensity_lazy_output(self, dummy_signal):
+        vbse_gen = kp.generators.VirtualBSEGenerator(dummy_signal)
+        vbse_gen.grid_shape = (3, 3)
+        vbse_img = vbse_gen.get_images_from_grid()
+        with pytest.raises(
+            ValueError, match="`lazy_output=True` requires `inplace=False`"
+        ):
+            _ = vbse_img.normalize_intensity(lazy_output=True)
+
+        vbse_img2 = vbse_img.normalize_intensity(inplace=False, lazy_output=True)
+        assert isinstance(vbse_img2, kp.signals.LazyVirtualBSEImage)
+
+        vbse_img3 = vbse_img.as_lazy()
+        vbse_img4 = vbse_img3.normalize_intensity(inplace=False, lazy_output=False)
+        assert isinstance(vbse_img4, kp.signals.VirtualBSEImage)

--- a/kikuchipy/signals/virtual_bse_image.py
+++ b/kikuchipy/signals/virtual_bse_image.py
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
 from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from kikuchipy.signals._kikuchipy_signal import KikuchipySignal2D
+from kikuchipy.signals._kikuchipy_signal import KikuchipySignal2D, LazyKikuchipySignal2D
 
 
 class VirtualBSEImage(KikuchipySignal2D):
@@ -47,9 +48,18 @@ class VirtualBSEImage(KikuchipySignal2D):
         ] = None,
         percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().rescale_intensity(
-            relative, in_range, out_range, dtype_out, percentiles, show_progressbar
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        return super().rescale_intensity(
+            relative,
+            in_range,
+            out_range,
+            dtype_out,
+            percentiles,
+            show_progressbar,
+            inplace,
+            lazy_output,
         )
 
     def normalize_intensity(
@@ -58,5 +68,31 @@ class VirtualBSEImage(KikuchipySignal2D):
         divide_by_square_root: bool = False,
         dtype_out: Union[str, np.dtype, type, None] = None,
         show_progressbar: Optional[bool] = None,
-    ) -> None:
-        super().normalize_intensity(num_std, divide_by_square_root, dtype_out)
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        return super().normalize_intensity(
+            num_std,
+            divide_by_square_root,
+            show_progressbar,
+            dtype_out,
+            inplace,
+            lazy_output,
+        )
+
+
+class LazyVirtualBSEImage(LazyKikuchipySignal2D, VirtualBSEImage):
+    """Lazy implementation of
+    :class:`~kikuchipy.signals.VirtualBSEImage`.
+
+    See the documentation of ``VirtualBSEImage`` for attributes and
+    methods.
+
+    This class extends HyperSpy's
+    :class:`~hyperspy._signals.signal2d.LazySignal2D` class for EBSD
+    master patterns. See the documentation of that class for how to
+    create this signal and the list of inherited attributes and methods.
+    """
+
+    def compute(self, *args, **kwargs) -> None:
+        super().compute(*args, **kwargs)


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR adds the option to pass `inplace=False` to many methods, like `EBSD.remove_static_background()` or `EBSDMasterPattern.rescale_intensity()`. Most methods also support to return a lazy signal instead of one in memory via `lazy_output=True`.

A `LazyVirtualBSEImage` class is added for use with mostly `VirtualBSEImage.rescale_intensity(inplace=False, lazy_output=True)`.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> s = kp.data.nickel_ebsd_small()

# Before

>>> s2 = s.deepcopy()
>>> s2.remove_static_background()

# Now

>>> s2 = s.remove_static_background(inplace=False)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
