### PR TITLE
Make adaptive histogram equalization available to all classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Unreleased
 
 Added
 -----
+- Adaptive histogram equalization is available to all signals.
+  (`#606 <https://github.com/pyxem/kikuchipy/pull/606>`_)
 - Option to return a new signal (lazy or not) instead of operating inplace is added to
   many methods in all classes via ``inplace`` and ``lazy_output`` boolean parameters.
   (`#605 <https://github.com/pyxem/kikuchipy/pull/605>`_)
@@ -101,6 +103,9 @@ Added
 
 Changed
 -------
+- Added warnings when trying to perform adaptive histogram equalization on a signal with
+  data in floating type or when some of the data is NaN.
+  (`#606 <https://github.com/pyxem/kikuchipy/pull/606>`_)
 - Dask arrays returned from EBSD refinement methods has the number of function
   evaluations as the second element after the score.
   (`#593 <https://github.com/pyxem/kikuchipy/pull/593>`_)

--- a/examples/pattern_processing/adaptive_histogram_equalization.py
+++ b/examples/pattern_processing/adaptive_histogram_equalization.py
@@ -1,0 +1,79 @@
+"""
+===============================
+Adaptive histogram equalization
+===============================
+
+This example shows how to perform AHE on a simulated pattern and a master pattern.
+Two identical simulated patterns, but one projected from the master pattern *after* AHE
+has been applied to it, are compared. We'll use
+:meth:`kikuchipy.signals.EBSDMasterPattern.adaptive_histogram_equalization` and the
+equivalent method for the ``EBSD`` class.
+
+Adaptive histogram equalization (AHE) has been used to enhance pattern contrast and
+improve the efficacy of the normalized dot product (NDP) metric when comparing
+experimental and simulated patterns, e.g. in dictionary indexing
+:cite:`marquardt2017quantitative`. Before performing AHE, it might be worth considering
+using the normalized cross-correlation (NCC) metric instead.
+"""
+
+import hyperspy.api as hs
+import kikuchipy as kp
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from orix.quaternion import Rotation
+
+
+hs.preferences.General.show_progressbar = False
+
+# Master pattern in square Lambert projection, of integer data type
+mp = kp.data.nickel_ebsd_master_pattern_small(projection="lambert")
+
+mp2 = mp.adaptive_histogram_equalization(inplace=False)
+
+# Plot master pattern before and after correction and the intensity histograms
+mps_data = [mp.data, mp2.data]
+fig, axes = plt.subplots(2, 2, height_ratios=[3, 1.5])
+for ax, pattern, title in zip(
+    axes[0], mps_data, ["Original", "Adaptive histogram eq."]
+):
+    ax.imshow(pattern, cmap="gray")
+    ax.set_title(title)
+    ax.axis("off")
+for ax, pattern in zip(axes[1], mps_data):
+    ax.hist(pattern.ravel(), bins=100)
+    ax.set(xlabel="Gray level", ylabel="Frequency")
+fig.tight_layout()
+
+########################################################################################
+# Let's show that intensities are approximately the same in patterns where one is
+# equalized while the other is projected from a master pattern which itself is
+# equalized.
+
+# Project experimental patterns from each master pattern
+det = kp.detectors.EBSDDetector((100, 100), sample_tilt=0)
+r = Rotation.identity()
+s1 = mp.get_patterns(r, det, energy=20, dtype_out="uint8", compute=True)
+s2 = mp2.get_patterns(r, det, energy=20, dtype_out="uint8", compute=True)
+
+# Adaptive histogram equalization of the first pattern
+s1.adaptive_histogram_equalization()
+
+# Plot the patterns, their difference and their intensity histograms
+patterns = [s1.data, s2.data, (s1 - s2).data]
+fig, axes = plt.subplots(2, 3, figsize=(8.5, 4), height_ratios=[3, 1.5])
+for ax, pattern, title, cmap in zip(
+    axes[0],
+    patterns,
+    ["AHE of pattern", "AHE of master pattern", "Difference"],
+    ["gray", "gray", "seismic"],
+):
+    im = ax.imshow(pattern.squeeze(), cmap=cmap)
+    ax.set_title(title)
+    ax.axis("off")
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="5%", pad=0.05)
+    plt.colorbar(im, cax=cax)
+for ax, pattern in zip(axes[1], patterns):
+    ax.hist(pattern.ravel(), bins=100)
+    ax.set(xlabel="Gray level", ylabel="Frequency")
+fig.tight_layout()

--- a/kikuchipy/pattern/tests/test_chunk.py
+++ b/kikuchipy/pattern/tests/test_chunk.py
@@ -15,12 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from packaging import version
-
 import numpy as np
 import pytest
 from scipy.ndimage import gaussian_filter
-from skimage import __version__ as skimage_version
 
 from kikuchipy.filters.fft_barnes import _fft_filter
 from kikuchipy.filters.window import Window
@@ -31,14 +28,6 @@ from kikuchipy.pattern._pattern import (
 )
 from kikuchipy.pattern import chunk
 from kikuchipy.signals.util._dask import get_dask_array
-
-
-# Expected output intensities from various image processing methods
-ADAPT_EQ_UINT8 = np.array([[92, 215, 92], [255, 215, 92], [215, 26, 0]], dtype=np.uint8)
-if version.parse(skimage_version) < version.parse("0.17"):  # pragma: no cover
-    ADAPT_EQ_UINT8 = np.array(
-        [[127, 223, 127], [255, 223, 31], [223, 31, 0]], dtype=np.uint8
-    )
 
 
 class TestGetDynamicBackgroundChunk:
@@ -152,23 +141,6 @@ class TestGetDynamicBackgroundChunk:
         assert isinstance(background, np.ndarray)
         assert background.dtype == dtype_out
         assert np.allclose(background[0, 0], answer, atol=1e-4)
-
-
-class TestAdaptiveHistogramEqualizationChunk:
-    def test_adaptive_histogram_equalization_chunk(self, dummy_signal):
-        dask_array = get_dask_array(dummy_signal)
-        dtype_out = dask_array.dtype
-        kernel_size = (10, 10)
-        nbins = 128
-        equalized_patterns = dask_array.map_blocks(
-            func=chunk.adaptive_histogram_equalization,
-            kernel_size=kernel_size,
-            nbins=nbins,
-        )
-
-        # Check for correct data type and gives expected output intensities
-        assert equalized_patterns.dtype == dtype_out
-        assert np.allclose(equalized_patterns[0, 0].compute(), ADAPT_EQ_UINT8)
 
 
 class TestFFTFilterChunk:

--- a/kikuchipy/signals/ebsd_master_pattern.py
+++ b/kikuchipy/signals/ebsd_master_pattern.py
@@ -16,7 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import dask
 import dask.array as da
@@ -465,6 +465,24 @@ class EBSDMasterPattern(KikuchiMasterPattern):
             show_progressbar=show_progressbar,
             inplace=inplace,
             lazy_output=lazy_output,
+        )
+
+    def adaptive_histogram_equalization(
+        self,
+        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
+        clip_limit: Union[int, float] = 0,
+        nbins: int = 128,
+        show_progressbar: Optional[bool] = None,
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        return super().adaptive_histogram_equalization(
+            kernel_size,
+            clip_limit,
+            nbins,
+            show_progressbar,
+            inplace,
+            lazy_output,
         )
 
     # --- Inherited methods from Signal2D overwritten. If the inherited

--- a/kikuchipy/signals/ecp_master_pattern.py
+++ b/kikuchipy/signals/ecp_master_pattern.py
@@ -16,7 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from orix.crystal_map import Phase
@@ -107,7 +107,9 @@ class ECPMasterPattern(KikuchiMasterPattern):
             show_kwargs=show_kwargs,
         )
 
-    # --- Inherited methods from CommonImage overwritten
+    # --- Inherited methods from KikuchipySignal overwritten. If the
+    # inherited methods are not altered, they are included for
+    # documentation purposes.
 
     def normalize_intensity(
         self,
@@ -149,6 +151,24 @@ class ECPMasterPattern(KikuchiMasterPattern):
             show_progressbar=show_progressbar,
             inplace=inplace,
             lazy_output=lazy_output,
+        )
+
+    def adaptive_histogram_equalization(
+        self,
+        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
+        clip_limit: Union[int, float] = 0,
+        nbins: int = 128,
+        show_progressbar: Optional[bool] = None,
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        return super().adaptive_histogram_equalization(
+            kernel_size,
+            clip_limit,
+            nbins,
+            show_progressbar,
+            inplace,
+            lazy_output,
         )
 
     # --- Inherited methods from Signal2D overwritten

--- a/kikuchipy/signals/tests/test_ecp_master_pattern.py
+++ b/kikuchipy/signals/tests/test_ecp_master_pattern.py
@@ -179,3 +179,9 @@ class TestECPMasterPattern:
         mp3 = mp.as_lazy()
         mp4 = mp3.normalize_intensity(inplace=False, lazy_output=False)
         assert isinstance(mp4, kp.signals.ECPMasterPattern)
+
+    def test_adaptive_histogram_equalization(self):
+        mp = kp.load(ECP_FILE)
+        mp.rescale_intensity(dtype_out=np.uint8)
+        mp.adaptive_histogram_equalization()
+        assert all([mp.data.min() >= 0, mp.data.max() <= 255])

--- a/kikuchipy/signals/tests/test_virtual_bse_image.py
+++ b/kikuchipy/signals/tests/test_virtual_bse_image.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 
+import hyperspy.api as hs
 import kikuchipy as kp
 
 
@@ -112,3 +113,11 @@ class TestVirtualBSEImage:
         vbse_img3 = vbse_img.as_lazy()
         vbse_img4 = vbse_img3.normalize_intensity(inplace=False, lazy_output=False)
         assert isinstance(vbse_img4, kp.signals.VirtualBSEImage)
+
+    def test_adaptive_histogram_equalization(self):
+        data = np.random.random(4800).reshape((40, 30, 2, 2))
+        s = kp.signals.EBSD(data)
+        vbse_img = s.get_virtual_bse_intensity(hs.roi.RectangularROI(0, 0, 2, 2))
+        vbse_img.rescale_intensity(dtype_out=np.uint8)
+        vbse_img.adaptive_histogram_equalization()
+        assert abs(np.unique(vbse_img.data).size - 255) <= 5

--- a/kikuchipy/signals/virtual_bse_image.py
+++ b/kikuchipy/signals/virtual_bse_image.py
@@ -16,7 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -76,6 +76,24 @@ class VirtualBSEImage(KikuchipySignal2D):
             divide_by_square_root,
             show_progressbar,
             dtype_out,
+            inplace,
+            lazy_output,
+        )
+
+    def adaptive_histogram_equalization(
+        self,
+        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
+        clip_limit: Union[int, float] = 0,
+        nbins: int = 128,
+        show_progressbar: Optional[bool] = None,
+        inplace: bool = True,
+        lazy_output: Optional[bool] = None,
+    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        return super().adaptive_histogram_equalization(
+            kernel_size,
+            clip_limit,
+            nbins,
+            show_progressbar,
             inplace,
             lazy_output,
         )


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Made `adaptive_histogram_equalization()` available to both master pattern classes and the `VirtualBSEImage` class. Also added an example to the docs showing the use of these methods.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
See example in the docs built from this PR.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
