### PR TITLE
Remove viz PyPI selector and other minor maintenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/checkout@v3
 
@@ -41,12 +44,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       continue-on-error: true
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ Added
 
 Changed
 -------
+- ``zone_axes_kwargs`` parameter in
+  ``GeometricalKikuchiPatternSimulation.as_collections()`` does not use ``color``
+  internally to set the default color to white anymore, but uses ``fc`` (facecolor)
+  instead. This change was necessary to improve handling of other keyword arguments.
 
 Deprecated
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
   ``GeometricalKikuchiPatternSimulation.as_collections()`` does not use ``color``
   internally to set the default color to white anymore, but uses ``fc`` (facecolor)
   instead. This change was necessary to improve handling of other keyword arguments.
+  (`#643 <https://github.com/pyxem/kikuchipy/pull/643>`_)
 
 Deprecated
 ----------
@@ -33,6 +34,8 @@ Removed
 -------
 - Removed ``generators`` and ``projections`` modules which were deprecated in version
   0.8. (`#612 <https://github.com/pyxem/kikuchipy/pull/612>`_)
+- The deprecated PyPI selector ``viz`` is removed.
+  (`#643 <https://github.com/pyxem/kikuchipy/pull/643>`_)
 
 Fixed
 -----

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -49,12 +49,6 @@ Note that this command will not install ``pyopencl``, which is required for GPU 
 in ``pyebsdindex``. If the above command failed for some reason, one can try to install
 each optional dependency individually.
 
-.. warning::
-
-    The option to install optional dependency ``pyvista`` via
-    ``pip install kikuchipy[viz]`` will be removed in version 0.9. Please install
-    manually or via ``pip install kikuchipy[all]`` instead.
-
 .. _install-with-anaconda:
 
 With Anaconda

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.9
   - pip
   - pip:
-      - --editable .[doc,viz]
+      - --editable .[doc,all]

--- a/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -460,12 +460,15 @@ class GeometricalKikuchiPatternSimulation:
         """
         coords = self.lines_coordinates(index, coordinates)
         coords = coords.reshape((coords.shape[0], 2, 2))
-        line_defaults = dict(
-            color="r", linewidth=1, alpha=1, zorder=1, label="kikuchi_lines"
-        )
-        for k, v in line_defaults.items():
-            kwargs.setdefault(k, v)
-        return mcollections.LineCollection(segments=list(coords), **kwargs)
+        kw = {
+            "color": "r",
+            "linewidth": 1,
+            "alpha": 1,
+            "zorder": 1,
+            "label": "kikuchi_lines",
+        }
+        kw.update(kwargs)
+        return mcollections.LineCollection(segments=list(coords), **kw)
 
     def _lines_as_markers(self, **kwargs) -> List[line_segment]:
         """Get Kikuchi lines as a list of HyperSpy markers.
@@ -483,9 +486,8 @@ class GeometricalKikuchiPatternSimulation:
         """
         coords = self.lines_coordinates(index=(), exclude_nan=False)
         lines_list = []
-        segment_defaults = dict(color="r", zorder=1)
-        for k, v in segment_defaults.items():
-            kwargs.setdefault(k, v)
+        kw = {"color": "r", "zorder": 1}
+        kw.update(kwargs)
 
         for i in range(self._lines.vector.size):
             line = coords[..., i, :]
@@ -495,7 +497,7 @@ class GeometricalKikuchiPatternSimulation:
                 y1 = line[..., 1].squeeze()
                 x2 = line[..., 2].squeeze()
                 y2 = line[..., 3].squeeze()
-                marker = line_segment(x1=x1, y1=y1, x2=x2, y2=y2, **kwargs)
+                marker = line_segment(x1=x1, y1=y1, x2=x2, y2=y2, **kw)
                 lines_list.append(marker)
 
         return lines_list
@@ -533,10 +535,10 @@ class GeometricalKikuchiPatternSimulation:
         if ncols > 1:
             pcx *= ncols - 1
 
-        for k, v in dict(size=300, marker="*", fc="gold", ec="k", zorder=4).items():
-            kwargs.setdefault(k, v)
+        kw = {"size": 300, "marker": "*", "fc": "gold", "ec": "k", "zorder": 4}
+        kw.update(kwargs)
 
-        pc_marker = point(x=pcx, y=pcy, **kwargs)
+        pc_marker = point(x=pcx, y=pcy, **kw)
 
         return [pc_marker]
 
@@ -639,10 +641,9 @@ class GeometricalKikuchiPatternSimulation:
         circles = []
         for x, y in coords:
             circles.append(mpath.Path.circle((x, y), scatter_size))
-        path_defaults = dict(color="w", ec="k", zorder=1, label="zone_axes")
-        for k, v in path_defaults.items():
-            kwargs.setdefault(k, v)
-        return mcollections.PathCollection(circles, **kwargs)
+        kw = {"ec": "k", "fc": "w", "zorder": 1, "label": "zone_axes"}
+        kw.update(kwargs)
+        return mcollections.PathCollection(circles, **kw)
 
     def _zone_axes_labels_as_list(
         self, index: Union[int, tuple], coordinates: str, **kwargs
@@ -667,7 +668,7 @@ class GeometricalKikuchiPatternSimulation:
             List of zone axes labels.
         """
         za = self._zone_axes
-        za_labels = za.vector.coordinates.round(0).astype(np.int64)
+        za_labels = za.vector.coordinates.round().astype(np.int64)
         za_labels_str = np.array2string(za_labels, threshold=za_labels.size)
         za_labels_list = re.sub("[][ ]", "", za_labels_str[1:-1]).split("\n")
         xy = self.zone_axes_coordinates(index, coordinates, exclude_nan=False)
@@ -675,13 +676,12 @@ class GeometricalKikuchiPatternSimulation:
             xy[..., 1] -= 0.03 * self.detector.nrows
         else:  # gnomonic
             xy[..., 1] += 0.03 * np.diff(self.detector.y_range)[0]
-        text_defaults = dict(ha="center", bbox=dict(boxstyle="square", fc="w", pad=0.1))
-        for k, v in text_defaults.items():
-            kwargs.setdefault(k, v)
+        kw = {"ha": "center", "bbox": {"boxstyle": "square", "fc": "w", "pad": 0.1}}
+        kw.update(kwargs)
         texts = []
         for (x, y), label in zip(xy, za_labels_list):
             if np.all(~np.isnan([x, y])):
-                text_i = mtext.Text(x, y, label, **kwargs)
+                text_i = mtext.Text(x, y, label, **kw)
                 texts.append(text_i)
         return texts
 
@@ -702,14 +702,14 @@ class GeometricalKikuchiPatternSimulation:
         coords = self.zone_axes_coordinates(index=(), exclude_nan=False)
         zone_axes_list = []
 
-        for k, v in dict(ec="none", zorder=2).items():
-            kwargs.setdefault(k, v)
+        kw = {"ec": "none", "zorder": 2}
+        kw.update(kwargs)
 
         for i in range(self._zone_axes.vector.size):
             # TODO: Inefficient, squeeze before the loop if possible
             zone_axis = coords[..., i, :].squeeze()
             if not np.all(np.isnan(zone_axis)):
-                marker = point(x=zone_axis[..., 0], y=zone_axis[..., 1], **kwargs)
+                marker = point(x=zone_axis[..., 0], y=zone_axis[..., 1], **kw)
                 zone_axes_list.append(marker)
 
         return zone_axes_list
@@ -730,18 +730,18 @@ class GeometricalKikuchiPatternSimulation:
         """
         coords = self.zone_axes_coordinates(index=(), exclude_nan=False)
 
-        zone_axes = self._zone_axes.vector.coordinates.round(0).astype(np.int64)
+        zone_axes = self._zone_axes.vector.coordinates.round().astype(np.int64)
         array_str = np.array2string(zone_axes, threshold=zone_axes.size)
         texts = re.sub("[][ ]", "", array_str).split("\n")
 
-        for k, v in dict(
-            color="k",
-            zorder=3,
-            ha="center",
-            va="bottom",
-            bbox=dict(fc="w", ec="k", boxstyle="square", pad=0.2),
-        ).items():
-            kwargs.setdefault(k, v)
+        kw = {
+            "color": "k",
+            "zorder": 3,
+            "ha": "center",
+            "va": "bottom",
+            "bbox": {"fc": "w", "ec": "k", "boxstyle": "square", "pad": 0.2},
+        }
+        kw.update(kwargs)
 
         zone_axes_label_list = []
         is_finite = np.isfinite(coords)[..., 0]
@@ -756,7 +756,7 @@ class GeometricalKikuchiPatternSimulation:
                 # TODO: Inefficient, squeeze before the loop if possible
                 x = x.squeeze()
                 y = y.squeeze()
-                text_marker = text(x=x, y=y, text=texts[i], **kwargs)
+                text_marker = text(x=x, y=y, text=texts[i], **kw)
                 zone_axes_label_list.append(text_marker)
 
         return zone_axes_label_list

--- a/kikuchipy/simulations/tests/test_kikuchi_pattern_simulation.py
+++ b/kikuchipy/simulations/tests/test_kikuchi_pattern_simulation.py
@@ -52,7 +52,6 @@ def setup_reflectors():
 class TestGeometricalKikuchiPatternSimulation:
     """General features of the GeometricalKikuchiPatternSimulation
     class.
-
     """
 
     def setup_method(self):
@@ -147,7 +146,6 @@ class TestGeometricalKikuchiPatternSimulation:
 class TestAsCollections:
     """Getting lines, zone axes, zone axes labels and PC as Matplotlib
     collections.
-
     """
 
     def setup_method(self):
@@ -207,13 +205,14 @@ class TestAsCollections:
         coll = sim.as_collections(
             zone_axes=True,
             zone_axes_labels=True,
-            lines_kwargs=dict(linewidth=2),  # Default is 1
-            zone_axes_kwargs=dict(color="k"),  # Default is white
-            zone_axes_labels_kwargs=dict(fontsize=5),  # Default is 10
+            lines_kwargs={"linewidth": 2},  # Default is 1
+            zone_axes_kwargs={"fc": "r", "ec": "b"},
+            zone_axes_labels_kwargs={"fontsize": 5},  # Default is 10
         )
 
         assert coll[0].get_linewidth() == 2
-        assert np.allclose(coll[1].get_facecolor()[0][:3], 0)
+        assert np.allclose(coll[1].get_facecolor()[0][:3], [1, 0, 0])
+        assert np.allclose(coll[1].get_edgecolor()[0][:3], [0, 0, 1])
         assert coll[2][0].get_fontsize() == 5
 
     def test_coordinates(self):
@@ -244,7 +243,6 @@ class TestAsCollections:
 class TestAsMarkers:
     """Getting lines, zone axes, zone axes labels and PC as HyperSpy
     markers.
-
     """
 
     def setup_method(self):

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -24,11 +24,9 @@ build:
     - xvfb
 
 # Build doc in all formats (HTML, PDF and ePub)
-# TODO: Enable PDF build when issues like this
-#  (https://github.com/readthedocs/readthedocs.org/issues/10150) are addressed by RTD.
 formats:
   - htmlzip
-#  - pdf
+  - pdf
 
 # Python environment for building the docs
 python:

--- a/setup.py
+++ b/setup.py
@@ -72,11 +72,6 @@ extra_feature_requirements = {
         "pyebsdindex                    ~= 0.1",
         "pyvista",
     ],
-    # TODO: Remove this option in release 0.9
-    "viz": [
-        "matplotlib                     >= 3.5",
-        "pyvista",
-    ],
 }
 # fmt: on
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
* Remove deprecated `viz` PyPI selector
* Allow RTD to build PDF again (after they introduced intentional failure in previously passing LaTeX builds for a reason I didn't understand)
* Use `trusted publisher' option in publishing workflow
* Improve color control in keyword argument to `GeometricalKikuchiPatternSimulation.as_collections()`

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
