### PR TITLE
Allow publish action to fail uploading to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      continue-on-error: true
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Wanted to check whether docs were not included in the PyPI upload, so I uploaded the source distribution tagged with 0.8.0 from my machine to TestPyPI. The docs were not included, great. But now the automatic upload from GitHub fails because 0.8.0 already exists on TestPyPI. Not great.

This is (temporarily?) fixed by allowing the publish action to fail uploading to TestPyPI.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
