### PR TITLE
New patch release 0.8.7 fixing passing a PC array > 1D to HI PC optimization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,15 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+0.8.7 (2023-07-23)
+==================
+
+Fixed
+-----
+- Passing a 3-component PC array with more than one dimension to
+  ``EBSD.hough_indexing_optimize_pc()`` works.
+  (`#647 <https://github.com/pyxem/kikuchipy/pull/647>`_)
+
 0.8.6 (2023-05-29)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
-0.8.7 (2023-07-23)
+0.8.7 (2023-07-24)
 ==================
 
 Fixed

--- a/kikuchipy/release.py
+++ b/kikuchipy/release.py
@@ -37,4 +37,4 @@ maintainer_email = "hakon.w.anes@ntnu.no"
 name = "kikuchipy"
 platforms = ["Linux", "MacOS X", "Windows"]
 status = "Development"
-version = "0.8.6"
+version = "0.8.7"

--- a/kikuchipy/signals/ebsd.py
+++ b/kikuchipy/signals/ebsd.py
@@ -1773,7 +1773,7 @@ class EBSD(KikuchipySignal2D):
         pc0 = np.asarray(pc0)
         if pc0.size != 3:
             raise ValueError("`pc0` must be of size 3")
-        pc0 = list(pc0)
+        pc0 = list(pc0.squeeze())
 
         supported_methods = ["nelder-mead", "pso"]
         method = method.lower()

--- a/kikuchipy/signals/tests/test_ebsd_hough_indexing.py
+++ b/kikuchipy/signals/tests/test_ebsd_hough_indexing.py
@@ -228,15 +228,15 @@ class TestHoughIndexing:
         assert xmap2.dx == 3
 
     def test_optimize_pc(self):
-        # Batch
         det2 = self.signal.hough_indexing_optimize_pc(
             self.detector.pc_average, self.indexer
         )
         assert det2.navigation_shape == (1,)
         assert np.allclose(det2.pc_average, self.detector.pc_average, atol=1e-2)
-        det3 = self.signal.hough_indexing_optimize_pc(
-            self.detector.pc_average, self.indexer, batch=True
-        )
+
+        # Batch with PC array with more than one dimension
+        pc0 = np.atleast_2d(self.detector.pc_average)
+        det3 = self.signal.hough_indexing_optimize_pc(pc0, self.indexer, batch=True)
         assert det3.navigation_shape == (3, 3)
         assert np.allclose(det2.pc_average, det3.pc_average, atol=1e-2)
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
We cannot pass a 3-component projection center (PC) array with more than one dimension to `EBSD.hough_indexing_optimize_pc()`. This PR fixes this. Since it's a bug, I'll release the fix as a patch release 0.8.7 tomorrow Monday 24 July.

The previousy failing behavior is now tested.

The error raised is:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[10], line 1
----> 1 det_ref = s_in.hough_indexing_optimize_pc(pc0=det.pc, indexer=indexer)
      3 print(det.pc - det_ref.pc)

File ~/checkouts/readthedocs.org/user_builds/kikuchipy/envs/646/lib/python3.11/site-packages/kikuchipy/signals/ebsd.py:1803, in EBSD.hough_indexing_optimize_pc(self, pc0, indexer, batch, method)
   1800 if self._lazy:  # pragma: no cover
   1801     patterns = patterns.rechunk({0: "auto", 1: -1, 2: -1})
-> 1803 pc = _optimize_pc(
   1804     pc0=pc0, patterns=patterns, indexer=indexer, batch=batch, method=method
   1805 )
   1807 if batch:
   1808     pc = pc.reshape(nav_shape + (3,))

File ~/checkouts/readthedocs.org/user_builds/kikuchipy/envs/646/lib/python3.11/site-packages/kikuchipy/indexing/_hough_indexing.py:411, in _optimize_pc(pc0, patterns, indexer, batch, method)
    409 else:
    410     from pyebsdindex.pcopt import optimize as optimize_func
--> 411 return optimize_func(pats=patterns, indexer=indexer, PC0=pc0, batch=batch)

File ~/checkouts/readthedocs.org/user_builds/kikuchipy/envs/646/lib/python3.11/site-packages/pyebsdindex/pcopt.py:119, in optimize(pats, indexer, PC0, batch)
    116     PC0 = PCtemp
    118 if not batch:
--> 119     PCopt = opt.minimize(
    120         _optfunction,
    121         PC0,
    122         args=(indexer, banddat),
    123         method="Nelder-Mead",
    124         options={"fatol": 0.00001}
    125     )
    126     PCoutRet = PCopt['x']
    127 else:

File ~/checkouts/readthedocs.org/user_builds/kikuchipy/envs/646/lib/python3.11/site-packages/scipy/optimize/_minimize.py:533, in minimize(fun, x0, args, method, jac, hess, hessp, bounds, constraints, tol, callback, options)
    530 x0 = np.atleast_1d(np.asarray(x0))
    532 if x0.ndim != 1:
--> 533     raise ValueError("'x0' must only have one dimension.")
    535 if x0.dtype.kind in np.typecodes["AllInteger"]:
    536     x0 = np.asarray(x0, dtype=float)

ValueError: 'x0' must only have one dimension.
```

It is seen in the docs built from #646: https://kikuchipy--646.org.readthedocs.build/en/646/tutorials/pc_calibration_moving_screen_technique.html.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
