### PR TITLE
Compatibility with PyEBSDIndex 0.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,7 @@ jobs:
         run: |
           pip install -e .'[all]'
           pip install pyopencl
+          pip install git+https://github.com/drowenhorst-nrl/PyEBSDIndex.git@NLPARDebug
 
       - name: Install optional dependencies on macOS (without nlopt)
         if: ${{ contains(matrix.LABEL, 'minimum_requirement') == false && matrix.os == 'macos-latest' }}
@@ -105,6 +106,7 @@ jobs:
         run: |
           pip install -e .
           pip install 'pyebsdindex[gpu]' pyvista
+          pip install git+https://github.com/drowenhorst-nrl/PyEBSDIndex.git@NLPARDebug
 
       - name: Display Python, pip and package versions
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,6 @@ jobs:
         run: |
           pip install -e .'[all]'
           pip install pyopencl
-          pip install git+https://github.com/drowenhorst-nrl/PyEBSDIndex.git@NLPARDebug
 
       - name: Install optional dependencies on macOS (without nlopt)
         if: ${{ contains(matrix.LABEL, 'minimum_requirement') == false && matrix.os == 'macos-latest' }}
@@ -106,7 +105,6 @@ jobs:
         run: |
           pip install -e .
           pip install 'pyebsdindex[gpu]' pyvista
-          pip install git+https://github.com/drowenhorst-nrl/PyEBSDIndex.git@NLPARDebug
 
       - name: Display Python, pip and package versions
         run: |

--- a/kikuchipy/signals/tests/test_ebsd_hough_indexing.py
+++ b/kikuchipy/signals/tests/test_ebsd_hough_indexing.py
@@ -301,7 +301,7 @@ class TestPCOptimization:
 
         det = self.signal.hough_indexing_optimize_pc(det0.pc_average, self.indexer)
         assert det.navigation_shape == (1,)
-        assert np.allclose(det.pc_average, det0.pc_average, atol=1e-2)
+        assert np.allclose(det.pc_average, det0.pc_average, atol=0.05)
 
         # Batch with PC array with more than one dimension
         det2 = self.signal.hough_indexing_optimize_pc(

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ extra_feature_requirements = {
         # We can change from ~= to >= once we consider PyEBSDIndex
         # stable. This is typically when a minor release with no or
         # only minor breaking changes is made available.
-        "pyebsdindex                    ~= 0.2",
+        "pyebsdindex                    >= 0.2",
         "pyvista",
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,6 @@ extra_feature_requirements = {
     ],
     "all": [
         "nlopt",
-        # We ask for a compatible release of PyEBSDIndex as we
-        # anticipate breaking changes in coming releases. We do so
-        # because there were breaking changes between 0.1.2 and 0.2.0.
-        # We can change from ~= to >= once we consider PyEBSDIndex
-        # stable. This is typically when a minor release with no or
-        # only minor breaking changes is made available.
         "pyebsdindex                    >= 0.2",
         "pyvista",
     ],


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->

Testing whether https://github.com/USNavalResearchLaboratory/PyEBSDIndex/pull/60 fixes #675.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)
- [x] Remove install of specific PyEBSDIndex branch in CI after 0.3.2 is released

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `release.py`, `.zenodo.json` and
      `.all-contributorsrc` with the table regenerated.
