### PR TITLE
Fix merging of maps with non-indexed points and release v0.8.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+0.8.5 (2023-05-21)
+==================
+
+Fixed
+-----
+- Not-indexed points in crystal maps are handled correctly when merging.
+  (`#639 <https://github.com/pyxem/kikuchipy/pull/639>`_)
+
 0.8.4 (2023-04-07)
 ==================
 

--- a/kikuchipy/pattern/tests/test_pattern.py
+++ b/kikuchipy/pattern/tests/test_pattern.py
@@ -181,6 +181,7 @@ class TestRemoveStaticBackgroundPattern:
         assert np.allclose(p0, p)
         assert p0.dtype == p.dtype
 
+    @pytest.mark.filterwarnings("ignore:invalid value")
     def test_remove_static_background_divide(self, dummy_signal, dummy_background):
         p = dummy_signal.inav[0, 0].data
         dtype_out = p.dtype

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -37,4 +37,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.8.4"
+version = "0.8.5"

--- a/kikuchipy/signals/tests/test_ebsd.py
+++ b/kikuchipy/signals/tests/test_ebsd.py
@@ -557,6 +557,7 @@ class TestRemoveDynamicBackgroundEBSD:
         with pytest.raises(ValueError, match=f"{filter_domain} must be "):
             dummy_signal.remove_dynamic_background(filter_domain=filter_domain)
 
+    @pytest.mark.filterwarnings("ignore:invalid value")
     def test_inplace(self, dummy_signal):
         # Current signal is unaffected
         s = dummy_signal.deepcopy()
@@ -580,6 +581,7 @@ class TestRemoveDynamicBackgroundEBSD:
         s4.compute()
         assert np.allclose(s4.data, dummy_signal.data)
 
+    @pytest.mark.filterwarnings("ignore:invalid value")
     def test_lazy_output(self, dummy_signal):
         with pytest.raises(
             ValueError, match="`lazy_output=True` requires `inplace=False`"


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Fixes #637.

@Erlendos12, can you test this branch in EBSP Indexer against your problem reported in #637 for me?

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
Create two crystal maps with some points considered not-indexed, only some of them not-indexed in both maps
```python
import kikuchipy as kp
import numpy as np
from orix.crystal_map import CrystalMap
from orix.quaternion import Rotation


xmap_a = CrystalMap.empty((4, 3))
xmap_a.phases[0].name = "a"
is_indexed_a = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [0, 1, 1]], dtype=bool).ravel()
xmap_a.phases.add_not_indexed()
xmap_a[~is_indexed_a].phase_id = -1
xmap_a.prop["scores"] = np.array([[2, 2, 0], [3, 0, 4], [0, 4, 3], [0, 2, 1]], dtype=float).ravel()

xmap_b = CrystalMap.empty((4, 3))
xmap_b.phases[0].name = "b"
is_indexed_b = np.array([[1, 1, 0], [1, 1, 1], [0, 1, 1], [0, 1, 0]], dtype=bool).ravel()
xmap_b.phases.add_not_indexed()
xmap_b[~is_indexed_b].phase_id = -1
xmap_b.prop["scores"] = np.array([[3, 1, 0], [2, 1, 5], [0, 2, 4], [0, 1, 0]], dtype=float).ravel()

xmap_ab = kp.indexing.merge_crystal_maps([xmap_a, xmap_b])

print(xmap_ab)
# Before:
# Phase  Orientations         Name  Space group  Point group  Proper point group       Color
#     0   12 (100.0%)  not_indexed         None         None                None      w
# Properties: scores, merged_scores
# Scan unit: px

# Now:
# Phase  Orientations         Name  Space group  Point group  Proper point group       Color
#    -1     3 (25.0%)  not_indexed         None         None                None           w
#     0     5 (41.7%)            a         None         None                None    tab:blue
#     1     4 (33.3%)            b         None         None                None  tab:orange
# Properties: scores, merged_scores
# Scan unit: px
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
