### PR TITLE
Temporarily pin HyperSpy to version < 2.0 for kikuchipy v0.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,9 @@ Changed
 - Remove dependency on panel for documentation, and with that interactive 3D
   visualization of master patterns in the documentation (the hope is to reintroduce it
   with trame at some point). (`#652 <https://github.com/pyxem/kikuchipy/pull/652>`_)
+- Restrict HyperSpy to below the forthcoming version 2. The plan is to remove this
+  restriction once kikuchipy is compatible with this version.
+  (`#657 <https://github.com/pyxem/kikuchipy/pull/657>`_)
 
 Deprecated
 ----------

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
         "dask[array]        >= 2021.8.1",
         "diffpy.structure   >= 3",
         "diffsims           >= 0.5.1",
-        "hyperspy           >= 1.7.3",
+        "hyperspy           >= 1.7.3, < 2",
         "h5py               >= 2.10",
         "imageio",
         "matplotlib         >= 3.5",


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
We pin HyperSpy to version < 2. This is a temporary solution for the imminent kikuchipy v0.9.

See #650 for the progress on support for HyperSpy 2.0.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
