### PR TITLE
Remove Python 3.8 and 3.9 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         python-version: ['3.11', '3.12']
         include:
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.10
             DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy==1.7.3 matplotlib==3.5 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.2.0 scikit-image==0.21.0
             LABEL: -oldest
           - os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,11 @@ jobs:
         python-version: ['3.11', '3.12']
         include:
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy==1.7.3 matplotlib==3.5 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.2.0 scikit-image==0.21.0
             LABEL: -oldest
           - os: ubuntu-latest
-            python-version: 3.12
+            python-version: '3.12'
             LABEL: -minimum_requirement
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Added
 
 Changed
 -------
+- Minimum Python version is now 3.10.
+  (`#? <https://github.com/pyxem/kikuchipy/pull/?>`_)
 
 Removed
 -------

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ library.
 .. |tests_status| image:: https://github.com/pyxem/kikuchipy/actions/workflows/tests.yml/badge.svg
    :target: https://github.com/pyxem/kikuchipy/actions/workflows/tests.yml
 
-.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.10+-blue.svg
    :target: https://www.python.org/downloads/
 
 .. |Coveralls| image:: https://coveralls.io/repos/github/pyxem/kikuchipy/badge.svg?branch=develop

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ from numbers import Number
 import os
 from pathlib import Path
 import tempfile
-from typing import Callable, Generator, List
+from typing import Callable, Generator
 
 import dask.array as da
 from diffpy.structure import Atom, Lattice, Structure
@@ -39,10 +39,11 @@ import pytest
 import skimage.color as skc
 
 import kikuchipy as kp
+from kikuchipy import constants
 from kikuchipy.data._data import marshall
 from kikuchipy.io.plugins._h5ebsd import _dict2hdf5group
 
-if kp.constants.installed["pyvista"]:
+if constants.installed["pyvista"]:
     import pyvista as pv
 
     pv.OFF_SCREEN = True
@@ -227,7 +228,7 @@ def nickel_phase(nickel_structure) -> Generator[Phase, None, None]:
 
 
 @pytest.fixture
-def pc1() -> Generator[List[float], None, None]:
+def pc1() -> Generator[list[float], None, None]:
     """One projection center (PC) in TSL convention."""
     yield [0.4210, 0.7794, 0.5049]
 

--- a/doc/dev/code_style.rst
+++ b/doc/dev/code_style.rst
@@ -34,7 +34,7 @@ Package imports should be structured into three blocks with blank lines between 
 We use type hints in the function definition without type duplication in the function
 docstring, for example::
 
-    def my_function(a: int, b: Optional[bool] = None) -> Tuple[float, np.ndarray]:
+    def my_function(a: int, b: bool | None = None) -> tuple[float, np.ndarray]:
         """This is a new function.
 
         Parameters

--- a/doc/dev/handling_deprecations.rst
+++ b/doc/dev/handling_deprecations.rst
@@ -24,7 +24,7 @@ The decorator should be placed right above the object signature to be deprecated
 Parameters can be deprecated as well::
 
     @deprecate_argument(name="n", since=0.8, removal=0.9, alternative="m")
-    def foo(self, n: Optional[int] = None, m: int: Optional[int] = None) -> int:
+    def foo(self, n: int | None = None, m: int: int | None = None) -> int:
         if m is None:
             m = n
         return m + 1

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 kikuchipy can be installed with `pip <https://pypi.org/project/kikuchipy/>`__,
 `conda <https://anaconda.org/conda-forge/kikuchipy>`__, the
-:ref:`hyperspy:hyperspy-bundle`, or from source, and supports Python >= 3.8.
+:ref:`hyperspy:hyperspy-bundle`, or from source, and supports Python >= 3.10.
 All alternatives are available on Windows, macOS and Linux.
 
 .. _install-with-pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,9 @@ description = "Processing, simulating, and indexing of electron backscatter diff
 license = {file = "LICENSE"}
 readme = {file = "README.rst", content-type = "text/x-rst"}
 dynamic = ["version"]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dependencies = [
     "lazy_loader",
     "matplotlib       >= 3.5",
     "numba            >= 0.57",
-    "numpy            >= 1.23.0",
+    # TODO: Remove pinning of NumPy <2 once HyperSpy 2.0 is supported
+    "numpy            >= 1.23.0, <2",
     "orix             >= 0.12.1",
     "pooch            >= 1.3.0",
     "pyyaml",

--- a/src/kikuchipy/_rotation/__init__.py
+++ b/src/kikuchipy/_rotation/__init__.py
@@ -70,7 +70,7 @@ def _rotation_from_rodrigues(rx: float, ry: float, rz: float) -> np.ndarray:
     d = s * rz / norm
     rot = np.array([a, b, c, d], dtype="float64")
 
-    if rot[0] < 0:  # pragma: no cover
+    if rot[0] < 0:
         rot = -rot
 
     return rot

--- a/src/kikuchipy/_util/_deprecated.py
+++ b/src/kikuchipy/_util/_deprecated.py
@@ -28,7 +28,7 @@ not for users.
 
 import functools
 import inspect
-from typing import Callable, Optional, Union
+from typing import Callable
 import warnings
 
 import numpy as np
@@ -47,11 +47,11 @@ class deprecated:
 
     def __init__(
         self,
-        since: Union[str, int, float],
-        alternative: Optional[str] = None,
+        since: str | int | float,
+        alternative: str | None = None,
         alternative_is_function: bool = True,
-        removal: Union[str, int, float, None] = None,
-    ):
+        removal: str | int | float | None = None,
+    ) -> None:
         """Visible deprecation warning.
 
         Parameters
@@ -71,7 +71,7 @@ class deprecated:
         self.alternative_is_function = alternative_is_function
         self.removal = removal
 
-    def __call__(self, func: Callable):
+    def __call__(self, func: Callable) -> None:
         # Wrap function to raise warning when called, and add warning to
         # docstring
         if self.alternative is not None:
@@ -91,7 +91,7 @@ class deprecated:
             msg = f"Attribute `{func.__name__}` is deprecated{rm_msg}.{alt_msg}"
 
         @functools.wraps(func)
-        def wrapped(*args, **kwargs):
+        def wrapped(*args, **kwargs) -> Callable:
             warnings.simplefilter(
                 action="always", category=np.VisibleDeprecationWarning, append=True
             )
@@ -126,13 +126,19 @@ class deprecated_argument:
     <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L115>`_.
     """
 
-    def __init__(self, name, since, removal, alternative=None):
+    def __init__(
+        self,
+        name: str,
+        since: str | float,
+        removal: str | float,
+        alternative: str | None = None,
+    ) -> None:
         self.name = name
         self.since = since
         self.removal = removal
         self.alternative = alternative
 
-    def __call__(self, func):
+    def __call__(self, func: Callable) -> Callable:
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             if self.name in kwargs.keys():

--- a/src/kikuchipy/_util/_transfer_axes.py
+++ b/src/kikuchipy/_util/_transfer_axes.py
@@ -15,11 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from hyperspy.axes import AxesManager
 
-def _transfer_navigation_axes_to_signal_axes(new_axes, old_axes):
+
+def _transfer_navigation_axes_to_signal_axes(
+    new_axes: AxesManager, old_axes: AxesManager
+) -> AxesManager:
     """Transfer navigation axis calibrations from an old signal to the
-    signal axes of a new signal produced from it by a generator. Used
-    from methods that generate a signal with a single value at each
+    signal axes of a new signal produced from it by a generator.
+
+    Used from methods that generate a signal with a single value at each
     navigation position.
 
     Adapted from the pyxem package.

--- a/src/kikuchipy/constants.py
+++ b/src/kikuchipy/constants.py
@@ -18,15 +18,14 @@
 """Constants and such useful across modules."""
 
 from importlib.metadata import version
-from typing import Dict, List
 
 # NB! Update project config file if this list is updated!
-optional_deps: List[str] = [
+optional_deps: list[str] = [
     "pyvista",
     "nlopt",
     "pyebsdindex",
 ]
-installed: Dict[str, bool] = {}
+installed: dict[str, bool] = {}
 for pkg in optional_deps:
     try:
         _ = version(pkg)

--- a/src/kikuchipy/detectors/calibration.py
+++ b/src/kikuchipy/detectors/calibration.py
@@ -18,7 +18,6 @@
 """Calibration of the EBSD projection/pattern center."""
 
 from itertools import combinations
-from typing import List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -77,13 +76,13 @@ class PCCalibrationMovingScreen:
         self,
         pattern_in: np.ndarray,
         pattern_out: np.ndarray,
-        points_in: Union[np.ndarray, List[Tuple[float]]],
-        points_out: Union[np.ndarray, List[Tuple[float]]],
+        points_in: np.ndarray | list[tuple[float]],
+        points_out: np.ndarray | list[tuple[float]],
         delta_z: float = 1.0,
-        px_size: Optional[float] = None,
+        px_size: float | None = None,
         binning: int = 1,
         convention: str = "tsl",
-    ):
+    ) -> None:
         """Create an instance storing the PC estimates, the average PC,
         and other parameters relevant for the estimation.
         """
@@ -98,7 +97,7 @@ class PCCalibrationMovingScreen:
         self.make_lines()
 
     @property
-    def shape(self) -> Tuple[int, int]:
+    def shape(self) -> tuple[int, int]:
         """Return the detector shape, (nrows, ncols)."""
         return self.patterns[0].shape
 
@@ -253,13 +252,13 @@ class PCCalibrationMovingScreen:
 
     def plot(
         self,
-        pattern_kwargs: dict = dict(cmap="gray"),
-        line_kwargs: dict = dict(linewidth=2, zorder=1),
-        scatter_kwargs: dict = dict(zorder=2),
-        pc_kwargs: dict = dict(marker="*", s=300, facecolor="gold", edgecolor="k"),
+        pattern_kwargs: dict | None = None,
+        line_kwargs: dict | None = None,
+        scatter_kwargs: dict | None = None,
+        pc_kwargs: dict | None = None,
         return_figure: bool = False,
         **kwargs: dict,
-    ) -> Union[None, Tuple[plt.Figure, List[plt.Axes]]]:
+    ) -> None | tuple[plt.Figure, list[plt.Axes]]:
         """A convenience method of three images, the first two with the
         patterns with points and lines annotated, and the third with the
         calibration results.
@@ -289,6 +288,15 @@ class PCCalibrationMovingScreen:
         fig
             Figure, returned if ``return_figure=True``.
         """
+        if pattern_kwargs is None:
+            pattern_kwargs = {"cmap": "gray"}
+        if line_kwargs is None:
+            line_kwargs = {"linewidth": 2, "zorder": 1}
+        if scatter_kwargs is None:
+            scatter_kwargs = {"zorder": 2}
+        if pc_kwargs is None:
+            pc_kwargs = {"marker": "*", "s": 300, "facecolor": "gold", "edgecolor": "k"}
+
         pat1, pat2 = self.patterns
         points1, points2 = self.points
         px = self.pxy[0]
@@ -335,7 +343,7 @@ class PCCalibrationMovingScreen:
         if return_figure:
             return fig
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = self.__class__.__name__
         points = np.array_str(self.points, precision=0)
         pcx, pcy, pcz = self.pc
@@ -346,9 +354,8 @@ class PCCalibrationMovingScreen:
 
 
 def _get_intersection_from_lines(
-    line1: Union[List[int], np.ndarray],
-    line2: Union[List[int], np.ndarray],
-) -> Tuple[float, float]:
+    line1: list[int] | np.ndarray, line2: list[int] | np.ndarray
+) -> tuple[float, float]:
     """line: [x1, y1, x2, y2]"""
     x1, y1, x2, y2 = line1
     x3, y3, x4, y4 = line2

--- a/src/kikuchipy/detectors/ebsd_detector.py
+++ b/src/kikuchipy/detectors/ebsd_detector.py
@@ -22,7 +22,7 @@ from datetime import datetime
 import logging
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 from diffsims.crystallography import ReciprocalLatticeVector
 from matplotlib.figure import Figure
@@ -495,7 +495,7 @@ class EBSDDetector:
         return np.atleast_2d(np.sqrt(np.max(corners, axis=-1)))
 
     @classmethod
-    def load(cls, fname: Path | str) -> Self:
+    def load(cls, fname: Path | str) -> EBSDDetector:
         """Return an EBSD detector loaded from a text file saved with
         :meth:`save`.
 
@@ -557,7 +557,7 @@ class EBSDDetector:
 
         return cls(pc=pc, **detector_kw)
 
-    def crop(self, extent: tuple[int, int, int, int] | list[int]) -> Self:
+    def crop(self, extent: tuple[int, int, int, int] | list[int]) -> EBSDDetector:
         """Return a new detector with its :attr:`shape` cropped and
         :attr:`pc` values updated accordingly.
 
@@ -622,7 +622,7 @@ class EBSDDetector:
             azimuthal=self.azimuthal,
         )
 
-    def deepcopy(self) -> Self:
+    def deepcopy(self) -> EBSDDetector:
         """Return a deep copy using :func:`copy.deepcopy`.
 
         Returns
@@ -852,7 +852,7 @@ class EBSDDetector:
         px_size: float | None = None,
         binning: int | None = None,
         is_outlier: tuple | list | np.ndarray | None = None,
-    ) -> Self:
+    ) -> EBSDDetector:
         r"""Return a new detector with projection centers (PCs) in a 2D
         map extrapolated from an average PC.
 
@@ -959,7 +959,7 @@ class EBSDDetector:
         plot: bool = True,
         return_figure: bool = False,
         figure_kwargs: dict | None = None,
-    ) -> Self | tuple[EBSDDetector, Figure]:
+    ) -> EBSDDetector | tuple[EBSDDetector, Figure]:
         """Return a new detector with interpolated projection centers
         (PCs) for all points in a map by fitting a plane to :attr:`pc`
         :cite:`winkelmann2020refined`.

--- a/src/kikuchipy/detectors/ebsd_detector.py
+++ b/src/kikuchipy/detectors/ebsd_detector.py
@@ -22,8 +22,9 @@ from datetime import datetime
 import logging
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Self
 
+from diffsims.crystallography import ReciprocalLatticeVector
 from matplotlib.figure import Figure
 from matplotlib.markers import MarkerStyle
 import matplotlib.patches as mpatches
@@ -42,18 +43,22 @@ from kikuchipy.indexing._hough_indexing import _get_indexer_from_detector
 
 if TYPE_CHECKING:  # pragma: no cover
     from diffsims.crystallography import ReciprocalLatticeVector
-    from pyebsdindex import EBSDIndexer
+
+    from kikuchipy.constants import installed
+
+    if installed["pyebsdindex"]:
+        from pyebsdindex.ebsd_index import EBSDIndexer
 
 
 _logger = logging.getLogger(__name__)
 
-CONVENTION_ALIAS = {
+CONVENTION_ALIAS: dict[str, list[str]] = {
     "bruker": ["bruker"],
     "tsl": ["edax", "tsl", "amatek"],
     "oxford": ["oxford", "aztec"],
     "emsoft": ["emsoft", "emsoft4", "emsoft5"],
 }
-CONVENTION_ALIAS_ALL = list(np.concatenate(list(CONVENTION_ALIAS.values())))
+CONVENTION_ALIAS_ALL: list = list(np.concatenate(list(CONVENTION_ALIAS.values())))
 
 
 class EBSDDetector:
@@ -194,14 +199,14 @@ class EBSDDetector:
 
     def __init__(
         self,
-        shape: Tuple[int, int] = (1, 1),
-        px_size: float = 1,
+        shape: tuple[int, int] = (1, 1),
+        px_size: float = 1.0,
         binning: int = 1,
-        tilt: float = 0,
-        azimuthal: float = 0,
-        sample_tilt: float = 70,
-        pc: Union[np.ndarray, list, tuple] = (0.5, 0.5, 0.5),
-        convention: Optional[str] = None,
+        tilt: float = 0.0,
+        azimuthal: float = 0.0,
+        sample_tilt: float = 70.0,
+        pc: np.ndarray | list | tuple = (0.5, 0.5, 0.5),
+        convention: str | None = None,
     ) -> None:
         """Create an EBSD detector with a shape, pixel size, binning
         factor, sample and detector tilt about the detector X axis,
@@ -210,7 +215,7 @@ class EBSDDetector:
         """
         self.shape = shape
         self.px_size = float(px_size)
-        self.binning = float(binning)
+        self.binning: float = float(binning)
         self.tilt = float(tilt)
         self.azimuthal = float(azimuthal)
         self.sample_tilt = float(sample_tilt)
@@ -238,7 +243,7 @@ class EBSDDetector:
         )
 
     @property
-    def specimen_scintillator_distance(self) -> float:
+    def specimen_scintillator_distance(self) -> np.ndarray:
         """Return the specimen to scintillator distance, known in EMsoft
         as :math:`L`.
         """
@@ -275,7 +280,7 @@ class EBSDDetector:
         return self.ncols / self.nrows
 
     @property
-    def unbinned_shape(self) -> Tuple[int, int]:
+    def unbinned_shape(self) -> tuple[int, int]:
         """Return the unbinned detector shape in pixels."""
         return tuple(np.array(self.shape) * self.binning)
 
@@ -298,7 +303,7 @@ class EBSDDetector:
         return self._pc
 
     @pc.setter
-    def pc(self, value: Union[np.ndarray, List, Tuple]):
+    def pc(self, value: np.ndarray | list | tuple) -> None:
         """Set all projection center coordinates, assuming Bruker's
         convention.
         """
@@ -325,7 +330,7 @@ class EBSDDetector:
         return self.pc[..., 0]
 
     @pcx.setter
-    def pcx(self, value: Union[np.ndarray, list, tuple, float]):
+    def pcx(self, value: np.ndarray | list | tuple | float):
         """Set the x projection center coordinates."""
         self._pc[..., 0] = np.atleast_2d(value).astype(float)
 
@@ -343,7 +348,7 @@ class EBSDDetector:
         return self.pc[..., 1]
 
     @pcy.setter
-    def pcy(self, value: Union[np.ndarray, list, tuple, float]):
+    def pcy(self, value: np.ndarray | list | tuple | float):
         """Set y projection center coordinates."""
         self._pc[..., 1] = np.atleast_2d(value).astype(float)
 
@@ -361,7 +366,7 @@ class EBSDDetector:
         return self.pc[..., 2]
 
     @pcz.setter
-    def pcz(self, value: Union[np.ndarray, list, tuple, float]):
+    def pcz(self, value: np.ndarray | list | tuple | float):
         """Set z projection center coordinates."""
         self._pc[..., 2] = np.atleast_2d(value).astype(float)
 
@@ -417,12 +422,12 @@ class EBSDDetector:
         return np.array([0, self.ncols - 1, 0, self.nrows - 1])
 
     @property
-    def x_min(self) -> Union[np.ndarray, float]:
+    def x_min(self) -> np.ndarray | float:
         """Return the left bound of detector in gnomonic coordinates."""
         return -self.aspect_ratio * (self.pcx / self.pcz)
 
     @property
-    def x_max(self) -> Union[np.ndarray, float]:
+    def x_max(self) -> np.ndarray | float:
         """Return the right bound of detector in gnomonic coordinates."""
         return self.aspect_ratio * (1 - self.pcx) / self.pcz
 
@@ -432,12 +437,12 @@ class EBSDDetector:
         return np.dstack((self.x_min, self.x_max)).reshape(self.navigation_shape + (2,))
 
     @property
-    def y_min(self) -> Union[np.ndarray, float]:
+    def y_min(self) -> np.ndarray | float:
         """Return the top bound of detector in gnomonic coordinates."""
         return -(1 - self.pcy) / self.pcz
 
     @property
-    def y_max(self) -> Union[np.ndarray, float]:
+    def y_max(self) -> np.ndarray | float:
         """Return the bottom bound of detector in gnomonic coordinates."""
         return self.pcy / self.pcz
 
@@ -490,7 +495,7 @@ class EBSDDetector:
         return np.atleast_2d(np.sqrt(np.max(corners, axis=-1)))
 
     @classmethod
-    def load(cls, fname: Union[Path, str]) -> EBSDDetector:
+    def load(cls, fname: Path | str) -> Self:
         """Return an EBSD detector loaded from a text file saved with
         :meth:`save`.
 
@@ -517,7 +522,7 @@ class EBSDDetector:
             "navigation_shape",
         ]
 
-        detector_kw = dict(zip(keys, [None] * len(keys)))
+        detector_kw: dict = dict(zip(keys, [None] * len(keys)))
         with open(fname, mode="r") as f:
             header = []
             for line in f.readlines():
@@ -552,7 +557,7 @@ class EBSDDetector:
 
         return cls(pc=pc, **detector_kw)
 
-    def crop(self, extent: Union[Tuple[int, int, int, int], List[int]]) -> EBSDDetector:
+    def crop(self, extent: tuple[int, int, int, int] | list[int]) -> Self:
         """Return a new detector with its :attr:`shape` cropped and
         :attr:`pc` values updated accordingly.
 
@@ -607,17 +612,17 @@ class EBSDDetector:
         pcy_new = (self.pcy * ny - top) / ny_new
         pcz_new = self.pcz * ny / ny_new
 
-        return EBSDDetector(
+        return self.__class__(
             shape=(ny_new, nx_new),
             pc=np.dstack((pcx_new, pcy_new, pcz_new)),
             tilt=self.tilt,
             sample_tilt=self.sample_tilt,
-            binning=self.binning,
+            binning=int(self.binning),
             px_size=self.px_size,
             azimuthal=self.azimuthal,
         )
 
-    def deepcopy(self) -> EBSDDetector:
+    def deepcopy(self) -> Self:
         """Return a deep copy using :func:`copy.deepcopy`.
 
         Returns
@@ -634,13 +639,13 @@ class EBSDDetector:
         degrees: bool = False,
         return_figure: bool = False,
         return_outliers: bool = False,
-        figure_kwargs: Optional[dict] = None,
-    ) -> Union[
-        float,
-        Tuple[float, np.ndarray],
-        Tuple[float, plt.Figure],
-        Tuple[float, np.ndarray, plt.Figure],
-    ]:
+        figure_kwargs: dict | None = None,
+    ) -> (
+        float
+        | tuple[float, np.ndarray]
+        | tuple[float, Figure]
+        | tuple[float, np.ndarray, Figure]
+    ):
         r"""Estimate the tilt about the detector :math:`X_d` axis.
 
         This tilt is assumed to bring the sample plane normal into
@@ -772,8 +777,8 @@ class EBSDDetector:
     def estimate_xtilt_ztilt(
         self,
         degrees: bool = False,
-        is_outlier: Optional[Union[list, tuple, np.ndarray]] = None,
-    ) -> Union[float, Tuple[float, float]]:
+        is_outlier: list | tuple | np.ndarray | None = None,
+    ) -> float | tuple[float, float]:
         r"""Estimate the tilts about the detector :math:`X_d` and
         :math:`Z_d` axes.
 
@@ -840,14 +845,14 @@ class EBSDDetector:
 
     def extrapolate_pc(
         self,
-        pc_indices: Union[tuple, list, np.ndarray],
+        pc_indices: tuple | list | np.ndarray,
         navigation_shape: tuple,
         step_sizes: tuple,
-        shape: Optional[tuple] = None,
-        px_size: float = None,
-        binning: int = None,
-        is_outlier: Optional[Union[tuple, list, np.ndarray]] = None,
-    ):
+        shape: tuple | None = None,
+        px_size: float | None = None,
+        binning: int | None = None,
+        is_outlier: tuple | list | np.ndarray | None = None,
+    ) -> Self:
         r"""Return a new detector with projection centers (PCs) in a 2D
         map extrapolated from an average PC.
 
@@ -947,14 +952,14 @@ class EBSDDetector:
 
     def fit_pc(
         self,
-        pc_indices: Union[list, tuple, np.ndarray],
-        map_indices: Union[list, tuple, np.ndarray],
+        pc_indices: list | tuple | np.ndarray,
+        map_indices: list | tuple | np.ndarray,
         transformation: str = "projective",
-        is_outlier: Optional[np.ndarray] = None,
+        is_outlier: np.ndarray | None = None,
         plot: bool = True,
         return_figure: bool = False,
-        figure_kwargs: Optional[dict] = None,
-    ) -> Union[EBSDDetector, Tuple[EBSDDetector, plt.Figure]]:
+        figure_kwargs: dict | None = None,
+    ) -> Self | tuple[EBSDDetector, Figure]:
         """Return a new detector with interpolated projection centers
         (PCs) for all points in a map by fitting a plane to :attr:`pc`
         :cite:`winkelmann2020refined`.
@@ -1121,9 +1126,9 @@ class EBSDDetector:
     def get_indexer(
         self,
         phase_list: PhaseList,
-        reflectors: Optional[
-            List[Union["ReciprocalLatticeVector", np.ndarray, list, tuple, None]]
-        ] = None,
+        reflectors: (
+            list[ReciprocalLatticeVector | np.ndarray | list | tuple | None] | None
+        ) = None,
         **kwargs,
     ) -> "EBSDIndexer":
         r"""Return a PyEBSDIndex EBSD indexer.
@@ -1291,15 +1296,15 @@ class EBSDDetector:
         self,
         coordinates: str = "detector",
         show_pc: bool = True,
-        pc_kwargs: Optional[dict] = None,
-        pattern: Optional[np.ndarray] = None,
-        pattern_kwargs: Optional[dict] = None,
+        pc_kwargs: dict | None = None,
+        pattern: np.ndarray | None = None,
+        pattern_kwargs: dict | None = None,
         draw_gnomonic_circles: bool = False,
-        gnomonic_angles: Union[None, list, np.ndarray] = None,
-        gnomonic_circles_kwargs: Optional[dict] = None,
-        zoom: float = 1,
+        gnomonic_angles: np.ndarray | list | None = None,
+        gnomonic_circles_kwargs: dict | None = None,
+        zoom: float = 1.0,
         return_figure: bool = False,
-    ) -> Union[None, Figure]:
+    ) -> None | Figure:
         """Plot the detector screen viewed from the detector towards the
         sample.
 
@@ -1460,9 +1465,9 @@ class EBSDDetector:
         return_figure: bool = False,
         orientation: str = "horizontal",
         annotate: bool = False,
-        figure_kwargs: Optional[dict] = None,
+        figure_kwargs: dict | None = None,
         **kwargs,
-    ) -> Union[None, plt.Figure]:
+    ) -> None | Figure:
         """Plot all projection centers (PCs).
 
         Parameters
@@ -1618,7 +1623,7 @@ class EBSDDetector:
         if return_figure:
             return fig
 
-    def save(self, filename: str, convention: str = "Bruker", **kwargs) -> None:
+    def save(self, filename: str | Path, convention: str = "Bruker", **kwargs) -> None:
         """Save detector in a text file with projection centers (PCs) in
         the given convention.
 
@@ -1781,7 +1786,7 @@ class EBSDDetector:
 
 def _fit_hyperplane(
     pc_centered: np.ndarray,
-) -> Tuple[float, float, Rotation, Rotation, np.ndarray]:
+) -> tuple[float, float, Rotation, Rotation, np.ndarray]:
     # Hyperplane fit
     pc_trim_mean = scs.trim_mean(pc_centered, proportiontocut=0.1)
     pc_trim_centered = pc_centered - pc_trim_mean[np.newaxis, :]
@@ -1822,7 +1827,7 @@ def _fit_pc_projective(
     pc_centered_flat: np.ndarray,
     pc_indices_flat: np.ndarray,
     map_indices_flat: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     *_, rot_xtilt, rot_ztilt, pc_trim_mean = _fit_hyperplane(pc_centered_flat)
 
     v_pc_centered = Vector3d(pc_centered_flat)
@@ -1854,7 +1859,7 @@ def _fit_pc_projective(
 
 def _fit_pc_affine(
     pc_flat: np.ndarray, pc_indices_flat: np.ndarray, map_indices_flat: np.ndarray
-) -> Tuple[np.array, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     # Solve the least squares problem X * A = Y
     # Source: https://stackoverflow.com/a/20555267/3228100
     matrix, res, *_ = np.linalg.lstsq(pc_indices_flat, pc_flat, rcond=None)
@@ -1873,7 +1878,7 @@ def _plot_pc_fit(
     fit_slope: float,
     figure_kwargs: dict,
     return_figure: bool = False,
-) -> Union[None, plt.Figure]:
+) -> None | Figure:
     pcx, pcy, pcz = pc.T
     pcx_fit_2d, pcy_fit_2d, pcz_fit_2d = pc_fit.T
     pcx_fit = pcx_fit_2d.ravel()

--- a/src/kikuchipy/draw/_navigators.py
+++ b/src/kikuchipy/draw/_navigators.py
@@ -19,15 +19,13 @@
 navigators with :meth:`~hyperspy.signals.Signal2D.plot`.
 """
 
-from typing import Union
-
 import hyperspy.api as hs
 import numpy as np
 from skimage.exposure import rescale_intensity
 
 
 def get_rgb_navigator(
-    image: np.ndarray, dtype: Union[str, np.dtype, type] = "uint16"
+    image: np.ndarray, dtype: str | np.dtype | type = "uint16"
 ) -> hs.signals.Signal2D:
     """Create an RGB navigator signal which is suitable to pass to
     :meth:`~hyperspy._signals.signal2d.Signal2D.plot` as the

--- a/src/kikuchipy/draw/_plot_pattern_positions_in_map.py
+++ b/src/kikuchipy/draw/_plot_pattern_positions_in_map.py
@@ -22,8 +22,8 @@ calibration patterns. These are acquired manually within a region of
 interest within a larger area.
 """
 
-from typing import Optional
-
+import matplotlib.axes as maxes
+import matplotlib.figure as mfigure
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,13 +33,13 @@ def plot_pattern_positions_in_map(
     rc: np.ndarray,
     roi_shape: tuple,
     roi_origin: tuple = (0, 0),
-    area_shape: Optional[tuple] = None,
-    roi_image: Optional[np.ndarray] = None,
-    area_image: Optional[np.ndarray] = None,
-    axis: Optional[plt.Axes] = None,
+    area_shape: tuple | None = None,
+    roi_image: np.ndarray | None = None,
+    area_image: np.ndarray | None = None,
+    axis: maxes.Axes | None = None,
     return_figure: bool = False,
-    color: Optional[str] = "k",
-) -> Optional[plt.Figure]:
+    color: str | None = "k",
+) -> mfigure.Figure | mfigure.SubFigure | None:
     """Plot pattern positions in a 2D map within a region of interest
     (ROI), the ROI potentially within a larger area.
 
@@ -85,7 +85,7 @@ def plot_pattern_positions_in_map(
     roi_rect_kw = dict(fc="none", lw=2, clip_on=False, zorder=5)
     roi_ny, roi_nx = roi_shape
 
-    if isinstance(axis, plt.Axes):
+    if isinstance(axis, maxes.Axes):
         new_axis = False
         ax = axis
         fig = ax.figure

--- a/src/kikuchipy/draw/colors.py
+++ b/src/kikuchipy/draw/colors.py
@@ -30,7 +30,7 @@ PURPLE = (0.5, 0, 0.5)
 DARK_GREEN = (0, 0.5, 0)
 DARKER_GREEN = (0, 0.5, 0.5)
 DARK_BLUE = (0, 0, 0.5)
-TSL_COLORS = [
+TSL_COLORS: list[tuple] = [
     RED,
     YELLOW,
     GREEN,

--- a/src/kikuchipy/draw/markers.py
+++ b/src/kikuchipy/draw/markers.py
@@ -17,13 +17,11 @@
 
 """Creation of lists of HyperSpy markers."""
 
-from typing import Union
-
 from hyperspy.utils.markers import line_segment, point, text
 import numpy as np
 
 
-def get_line_segment_list(lines: Union[list, np.ndarray], **kwargs) -> list:
+def get_line_segment_list(lines: np.ndarray | list, **kwargs) -> list:
     """Return a list of line segment markers.
 
     Parameters
@@ -35,7 +33,7 @@ def get_line_segment_list(lines: Union[list, np.ndarray], **kwargs) -> list:
 
     Returns
     -------
-    marker_list : list
+    marker_list
         List of
         :class:`hyperspy.drawing._markers.line_segment.LineSegment`.
     """
@@ -54,7 +52,7 @@ def get_line_segment_list(lines: Union[list, np.ndarray], **kwargs) -> list:
     return marker_list
 
 
-def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
+def get_point_list(points: np.ndarray | list, **kwargs) -> list:
     """Return a list of point markers.
 
     Parameters
@@ -66,7 +64,7 @@ def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
 
     Returns
     -------
-    marker_list : list
+    marker_list
         List of :class:`hyperspy.drawing._markers.point.Point`.
     """
     points = np.asarray(points)
@@ -83,7 +81,7 @@ def get_point_list(points: Union[list, np.ndarray], **kwargs) -> list:
 
 
 def get_text_list(
-    texts: Union[list, np.ndarray], coordinates: Union[np.ndarray, list], **kwargs
+    texts: np.ndarray | list, coordinates: np.ndarray | list, **kwargs
 ) -> list:
     """Return a list of text markers.
 
@@ -98,7 +96,7 @@ def get_text_list(
 
     Returns
     -------
-    marker_list : list
+    marker_list
         List of :class:`hyperspy.drawing._markers.text.Text`.
     """
     coordinates = np.asarray(coordinates)

--- a/src/kikuchipy/filters/fft_barnes.py
+++ b/src/kikuchipy/filters/fft_barnes.py
@@ -19,8 +19,6 @@
 via FFT written by Connelly Barnes (public domain, 2007).
 """
 
-from typing import List, Tuple, Union
-
 import numba as nb
 import numpy as np
 from scipy.fft import irfft2, next_fast_len, rfft2
@@ -29,9 +27,9 @@ from kikuchipy.filters.window import Window
 
 
 def _fft_filter_setup(
-    image_shape: Tuple[int, int],
-    window: Union[np.ndarray, Window],
-) -> Tuple[Tuple[int, int], np.ndarray, Tuple[int, int], Tuple[int, int]]:
+    image_shape: tuple[int, int],
+    window: np.ndarray | Window,
+) -> tuple[tuple[int, int], np.ndarray, tuple[int, int], tuple[int, int]]:
     window_shape = window.shape
 
     # Optimal FFT shape
@@ -53,10 +51,7 @@ def _fft_filter_setup(
     return fft_shape, transfer_function, offset_before, offset_after
 
 
-def fft_filter(
-    image: np.ndarray,
-    window: Union[np.ndarray, Window],
-) -> np.ndarray:
+def fft_filter(image: np.ndarray, window: np.ndarray | Window) -> np.ndarray:
     """Filter a 2D image in the frequency domain with a window defined
     in the spatial domain.
 
@@ -100,8 +95,8 @@ def fft_filter(
 
 
 def _pad_window(
-    window: Union[np.ndarray, Window],
-    fft_shape: Union[Tuple[int, ...], List[int], np.ndarray],
+    window: np.ndarray | Window,
+    fft_shape: tuple[int, ...] | list[int] | np.ndarray,
 ) -> np.ndarray:
     wy, wx = window.shape
     window_pad = np.zeros(fft_shape, dtype=np.float32)
@@ -109,17 +104,13 @@ def _pad_window(
     return window_pad
 
 
-def _offset_before_fft(
-    window_shape: Union[Tuple[int, int], np.ndarray]
-) -> Tuple[int, int]:
+def _offset_before_fft(window_shape: tuple[int, int] | np.ndarray) -> tuple[int, int]:
     wy, wx = window_shape
     offset = (wy - ((wy - 1) // 2) - 1, wx - ((wx - 1) // 2) - 1)
     return offset
 
 
-def _offset_after_ifft(
-    window_shape: Union[Tuple[int, int], np.ndarray]
-) -> Tuple[int, int]:
+def _offset_after_ifft(window_shape: tuple[int, int] | np.ndarray) -> tuple[int, int]:
     wy, wx = window_shape
     offset = ((wy - 1) // 2, (wx - 1) // 2)
     return offset
@@ -128,9 +119,9 @@ def _offset_after_ifft(
 @nb.njit(cache=True, fastmath=True, nogil=True)
 def _pad_image(
     image: np.ndarray,
-    fft_shape: Tuple[int, ...],
-    window_shape: Tuple[int, int],
-    offset_before_fft: Tuple[int, int],
+    fft_shape: tuple[int, ...],
+    window_shape: tuple[int, int],
+    offset_before_fft: tuple[int, int],
 ) -> np.ndarray:
     iy, ix = image.shape
     wy, wx = window_shape
@@ -164,10 +155,10 @@ def _pad_image(
 def _fft_filter(
     image: np.ndarray,
     transfer_function: np.ndarray,
-    fft_shape: Tuple[int, int],
-    window_shape: Tuple[int, int],
-    offset_before_fft: Tuple[int, int],
-    offset_after_ifft: Tuple[int, int],
+    fft_shape: tuple[int, int],
+    window_shape: tuple[int, int],
+    offset_before_fft: tuple[int, int],
+    offset_after_ifft: tuple[int, int],
 ) -> np.ndarray:
     # Create new image array to pad with the image in the top left
     # corner

--- a/src/kikuchipy/filters/window.py
+++ b/src/kikuchipy/filters/window.py
@@ -15,8 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from copy import copy
-from typing import Self, Sequence
+from typing import Sequence
 
 from dask.array import Array
 import matplotlib.figure as mfigure
@@ -117,7 +119,7 @@ class Window(np.ndarray):
         window: str | np.ndarray | Array | None = None,
         shape: Sequence[int] | None = None,
         **kwargs,
-    ) -> Self:
+    ) -> Window:
         if window is None:
             window = "circular"
 
@@ -197,7 +199,7 @@ class Window(np.ndarray):
         self._name = getattr(obj, "_name", None)
         self._circular = getattr(obj, "_circular", False)
 
-    def __array_wrap__(self, obj: Self) -> Self | np.ndarray:
+    def __array_wrap__(self, obj: Self) -> Window | np.ndarray:
         if obj.shape == ():
             return obj[()]
         else:

--- a/src/kikuchipy/filters/window.py
+++ b/src/kikuchipy/filters/window.py
@@ -16,10 +16,10 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from copy import copy
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Self, Sequence
 
 from dask.array import Array
-from matplotlib.figure import Figure
+import matplotlib.figure as mfigure
 from matplotlib.pyplot import subplots
 from numba import njit
 import numpy as np
@@ -109,15 +109,15 @@ class Window(np.ndarray):
      [0.7788 0.8825 0.7788]]
     """
 
-    _name: str = None
+    _name: str | None = None
     _circular: bool = False
 
     def __new__(
         cls,
-        window: Union[None, str, np.ndarray, Array] = None,
-        shape: Optional[Sequence[int]] = None,
+        window: str | np.ndarray | Array | None = None,
+        shape: Sequence[int] | None = None,
         **kwargs,
-    ):
+    ) -> Self:
         if window is None:
             window = "circular"
 
@@ -191,13 +191,13 @@ class Window(np.ndarray):
 
         return obj
 
-    def __array_finalize__(self, obj):
+    def __array_finalize__(self, obj: Self | None) -> None:
         if obj is None:
             return
         self._name = getattr(obj, "_name", None)
         self._circular = getattr(obj, "_circular", False)
 
-    def __array_wrap__(self, obj):
+    def __array_wrap__(self, obj: Self) -> Self | np.ndarray:
         if obj.shape == ():
             return obj[()]
         else:
@@ -250,7 +250,7 @@ class Window(np.ndarray):
         """Return the window origin."""
         return tuple(i // 2 for i in self.shape)
 
-    def make_circular(self):
+    def make_circular(self) -> None:
         """Make the window circular.
 
         The data of window elements who's radial distance to the
@@ -272,7 +272,7 @@ class Window(np.ndarray):
         if self.name in ["rectangular", "boxcar"]:
             self._name = "circular"
 
-    def shape_compatible(self, shape: Tuple[int]) -> bool:
+    def shape_compatible(self, shape: tuple[int, ...]) -> bool:
         """Return whether the window shape is compatible with another
         shape.
 
@@ -302,41 +302,41 @@ class Window(np.ndarray):
         self,
         grid: bool = True,
         show_values: bool = True,
-        textcolors: Optional[List[str]] = None,
+        textcolors: list[str] | None = None,
         cmap: str = "viridis",
         cmap_label: str = "Value",
         colorbar: bool = True,
         return_figure: bool = False,
-    ) -> Figure:
+    ) -> mfigure.Figure | None:
         """Plot window values with indices relative to the origin.
 
         Parameters
         ----------
         grid
             Whether to separate each value with a white spacing in a
-            grid. Default is ``True``.
+            grid. Default is True.
         show_values
             Whether to show values as text in centre of element. Default
-            is ``True``.
+            is True.
         textcolors
             A list of two color specifications. The first is used for
             values below a threshold, the second for those above. If
-            not given (default), this is set to ``["white", "black"]``.
+            not given (default), this is set to ["white", "black"].
         cmap
             A colormap to color data with, available in
             :class:`matplotlib.colors.ListedColormap`. Default is
-            ``"viridis"``.
+            "viridis".
         cmap_label
-            Colormap label. Default is ``"Value"``.
+            Colormap label. Default is "Value".
         colorbar
-            Whether to show the colorbar. Default is ``True``.
+            Whether to show the colorbar. Default is True.
         return_figure
-            Whether to return the figure. Default is ``False``.
+            Whether to return the figure. Default is False.
 
         Returns
         -------
         fig
-            Figure returned if ``return_figure=True``.
+            Figure returned if *return_figure* is True.
 
         Examples
         --------
@@ -399,8 +399,8 @@ class Window(np.ndarray):
 
 
 def distance_to_origin(
-    shape: Union[Tuple[int], Tuple[int, int]],
-    origin: Union[None, Tuple[int], Tuple[int, int]] = None,
+    shape: tuple[int] | tuple[int, int],
+    origin: tuple[int] | tuple[int, int] | None = None,
 ) -> np.ndarray:
     """Return the distance to the window origin in pixels.
 
@@ -468,9 +468,9 @@ def modified_hann(Nx: int) -> np.ndarray:
 
 
 def lowpass_fft_filter(
-    shape: Tuple[int, int],
-    cutoff: Union[int, float],
-    cutoff_width: Union[None, int, float] = None,
+    shape: tuple[int, int],
+    cutoff: int | float,
+    cutoff_width: int | float | None = None,
 ) -> np.ndarray:
     r"""Return a frequency domain low-pass filter transfer function in
     2D.
@@ -535,9 +535,9 @@ def lowpass_fft_filter(
 
 
 def highpass_fft_filter(
-    shape: Tuple[int, int],
-    cutoff: Union[int, float],
-    cutoff_width: Union[None, int, float] = None,
+    shape: tuple[int, int],
+    cutoff: int | float,
+    cutoff_width: int | float | None = None,
 ) -> np.ndarray:
     r"""Return a frequency domain high-pass filter transfer function in
     2D.

--- a/src/kikuchipy/imaging/vbse.py
+++ b/src/kikuchipy/imaging/vbse.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Tuple, Union
-
 from dask.array import Array
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy.drawing._markers.horizontal_line import HorizontalLine
@@ -48,11 +46,11 @@ class VirtualBSEImager:
     kikuchipy.signals.EBSD.get_virtual_bse_intensity
     """
 
-    def __init__(self, signal: Union[EBSD, LazyEBSD]):
+    def __init__(self, signal: EBSD | LazyEBSD) -> None:
         self.signal = signal
         self._grid_shape = (5, 5)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__class__.__name__ + " for " + repr(self.signal)
 
     @property
@@ -83,19 +81,19 @@ class VirtualBSEImager:
         return self._grid_shape
 
     @grid_shape.setter
-    def grid_shape(self, shape: Union[Tuple[int, int], List[int]]):
+    def grid_shape(self, shape: tuple[int, int] | list[int]) -> None:
         """Set the generator grid shape."""
         self._grid_shape = tuple(shape)
 
     def get_rgb_image(
         self,
-        r: Union[BaseInteractiveROI, Tuple, List[BaseInteractiveROI], List[Tuple]],
-        g: Union[BaseInteractiveROI, Tuple, List[BaseInteractiveROI], List[Tuple]],
-        b: Union[BaseInteractiveROI, Tuple, List[BaseInteractiveROI], List[Tuple]],
-        percentiles: Optional[Tuple] = None,
+        r: BaseInteractiveROI | tuple | list[BaseInteractiveROI] | list[tuple],
+        g: BaseInteractiveROI | tuple | list[BaseInteractiveROI] | list[tuple],
+        b: BaseInteractiveROI | tuple | list[BaseInteractiveROI] | list[tuple],
+        percentiles: tuple | None = None,
         normalize: bool = True,
-        alpha: Union[None, np.ndarray, VirtualBSEImage] = None,
-        dtype_out: Union[str, np.dtype, type] = "uint8",
+        alpha: np.ndarray | VirtualBSEImage | None = None,
+        dtype_out: str | np.dtype | type = "uint8",
         add_bright: int = 0,
         contrast: float = 1.0,
     ) -> VirtualBSEImage:
@@ -192,7 +190,7 @@ class VirtualBSEImager:
         return vbse_rgb_image
 
     def get_images_from_grid(
-        self, dtype_out: Union[str, np.dtype, type] = "float32"
+        self, dtype_out: str | np.dtype | type = "float32"
     ) -> VirtualBSEImage:
         """Return an in-memory signal with a stack of virtual
         backscatter electron (BSE) images by integrating the intensities
@@ -237,7 +235,7 @@ class VirtualBSEImager:
 
         return vbse_images
 
-    def roi_from_grid(self, index: Union[Tuple, List[Tuple]]) -> RectangularROI:
+    def roi_from_grid(self, index: tuple | list[tuple]) -> RectangularROI:
         """Return a rectangular region of interest (ROI) on the EBSD
         detector from one or multiple grid tile indices as row(s) and
         column(s).
@@ -270,8 +268,8 @@ class VirtualBSEImager:
 
     def plot_grid(
         self,
-        pattern_idx: Optional[Tuple[int, ...]] = None,
-        rgb_channels: Union[None, List[Tuple], List[List[Tuple]]] = None,
+        pattern_idx: tuple[int, ...] | None = None,
+        rgb_channels: list[tuple] | list[list[tuple]] | None = None,
         visible_indices: bool = True,
         **kwargs,
     ) -> EBSD:
@@ -357,7 +355,7 @@ def _normalize_image(
     image: np.ndarray,
     add_bright: int = 0,
     contrast: float = 1.0,
-    dtype_out: Union[str, np.dtype, type] = "uint8",
+    dtype_out: str | np.dtype | type = "uint8",
 ) -> np.ndarray:
     """Normalize an image's intensities to a mean of 0 and a standard
     deviation of 1, with the possibility to also scale by a contrast
@@ -396,11 +394,11 @@ def _normalize_image(
 
 
 def _get_rgb_image(
-    channels: List[np.ndarray],
-    percentiles: Optional[Tuple] = None,
+    channels: list[np.ndarray],
+    percentiles: tuple | None = None,
     normalize: bool = True,
-    alpha: Optional[np.ndarray] = None,
-    dtype_out: Union[str, np.dtype, type] = "uint8",
+    alpha: np.ndarray | None = None,
+    dtype_out: str | np.dtype | type = "uint8",
     add_bright: int = 0,
     contrast: float = 1.0,
 ) -> np.ndarray:

--- a/src/kikuchipy/indexing/_dictionary_indexing.py
+++ b/src/kikuchipy/indexing/_dictionary_indexing.py
@@ -20,7 +20,6 @@ dictionary of simulated patterns with known orientations.
 """
 
 from time import sleep, time
-from typing import Optional, Tuple, Union
 
 import dask.array as da
 from dask.diagnostics import ProgressBar
@@ -33,9 +32,9 @@ from kikuchipy.indexing.similarity_metrics._similarity_metric import SimilarityM
 
 
 def _dictionary_indexing(
-    experimental: Union[np.ndarray, da.Array],
+    experimental: np.ndarray | da.Array,
     experimental_nav_shape: tuple,
-    dictionary: Union[np.ndarray, da.Array],
+    dictionary: np.ndarray | da.Array,
     step_sizes: tuple,
     dictionary_xmap: CrystalMap,
     metric: SimilarityMetric,
@@ -169,11 +168,11 @@ def _dictionary_indexing(
 
 
 def _match_chunk(
-    experimental: Union[np.ndarray, da.Array],
-    simulated: Union[np.ndarray, da.Array],
+    experimental: np.ndarray | da.Array,
+    simulated: np.ndarray | da.Array,
     keep_n: int,
     metric: SimilarityMetric,
-) -> Tuple[da.Array, da.Array]:
+) -> tuple[da.Array, da.Array]:
     """Match all experimental patterns to part of or the entire
     dictionary of simulated patterns.
 
@@ -207,7 +206,7 @@ def _dictionary_indexing_info_message(
     n_experimental_all: int,
     dictionary_size: int,
     phase_name: str,
-    n_experimental: Optional[int] = None,
+    n_experimental: int | None = None,
 ) -> str:
     """Return a message with useful dictionary indexing information.
 

--- a/src/kikuchipy/indexing/_merge_crystal_maps.py
+++ b/src/kikuchipy/indexing/_merge_crystal_maps.py
@@ -16,7 +16,6 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 from math import copysign
-from typing import List, Optional, Union
 import warnings
 
 import numpy as np
@@ -27,12 +26,12 @@ from kikuchipy.signals.util._crystal_map import _equal_phase
 
 
 def merge_crystal_maps(
-    crystal_maps: List[CrystalMap],
+    crystal_maps: list[CrystalMap],
     mean_n_best: int = 1,
-    greater_is_better: Optional[int] = None,
+    greater_is_better: int | None = None,
     scores_prop: str = "scores",
-    simulation_indices_prop: Optional[str] = None,
-    navigation_masks: Optional[List[Union[None, np.ndarray]]] = None,
+    simulation_indices_prop: str | None = None,
+    navigation_masks: list[np.ndarray | None] | None = None,
 ) -> CrystalMap:
     """Return a multi phase :class:`~orix.crystal_map.CrystalMap` by
     merging maps of 1D or 2D navigation shape based on scores.

--- a/src/kikuchipy/indexing/_orientation_similarity_map.py
+++ b/src/kikuchipy/indexing/_orientation_similarity_map.py
@@ -22,8 +22,6 @@ is compared to the corresponding lists in the nearest neighbour points.
 
 # TODO: Consider moving to orix.
 
-from typing import Optional
-
 import numpy as np
 from orix.crystal_map import CrystalMap
 from scipy.ndimage import generic_filter
@@ -31,11 +29,11 @@ from scipy.ndimage import generic_filter
 
 def orientation_similarity_map(
     xmap: CrystalMap,
-    n_best: Optional[int] = None,
+    n_best: int | None = None,
     simulation_indices_prop: str = "simulation_indices",
     normalize: bool = False,
-    from_n_best: Optional[int] = None,
-    footprint: Optional[np.ndarray] = None,
+    from_n_best: int | None = None,
+    footprint: np.ndarray | None = None,
     center_index: int = 2,
 ) -> np.ndarray:
     r"""Compute an orientation similarity map (OSM) where the ranked
@@ -146,9 +144,9 @@ def _orientation_similarity_per_pixel(
         for mi in match_indices[neighbours]
     ]
 
-    os = np.nanmean(number_of_equal_matches_to_its_neighbours)
+    os_i = np.nanmean(number_of_equal_matches_to_its_neighbours)
 
     if normalize:
-        os /= n
+        os_i /= n
 
-    return os
+    return os_i

--- a/src/kikuchipy/indexing/_refinement/_refinement.py
+++ b/src/kikuchipy/indexing/_refinement/_refinement.py
@@ -22,7 +22,7 @@ patterns.
 
 import sys
 from time import time
-from typing import Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable
 
 import dask.array as da
 from dask.diagnostics import ProgressBar
@@ -44,12 +44,20 @@ from kikuchipy.pattern import rescale_intensity
 from kikuchipy.signals.util._crystal_map import _get_indexed_points_in_data_in_xmap
 from kikuchipy.signals.util._master_pattern import _get_direction_cosines_from_detector
 
+if TYPE_CHECKING:  # pragma: no cover
+    from kikuchipy.constants import installed
+    from kikuchipy.detectors.ebsd_detector import EBSDDetector
+    from kikuchipy.signals.ebsd_master_pattern import EBSDMasterPattern
+
+    if installed["nlopt"]:
+        import nlopt
+
 
 def compute_refine_orientation_results(
     results: da.Array,
     xmap: CrystalMap,
     master_pattern: "EBSDMasterPattern",
-    navigation_mask: Optional[np.ndarray] = None,
+    navigation_mask: np.ndarray | None = None,
     pseudo_symmetry_checked: bool = False,
 ) -> CrystalMap:
     """Compute the results from
@@ -124,8 +132,8 @@ def compute_refine_projection_center_results(
     results: da.Array,
     detector: "EBSDDetector",
     xmap: CrystalMap,
-    navigation_mask: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, "EBSDDetector", np.ndarray]:
+    navigation_mask: np.ndarray | None = None,
+) -> tuple[np.ndarray, "EBSDDetector", np.ndarray]:
     """Compute the results from
     :meth:`~kikuchipy.signals.EBSD.refine_projection_center` and return
     the score array, :class:`~kikuchipy.detectors.EBSDDetector` and
@@ -191,9 +199,9 @@ def compute_refine_orientation_projection_center_results(
     detector: "EBSDDetector",
     xmap: CrystalMap,
     master_pattern: "EBSDMasterPattern",
-    navigation_mask: Optional[np.ndarray] = None,
+    navigation_mask: np.ndarray | None = None,
     pseudo_symmetry_checked: bool = False,
-) -> Tuple[CrystalMap, "EBSDDetector"]:
+) -> tuple[CrystalMap, "EBSDDetector"]:
     """Compute the results from
     :meth:`~kikuchipy.signals.EBSD.refine_orientation_projection_center`
     and return the :class:`~orix.crystal_map.CrystalMap` and
@@ -331,20 +339,20 @@ def _refine_orientation(
     xmap: CrystalMap,
     detector,
     master_pattern,
-    energy: Union[int, float],
-    patterns: Union[np.ndarray, da.Array],
+    energy: int | float,
+    patterns: np.ndarray | da.Array,
     points_to_refine: np.ndarray,
     signal_mask: np.ndarray,
-    trust_region: Union[tuple, list, np.ndarray, None],
+    trust_region: np.ndarray | list | tuple | None,
     rtol: float,
-    pseudo_symmetry_ops: Optional[Rotation] = None,
-    method: Optional[str] = None,
-    method_kwargs: Optional[dict] = None,
-    initial_step: Optional[float] = None,
-    maxeval: Optional[int] = None,
+    pseudo_symmetry_ops: Rotation | None = None,
+    method: str | None = None,
+    method_kwargs: dict | None = None,
+    initial_step: float | None = None,
+    maxeval: int | None = None,
     compute: bool = True,
-    navigation_mask: Optional[np.ndarray] = None,
-):
+    navigation_mask: np.ndarray | None = None,
+) -> CrystalMap:
     ref = _RefinementSetup(
         mode="ori",
         xmap=xmap,
@@ -435,17 +443,17 @@ def _refine_orientation_chunk_scipy(
     rotations: np.ndarray,
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
-    pcx: Optional[np.ndarray] = None,
-    pcy: Optional[np.ndarray] = None,
-    pcz: Optional[np.ndarray] = None,
-    signal_mask: Optional[np.ndarray] = None,
-    solver_kwargs: Optional[dict] = None,
-    direction_cosines: Optional[np.ndarray] = None,
-    nrows: Optional[int] = None,
-    ncols: Optional[int] = None,
-    tilt: Optional[float] = None,
-    azimuthal: Optional[float] = None,
-    sample_tilt: Optional[float] = None,
+    pcx: np.ndarray | None = None,
+    pcy: np.ndarray | None = None,
+    pcz: np.ndarray | None = None,
+    signal_mask: np.ndarray | None = None,
+    solver_kwargs: dict | None = None,
+    direction_cosines: np.ndarray | None = None,
+    nrows: int | None = None,
+    ncols: int | None = None,
+    tilt: float | None = None,
+    azimuthal: float | None = None,
+    sample_tilt: float | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ):
     """Refine orientations from patterns in one dask array chunk using
@@ -502,18 +510,18 @@ def _refine_orientation_chunk_nlopt(
     rotations: np.ndarray,
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
-    pcx: Optional[np.ndarray] = None,
-    pcy: Optional[np.ndarray] = None,
-    pcz: Optional[np.ndarray] = None,
-    opt: "nlopt.opt" = None,
-    signal_mask: Optional[np.ndarray] = None,
-    solver_kwargs: Optional[dict] = None,
-    direction_cosines: Optional[np.ndarray] = None,
-    nrows: Optional[int] = None,
-    ncols: Optional[int] = None,
-    tilt: Optional[float] = None,
-    azimuthal: Optional[float] = None,
-    sample_tilt: Optional[float] = None,
+    pcx: np.ndarray | None = None,
+    pcy: np.ndarray | None = None,
+    pcz: np.ndarray | None = None,
+    opt: "nlopt.opt | None" = None,
+    signal_mask: np.ndarray | None = None,
+    solver_kwargs: dict | None = None,
+    direction_cosines: np.ndarray | None = None,
+    nrows: int | None = None,
+    ncols: int | None = None,
+    tilt: float | None = None,
+    azimuthal: float | None = None,
+    sample_tilt: float | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ):
     """Refine orientations from patterns in one dask array chunk using
@@ -578,20 +586,20 @@ def _refine_pc(
     xmap: CrystalMap,
     detector,
     master_pattern,
-    energy: Union[int, float],
-    patterns: Union[np.ndarray, da.Array],
+    energy: int | float,
+    patterns: np.ndarray | da.Array,
     points_to_refine: np.ndarray,
     signal_mask: np.ndarray,
-    trust_region: Union[tuple, list, np.ndarray, None],
+    trust_region: np.ndarray | list | tuple | None,
     rtol: float,
-    rotations_ps: Optional[Rotation] = None,
-    method: Optional[str] = None,
-    method_kwargs: Optional[dict] = None,
-    initial_step: Optional[float] = None,
-    maxeval: Optional[int] = None,
+    rotations_ps: Rotation | None = None,
+    method: str | None = None,
+    method_kwargs: dict | None = None,
+    initial_step: float | None = None,
+    maxeval: int | None = None,
     compute: bool = True,
-    navigation_mask: Optional[np.ndarray] = None,
-):
+    navigation_mask: np.ndarray | None = None,
+) -> tuple[np.ndarray, "EBSDDetector", np.ndarray]:
     ref = _RefinementSetup(
         mode="pc",
         xmap=xmap,
@@ -646,7 +654,7 @@ def _refine_pc_chunk_scipy(
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
     solver_kwargs: dict,
-):
+) -> np.ndarray:
     """Refine projection centers using patterns in one dask array chunk."""
 
     nav_size = patterns.shape[0]
@@ -674,8 +682,8 @@ def _refine_pc_chunk_nlopt(
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
     solver_kwargs: dict,
-    opt: "nlopt.opt" = None,
-):
+    opt: "nlopt.opt | None" = None,
+) -> np.ndarray:
     """Refine projection centers using patterns in one dask array chunk."""
     # Copy optimizer
     import nlopt
@@ -706,20 +714,20 @@ def _refine_orientation_pc(
     xmap: CrystalMap,
     detector,
     master_pattern,
-    energy: Union[int, float],
-    patterns: Union[np.ndarray, da.Array],
+    energy: int | float,
+    patterns: np.ndarray | da.Array,
     points_to_refine: np.ndarray,
     signal_mask: np.ndarray,
-    trust_region: Union[tuple, list, np.ndarray, None],
+    trust_region: np.ndarray | list | tuple | None,
     rtol: float,
-    pseudo_symmetry_ops: Optional[Rotation] = None,
-    method: Optional[str] = None,
-    method_kwargs: Optional[dict] = None,
-    initial_step: Union[tuple, list, np.ndarray, None] = None,
-    maxeval: Optional[int] = None,
+    pseudo_symmetry_ops: Rotation | None = None,
+    method: str | None = None,
+    method_kwargs: dict | None = None,
+    initial_step: np.ndarray | list | tuple | None = None,
+    maxeval: int | None = None,
     compute: bool = True,
-    navigation_mask: Optional[np.ndarray] = None,
-) -> tuple:
+    navigation_mask: np.ndarray | None = None,
+) -> tuple[CrystalMap, "EBSDDetector"]:
     """See the docstring of
     :meth:`kikuchipy.signals.EBSD.refine_orientation_projection_center`.
     """
@@ -781,9 +789,9 @@ def _refine_orientation_pc_chunk_scipy(
     rot_pc: np.ndarray,
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
-    solver_kwargs: Optional[dict] = None,
+    solver_kwargs: dict | None = None,
     n_pseudo_symmetry_ops: int = 0,
-):
+) -> np.ndarray:
     """Refine orientations and projection centers using all patterns in
     one dask array chunk using *SciPy*.
     """
@@ -813,10 +821,10 @@ def _refine_orientation_pc_chunk_nlopt(
     rot_pc: np.ndarray,
     lower_bounds: np.ndarray,
     upper_bounds: np.ndarray,
-    solver_kwargs: Optional[dict] = None,
-    opt: "nlopt.opt" = None,
+    solver_kwargs: dict | None = None,
+    opt: "nlopt.opt | None" = None,
     n_pseudo_symmetry_ops: int = 0,
-):
+) -> np.ndarray:
     """Refine orientations and projection centers using all patterns in
     one dask array chunk using *NLopt*.
     """
@@ -903,10 +911,10 @@ class _RefinementSetup:
     nav_size: int
     n_pseudo_symmetry_ops: int = 0
     rotations_array: da.Array
-    rotations_pc_array: Optional[da.Array] = None
+    rotations_pc_array: da.Array | None = None
     # Optimization parameters
-    initial_step: Optional[list] = None
-    maxeval: Optional[int] = None
+    initial_step: list | None = None
+    maxeval: int | None = None
     method_name: str
     optimization_type: str
     package: str
@@ -924,16 +932,16 @@ class _RefinementSetup:
         xmap: CrystalMap,
         detector: "EBSDDetector",
         master_pattern: "EBSDMasterPattern",
-        energy: Union[int, float],
-        patterns: Union[np.ndarray, da.Array],
+        energy: int | float,
+        patterns: np.ndarray | da.Array,
         points_to_refine: np.ndarray,
         rtol: float,
         method: str,
-        method_kwargs: Optional[dict] = None,
-        initial_step: Optional[float] = None,
-        maxeval: Optional[int] = None,
-        signal_mask: Optional[np.ndarray] = None,
-        pseudo_symmetry_ops: Optional[Rotation] = None,
+        method_kwargs: dict | None = None,
+        initial_step: float | None = None,
+        maxeval: int | None = None,
+        signal_mask: np.ndarray | None = None,
+        pseudo_symmetry_ops: Rotation | None = None,
     ):
         """Set up EBSD refinement."""
         self.mode = mode
@@ -1054,9 +1062,9 @@ class _RefinementSetup:
         self,
         rtol: float,
         method: str,
-        method_kwargs: Optional[dict] = None,
-        initial_step: Union[float, int, Tuple[float, float], None] = None,
-        maxeval: Optional[int] = None,
+        method_kwargs: dict | None = None,
+        initial_step: float | int | tuple[float, float] | None = None,
+        maxeval: int | None = None,
     ) -> None:
         """Set *NLopt* or *SciPy* optimization parameters.
 
@@ -1148,8 +1156,8 @@ class _RefinementSetup:
         self,
         detector: "EBSDDetector",
         master_pattern: "EBSDMasterPattern",
-        energy: Union[int, float],
-        signal_mask: Optional[np.ndarray] = None,
+        energy: int | float,
+        signal_mask: np.ndarray | None = None,
     ) -> None:
         """Set fixed parameters to pass to the objective function.
 
@@ -1184,8 +1192,9 @@ class _RefinementSetup:
         self.fixed_parameters = params
 
     def get_bound_constraints(
-        self, trust_region: Union[tuple, list, np.ndarray, None]
-    ) -> Tuple[da.Array, da.Array]:
+        self,
+        trust_region: np.ndarray | list | tuple | None,
+    ) -> tuple[da.Array, da.Array]:
         """Return the bound constraints on the control variables.
 
         Parameters
@@ -1248,7 +1257,7 @@ class _RefinementSetup:
 
         return lower_bounds, upper_bounds
 
-    def get_info_message(self, trust_region) -> str:
+    def get_info_message(self, trust_region: np.ndarray | list | tuple | None) -> str:
         """Return a string with important refinement information to
         display to the user.
 
@@ -1293,8 +1302,8 @@ class _RefinementSetup:
 
 
 def _get_master_pattern_data(
-    master_pattern: "EBSDMasterPattern", energy: Union[int, float]
-) -> Tuple[np.ndarray, np.ndarray, int, int, float]:
+    master_pattern: "EBSDMasterPattern", energy: int | float
+) -> tuple[np.ndarray, np.ndarray, int, int, float]:
     """Return the upper and lower hemispheres along with their shape.
 
     Parameters

--- a/src/kikuchipy/indexing/_refinement/_solvers.py
+++ b/src/kikuchipy/indexing/_refinement/_solvers.py
@@ -20,7 +20,7 @@ centers by optimizing the similarity between experimental and simulated
 patterns.
 """
 
-from typing import Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable
 
 from numba import njit
 import numpy as np
@@ -37,9 +37,15 @@ from kikuchipy.pattern._pattern import (
 )
 from kikuchipy.signals.util._master_pattern import _get_direction_cosines_for_fixed_pc
 
+if TYPE_CHECKING:  # pragma: no cover
+    from kikuchipy.constants import installed
+
+    if installed["nlopt"]:
+        import nlopt
+
 
 @njit(cache=True, nogil=True, fastmath=True)
-def _prepare_pattern(pattern: np.ndarray, rescale: bool) -> Tuple[np.ndarray, float]:
+def _prepare_pattern(pattern: np.ndarray, rescale: bool) -> tuple[np.ndarray, float]:
     """Prepare experimental pattern.
 
     Parameters
@@ -75,21 +81,20 @@ def _refine_orientation_solver_scipy(
     method: Callable,
     method_kwargs: dict,
     trust_region_passed: bool,
-    fixed_parameters: Tuple[np.ndarray, np.ndarray, int, int, float],
-    direction_cosines: Optional[np.ndarray] = None,
-    pcx: Optional[float] = None,
-    pcy: Optional[float] = None,
-    pcz: Optional[float] = None,
-    nrows: Optional[int] = None,
-    ncols: Optional[int] = None,
-    tilt: Optional[float] = None,
-    azimuthal: Optional[float] = None,
-    sample_tilt: Optional[float] = None,
+    fixed_parameters: tuple[np.ndarray, np.ndarray, int, int, float],
+    direction_cosines: np.ndarray | None = None,
+    pcx: float | None = None,
+    pcy: float | None = None,
+    pcz: float | None = None,
+    nrows: int | None = None,
+    ncols: int | None = None,
+    tilt: float | None = None,
+    azimuthal: float | None = None,
+    sample_tilt: float | None = None,
     n_pseudo_symmetry_ops: int = 0,
-) -> Union[
-    Tuple[float, int, float, float, float],
-    Tuple[float, int, int, float, float, float],
-]:
+) -> (
+    tuple[float, int, float, float, float] | tuple[float, int, int, float, float, float]
+):
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the orientation
     (Rodrigues-Frank vector) used in the projection.
@@ -253,7 +258,7 @@ def _refine_pc_solver_scipy(
     method_kwargs: dict,
     fixed_parameters: tuple,
     trust_region_passed: bool,
-) -> Tuple[float, int, float, float, float]:
+) -> tuple[float, int, float, float, float]:
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the projection center (PC)
     parameters used in the projection.
@@ -336,10 +341,10 @@ def _refine_orientation_pc_solver_scipy(
     fixed_parameters: tuple,
     trust_region_passed: bool,
     n_pseudo_symmetry_ops: int = 0,
-) -> Union[
-    Tuple[float, int, float, float, float, float, float, float],
-    Tuple[float, int, int, float, float, float, float, float, float],
-]:
+) -> (
+    tuple[float, int, float, float, float, float, float, float]
+    | tuple[float, int, int, float, float, float, float, float, float]
+):
     """Maximize the similarity between an experimental pattern and a
     projected simulated pattern by optimizing the orientation and
     projection center (PC) parameters used in the projection.
@@ -466,21 +471,20 @@ def _refine_orientation_solver_nlopt(
     signal_mask: np.ndarray,
     rescale: bool,
     trust_region_passed: bool,
-    fixed_parameters: Tuple[np.ndarray, np.ndarray, int, int, float],
-    direction_cosines: Optional[np.ndarray] = None,
-    pcx: Optional[float] = None,
-    pcy: Optional[float] = None,
-    pcz: Optional[float] = None,
-    nrows: Optional[int] = None,
-    ncols: Optional[int] = None,
-    tilt: Optional[float] = None,
-    azimuthal: Optional[float] = None,
-    sample_tilt: Optional[float] = None,
+    fixed_parameters: tuple[np.ndarray, np.ndarray, int, int, float],
+    direction_cosines: np.ndarray | None = None,
+    pcx: float | None = None,
+    pcy: float | None = None,
+    pcz: float | None = None,
+    nrows: int | None = None,
+    ncols: int | None = None,
+    tilt: float | None = None,
+    azimuthal: float | None = None,
+    sample_tilt: float | None = None,
     n_pseudo_symmetry_ops: int = 0,
-) -> Union[
-    Tuple[float, int, float, float, float],
-    Tuple[float, int, int, float, float, float],
-]:
+) -> (
+    tuple[float, int, float, float, float] | tuple[float, int, int, float, float, float]
+):
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     # Get direction cosines if a unique PC per pattern is used
@@ -546,7 +550,7 @@ def _refine_pc_solver_nlopt(
     rescale: bool,
     fixed_parameters: tuple,
     trust_region_passed: bool,
-) -> Tuple[float, int, float, float, float]:
+) -> tuple[float, int, float, float, float]:
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     # Combine tuple of fixed parameters passed to the objective function
@@ -577,10 +581,10 @@ def _refine_orientation_pc_solver_nlopt(
     fixed_parameters: tuple,
     trust_region_passed: bool,
     n_pseudo_symmetry_ops: int = 0,
-) -> Union[
-    Tuple[float, int, float, float, float, float, float, float],
-    Tuple[float, int, int, float, float, float, float, float, float],
-]:
+) -> (
+    tuple[float, int, float, float, float, float, float, float]
+    | tuple[float, int, int, float, float, float, float, float, float]
+):
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     # Combine tuple of fixed parameters passed to the objective function

--- a/src/kikuchipy/indexing/similarity_metrics/_normalized_cross_correlation.py
+++ b/src/kikuchipy/indexing/similarity_metrics/_normalized_cross_correlation.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
-
 import dask
 import dask.array as da
 from numba import njit
@@ -55,13 +53,11 @@ class NormalizedCrossCorrelationMetric(SimilarityMetric):
     attributes.
     """
 
-    _allowed_dtypes: List[type] = [np.float32, np.float64]
+    _allowed_dtypes: list[type] = [np.float32, np.float64]
     _sign: int = 1
 
     def __call__(
-        self,
-        experimental: Union[da.Array, np.ndarray],
-        dictionary: Union[da.Array, np.ndarray],
+        self, experimental: da.Array | np.ndarray, dictionary: da.Array | np.ndarray
     ) -> da.Array:
         """Compute the similarities between experimental patterns and
         simulated dictionary patterns.
@@ -90,8 +86,8 @@ class NormalizedCrossCorrelationMetric(SimilarityMetric):
         return self.match(experimental, dictionary)
 
     def prepare_experimental(
-        self, patterns: Union[np.ndarray, da.Array]
-    ) -> Union[np.ndarray, da.Array]:
+        self, patterns: np.ndarray | da.Array
+    ) -> np.ndarray | da.Array:
         """Prepare experimental patterns before matching to dictionary
         patterns in :meth:`match`.
 
@@ -132,8 +128,8 @@ class NormalizedCrossCorrelationMetric(SimilarityMetric):
         return prepared_patterns
 
     def prepare_dictionary(
-        self, patterns: Union[np.ndarray, da.Array]
-    ) -> Union[np.ndarray, da.Array]:
+        self, patterns: np.ndarray | da.Array
+    ) -> np.ndarray | da.Array:
         """Prepare dictionary patterns before matching to experimental
         patterns in :meth:`match`.
 
@@ -164,8 +160,8 @@ class NormalizedCrossCorrelationMetric(SimilarityMetric):
 
     def match(
         self,
-        experimental: Union[np.ndarray, da.Array],
-        dictionary: Union[np.ndarray, da.Array],
+        experimental: np.ndarray | da.Array,
+        dictionary: np.ndarray | da.Array,
     ) -> da.Array:
         """Match all experimental patterns to all dictionary patterns
         and return their similarities.
@@ -186,17 +182,15 @@ class NormalizedCrossCorrelationMetric(SimilarityMetric):
             "ik,mk->im", experimental, dictionary, optimize=True, dtype=self.dtype
         )
 
-    def _mask_patterns(
-        self, patterns: Union[da.Array, np.ndarray]
-    ) -> Union[da.Array, np.ndarray]:
+    def _mask_patterns(self, patterns: da.Array | np.ndarray) -> da.Array | np.ndarray:
         with dask.config.set(**{"array.slicing.split_large_chunks": False}):
             patterns = patterns[:, ~self.signal_mask.ravel()]
         return patterns
 
     @staticmethod
     def _zero_mean_normalize_patterns(
-        patterns: Union[da.Array, np.ndarray]
-    ) -> Union[da.Array, np.ndarray]:
+        patterns: da.Array | np.ndarray,
+    ) -> da.Array | np.ndarray:
         if isinstance(patterns, np.ndarray):
             return _zero_mean_normalize_patterns_numpy(patterns)
         else:

--- a/src/kikuchipy/indexing/similarity_metrics/_normalized_dot_product.py
+++ b/src/kikuchipy/indexing/similarity_metrics/_normalized_dot_product.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
-
 import dask
 import dask.array as da
 import numpy as np
@@ -45,13 +43,13 @@ class NormalizedDotProductMetric(SimilarityMetric):
     attributes.
     """
 
-    _allowed_dtypes: List[type] = [np.float32, np.float64]
+    _allowed_dtypes: list[type] = [np.float32, np.float64]
     _sign: int = 1
 
     def __call__(
         self,
-        experimental: Union[da.Array, np.ndarray],
-        dictionary: Union[da.Array, np.ndarray],
+        experimental: da.Array | np.ndarray,
+        dictionary: da.Array | np.ndarray,
     ) -> da.Array:
         """Compute the similarities between experimental patterns and
         simulated dictionary patterns.
@@ -80,8 +78,8 @@ class NormalizedDotProductMetric(SimilarityMetric):
         return self.match(experimental, dictionary)
 
     def prepare_experimental(
-        self, patterns: Union[np.ndarray, da.Array]
-    ) -> Union[np.ndarray, da.Array]:
+        self, patterns: np.ndarray | da.Array
+    ) -> np.ndarray | da.Array:
         """Prepare experimental patterns before matching to dictionary
         patterns in :meth:`match`.
 
@@ -122,8 +120,8 @@ class NormalizedDotProductMetric(SimilarityMetric):
         return patterns
 
     def prepare_dictionary(
-        self, patterns: Union[np.ndarray, da.Array]
-    ) -> Union[np.ndarray, da.Array]:
+        self, patterns: np.ndarray | da.Array
+    ) -> np.ndarray | da.Array:
         """Prepare dictionary patterns before matching to experimental
         patterns in :meth:`match`.
 
@@ -153,8 +151,8 @@ class NormalizedDotProductMetric(SimilarityMetric):
 
     def match(
         self,
-        experimental: Union[np.ndarray, da.Array],
-        dictionary: Union[np.ndarray, da.Array],
+        experimental: np.ndarray | da.Array,
+        dictionary: np.ndarray | da.Array,
     ) -> da.Array:
         """Match all experimental patterns to all dictionary patterns
         and return their similarities.
@@ -175,17 +173,13 @@ class NormalizedDotProductMetric(SimilarityMetric):
             "ik,mk->im", experimental, dictionary, optimize=True, dtype=self.dtype
         )
 
-    def _mask_patterns(
-        self, patterns: Union[da.Array, np.ndarray]
-    ) -> Union[da.Array, np.ndarray]:
+    def _mask_patterns(self, patterns: da.Array | np.ndarray) -> da.Array | np.ndarray:
         with dask.config.set(**{"array.slicing.split_large_chunks": False}):
             patterns = patterns[:, ~self.signal_mask.ravel()]
         return patterns
 
     @staticmethod
-    def _normalize_patterns(
-        patterns: Union[da.Array, np.ndarray]
-    ) -> Union[da.Array, np.ndarray]:
+    def _normalize_patterns(patterns: da.Array | np.ndarray) -> da.Array | np.ndarray:
         if isinstance(patterns, da.Array):
             dispatcher = da
         else:

--- a/src/kikuchipy/indexing/similarity_metrics/_similarity_metric.py
+++ b/src/kikuchipy/indexing/similarity_metrics/_similarity_metric.py
@@ -16,7 +16,6 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import abc
-from typing import List, Optional, Union
 
 import numpy as np
 
@@ -64,18 +63,18 @@ class SimilarityMetric(abc.ABC):
         Default is ``False``.
     """
 
-    _allowed_dtypes: List[type] = []
-    _sign: Optional[int] = None
+    _allowed_dtypes: list[type] = []
+    _sign: int | None = None
 
     def __init__(
         self,
-        n_experimental_patterns: Optional[int] = None,
-        n_dictionary_patterns: Optional[int] = None,
-        navigation_mask: Optional[np.ndarray] = None,
-        signal_mask: Optional[np.ndarray] = None,
-        dtype: Union[str, np.dtype, type] = "float32",
+        n_experimental_patterns: int | None = None,
+        n_dictionary_patterns: int | None = None,
+        navigation_mask: np.ndarray | None = None,
+        signal_mask: np.ndarray | None = None,
+        dtype: str | np.dtype | type = "float32",
         rechunk: bool = False,
-    ):
+    ) -> None:
         """Create a similarity metric matching experimental and
         simulated EBSD patterns in a dictionary.
         """
@@ -86,7 +85,7 @@ class SimilarityMetric(abc.ABC):
         self._dtype = np.dtype(dtype)
         self._rechunk = rechunk
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         string = f"{self.__class__.__name__}: {np.dtype(self.dtype).name}, "
         sign_string = {1: "greater is better", -1: "lower is better"}
         string += sign_string[self.sign]
@@ -96,7 +95,7 @@ class SimilarityMetric(abc.ABC):
         return string
 
     @property
-    def allowed_dtypes(self) -> List[type]:
+    def allowed_dtypes(self) -> list[type]:
         """Return the list of allowed array data types used during
         matching.
         """
@@ -115,7 +114,7 @@ class SimilarityMetric(abc.ABC):
         return self._dtype
 
     @dtype.setter
-    def dtype(self, value: Union[str, np.dtype, type]):
+    def dtype(self, value: str | np.dtype | type) -> None:
         """Set which data type to cast the patterns to before
         matching.
         """
@@ -136,7 +135,7 @@ class SimilarityMetric(abc.ABC):
         return self._n_dictionary_patterns
 
     @n_dictionary_patterns.setter
-    def n_dictionary_patterns(self, value: int):
+    def n_dictionary_patterns(self, value: int) -> None:
         """Set the number of dictionary patterns to match."""
         self._n_dictionary_patterns = value
 
@@ -155,7 +154,7 @@ class SimilarityMetric(abc.ABC):
         return self._n_experimental_patterns
 
     @n_experimental_patterns.setter
-    def n_experimental_patterns(self, value: int):
+    def n_experimental_patterns(self, value: int) -> None:
         """Set the number of experimental patterns to match."""
         self._n_experimental_patterns = value
 
@@ -172,7 +171,7 @@ class SimilarityMetric(abc.ABC):
         return self._navigation_mask
 
     @navigation_mask.setter
-    def navigation_mask(self, value: np.ndarray):
+    def navigation_mask(self, value: np.ndarray) -> None:
         """Set the boolean mask of patterns to match, equal to the
         navigation (map) shape.
         """
@@ -191,7 +190,7 @@ class SimilarityMetric(abc.ABC):
         return self._signal_mask
 
     @signal_mask.setter
-    def signal_mask(self, value: np.ndarray):
+    def signal_mask(self, value: np.ndarray) -> None:
         """Set the boolean mask equal to the experimental patterns'
         detector shape ``(s rows, s columns)``.
         """
@@ -217,7 +216,7 @@ class SimilarityMetric(abc.ABC):
         return self._rechunk
 
     @rechunk.setter
-    def rechunk(self, value: bool):
+    def rechunk(self, value: bool) -> None:
         """Set whether to allow rechunking of arrays before matching."""
         self._rechunk = value
 
@@ -242,7 +241,7 @@ class SimilarityMetric(abc.ABC):
         """
         return NotImplemented  # pragma: no cover
 
-    def raise_error_if_invalid(self):
+    def raise_error_if_invalid(self) -> None:
         """Raise a ValueError if :attr:`dtype` is not among
         :attr:`allowed_dtypes` and the latter is not an empty list.
         """

--- a/src/kikuchipy/io/_util.py
+++ b/src/kikuchipy/io/_util.py
@@ -16,11 +16,11 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from typing import Any, Union
+from typing import Any
 import warnings
 
 
-def _get_input_bool(question: str) -> bool:
+def _get_input_bool(question: str) -> bool | None:
     """Get input from user on boolean choice, returning the answer.
 
     Parameters
@@ -46,7 +46,7 @@ def _get_input_bool(question: str) -> bool:
         return False
 
 
-def _get_input_variable(question: str, var_type: Any) -> Union[None, Any]:
+def _get_input_variable(question: str, var_type: Any) -> Any | None:
     """Get variable input from user, returning the variable.
 
     Parameters
@@ -73,7 +73,7 @@ def _get_input_variable(question: str, var_type: Any) -> Union[None, Any]:
         return None
 
 
-def _ensure_directory(filename: str):
+def _ensure_directory(filename: str) -> None:
     """Check if the filename path exists, create it if not."""
     directory = os.path.split(filename)[0]
     if directory and not os.path.exists(directory):

--- a/src/kikuchipy/io/plugins/bruker_h5ebsd.py
+++ b/src/kikuchipy/io/plugins/bruker_h5ebsd.py
@@ -18,7 +18,6 @@
 """Reader of EBSD data from a Bruker Nano h5ebsd file."""
 
 from pathlib import Path
-from typing import List, Union
 
 import h5py
 import numpy as np
@@ -67,7 +66,7 @@ class BrukerH5EBSDReader(H5EBSDReader):
         Keyword arguments passed to :class:`h5py.File`.
     """
 
-    def __init__(self, filename: str, **kwargs):
+    def __init__(self, filename: str, **kwargs) -> None:
         super().__init__(filename, **kwargs)
 
     def scan2dict(self, group: h5py.Group, lazy: bool = False) -> dict:
@@ -198,10 +197,10 @@ class BrukerH5EBSDReader(H5EBSDReader):
         return scan_dict
 
 
-def _bruker_roi_is_rectangular(iy, ix):
+def _bruker_roi_is_rectangular(iy: int, ix: int) -> tuple[int, int, bool]:
     iy_unique, iy_unique_counts = np.unique(iy, return_counts=True)
     ix_unique, ix_unique_counts = np.unique(ix, return_counts=True)
-    is_rectangular = (
+    is_rectangular = bool(
         np.all(np.diff(np.sort(iy_unique)) == 1)
         and np.all(np.diff(np.sort(ix_unique)) == 1)
         and np.unique(iy_unique_counts).size == 1
@@ -213,11 +212,11 @@ def _bruker_roi_is_rectangular(iy, ix):
 
 
 def file_reader(
-    filename: Union[str, Path],
-    scan_group_names: Union[None, str, List[str]] = None,
+    filename: str | Path,
+    scan_group_names: str | list[str] | None = None,
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read electron backscatter diffraction patterns, a crystal map,
     and an EBSD detector from a Bruker h5ebsd file
     :cite:`jackson2014h5ebsd`.

--- a/src/kikuchipy/io/plugins/ebsd_directory.py
+++ b/src/kikuchipy/io/plugins/ebsd_directory.py
@@ -22,7 +22,6 @@ import logging
 import os
 from pathlib import Path
 import re
-from typing import Dict, List, Optional, Union
 import warnings
 
 import dask
@@ -50,11 +49,11 @@ writes = False
 
 
 def file_reader(
-    filename: Union[str, Path],
-    xy_pattern: Optional[str] = None,
-    show_progressbar: Optional[bool] = None,
+    filename: str | Path,
+    xy_pattern: str | None = None,
+    show_progressbar: bool | None = None,
     lazy: bool = False,
-) -> List[Dict]:
+) -> list[dict]:
     r"""Read all images in a directory, assuming they are electron
     backscatter diffraction (EBSD) patterns of equal shape and data
     type.

--- a/src/kikuchipy/io/plugins/edax_binary.py
+++ b/src/kikuchipy/io/plugins/edax_binary.py
@@ -21,7 +21,7 @@ The reader is adapted from the EDAX UP1/2 reader in PyEBSDIndex.
 """
 
 from pathlib import Path
-from typing import BinaryIO, Dict, List, Optional, Tuple, Union
+from typing import BinaryIO
 import warnings
 
 import dask.array as da
@@ -49,10 +49,10 @@ writes = False
 
 
 def file_reader(
-    filename: Union[str, Path],
-    nav_shape: Optional[Tuple[int, int]] = None,
+    filename: str | Path,
+    nav_shape: tuple[int, int] | None = None,
     lazy: bool = False,
-) -> List[dict]:
+) -> list[dict]:
     """Read EBSD patterns from an EDAX binary UP1/2 file.
 
     Not meant to be used directly; use :func:`~kikuchipy.load`.
@@ -113,7 +113,7 @@ class EDAXBinaryFileReader:
         Open EDAX binary UP1/2 file with uncompressed patterns.
     """
 
-    def __init__(self, file: BinaryIO):
+    def __init__(self, file: BinaryIO) -> None:
         """Prepare to read EBSD patterns from an open EDAX UP1/2 file."""
         self.file = file
 
@@ -125,7 +125,7 @@ class EDAXBinaryFileReader:
         if self.version == 2:
             raise ValueError("Only files with version 1 or >= 3, not 2, can be read")
 
-    def read_header(self) -> Dict[str, int]:
+    def read_header(self) -> dict[str, int]:
         """Read and return header information.
 
         Returns
@@ -175,7 +175,7 @@ class EDAXBinaryFileReader:
         }
 
     def read_scan(
-        self, nav_shape: Optional[Tuple[int, int]] = None, lazy: bool = False
+        self, nav_shape: tuple[int, int] | None = None, lazy: bool = False
     ) -> dict:
         """Return a dictionary with scan information and patterns.
 

--- a/src/kikuchipy/io/plugins/edax_h5ebsd.py
+++ b/src/kikuchipy/io/plugins/edax_h5ebsd.py
@@ -18,7 +18,6 @@
 """Reader of EBSD data from an EDAX TSL h5ebsd file."""
 
 from pathlib import Path
-from typing import List, Union
 
 import h5py
 from orix.crystal_map import CrystalMap
@@ -66,7 +65,7 @@ class EDAXH5EBSDReader(H5EBSDReader):
         Keyword arguments passed to :class:`h5py.File`.
     """
 
-    def __init__(self, filename: str, **kwargs):
+    def __init__(self, filename: str, **kwargs) -> None:
         super().__init__(filename, **kwargs)
 
     def scan2dict(self, group: h5py.Group, lazy: bool = False) -> dict:
@@ -162,11 +161,11 @@ class EDAXH5EBSDReader(H5EBSDReader):
 
 
 def file_reader(
-    filename: Union[str, Path],
-    scan_group_names: Union[None, str, List[str]] = None,
+    filename: str | Path,
+    scan_group_names: str | list[str] | None = None,
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read electron backscatter diffraction patterns, a crystal map,
     and an EBSD detector from an EDAX h5ebsd file
     :cite:`jackson2014h5ebsd`.

--- a/src/kikuchipy/io/plugins/emsoft_ebsd.py
+++ b/src/kikuchipy/io/plugins/emsoft_ebsd.py
@@ -19,11 +19,10 @@
 
 import os
 from pathlib import Path
-from typing import List, Tuple, Union
 
 import dask.array as da
 from diffpy.structure import Atom, Lattice, Structure
-from h5py import File
+import h5py
 import numpy as np
 from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.quaternion import Rotation
@@ -54,11 +53,11 @@ footprint = ["emdata/ebsd/ebsdpatterns"]
 
 
 def file_reader(
-    filename: Union[str, Path],
-    scan_size: Union[None, int, Tuple[int, ...]] = None,
+    filename: str | Path,
+    scan_size: int | tuple[int, ...] | None = None,
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read dynamically simulated electron backscatter diffraction
     patterns from EMsoft's format produced by their EMEBSD.f90 program.
 
@@ -83,7 +82,7 @@ def file_reader(
         Data, axes, metadata and original metadata.
     """
     mode = kwargs.pop("mode", "r")
-    f = File(filename, mode=mode, **kwargs)
+    f = h5py.File(filename, mode=mode, **kwargs)
 
     _check_file_format(f)
 
@@ -166,7 +165,7 @@ def file_reader(
     return [scan]
 
 
-def _check_file_format(file: File):
+def _check_file_format(file: h5py.File) -> None:
     """Return whether the HDF file is in EMsoft's format.
 
     Parameters

--- a/src/kikuchipy/io/plugins/emsoft_ebsd_master_pattern.py
+++ b/src/kikuchipy/io/plugins/emsoft_ebsd_master_pattern.py
@@ -19,7 +19,6 @@
 """
 
 from pathlib import Path
-from typing import List, Optional, Union
 
 from kikuchipy.io.plugins._emsoft_master_pattern import EMsoftMasterPatternReader
 
@@ -45,19 +44,27 @@ footprint = ["emdata/ebsdmaster"]
 
 
 class EMsoftEBSDMasterPatternReader(EMsoftMasterPatternReader):
-    diffraction_type = "EBSD"
-    cl_parameters_group_name = "MCCL"  # Monte Carlo openCL
-    energy_string = "EkeVs"
+    @property
+    def diffraction_type(self) -> str:
+        return "EBSD"
+
+    @property
+    def cl_parameters_group_name(self) -> str:
+        return "MCCL"  # Monte Carlo openCL
+
+    @property
+    def energy_string(self) -> str:
+        return "EkeVs"
 
 
 def file_reader(
-    filename: Union[str, Path],
-    energy: Optional[range] = None,
+    filename: str | Path,
+    energy: range | None = None,
     projection: str = "stereographic",
     hemisphere: str = "upper",
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read simulated electron backscatter diffraction master patterns
     from EMsoft's HDF5 file format :cite:`callahan2013dynamical`.
 

--- a/src/kikuchipy/io/plugins/emsoft_ecp_master_pattern.py
+++ b/src/kikuchipy/io/plugins/emsoft_ecp_master_pattern.py
@@ -19,7 +19,6 @@
 """
 
 from pathlib import Path
-from typing import List, Optional, Union
 
 from kikuchipy.io.plugins._emsoft_master_pattern import EMsoftMasterPatternReader
 
@@ -45,19 +44,27 @@ footprint = ["emdata/ecpmaster"]
 
 
 class EMsoftECPMasterPatternReader(EMsoftMasterPatternReader):
-    diffraction_type = "ECP"
-    cl_parameters_group_name = "MCCL"  # Monte Carlo openCL
-    energy_string = "EkeV"
+    @property
+    def diffraction_type(self) -> str:
+        return "ECP"
+
+    @property
+    def cl_parameters_group_name(self) -> str:
+        return "MCCL"  # Monte Carlo openCL
+
+    @property
+    def energy_string(self) -> str:
+        return "EkeV"
 
 
 def file_reader(
-    filename: Union[str, Path],
-    energy: Optional[range] = None,
+    filename: str | Path,
+    energy: range | None = None,
     projection: str = "stereographic",
     hemisphere: str = "upper",
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read simulated electron channeling pattern (ECP) master patterns
     from EMsoft's HDF5 file format :cite:`callahan2013dynamical`.
 

--- a/src/kikuchipy/io/plugins/emsoft_tkd_master_pattern.py
+++ b/src/kikuchipy/io/plugins/emsoft_tkd_master_pattern.py
@@ -19,7 +19,6 @@
 """
 
 from pathlib import Path
-from typing import List, Optional, Union
 
 from kikuchipy.io.plugins._emsoft_master_pattern import EMsoftMasterPatternReader
 
@@ -45,19 +44,27 @@ footprint = ["emdata/tkdmaster"]
 
 
 class EMsoftTKDMasterPatternReader(EMsoftMasterPatternReader):
-    diffraction_type = "TKD"
-    cl_parameters_group_name = "MCCLfoil"  # Monte Carlo openCL
-    energy_string = "EkeVs"
+    @property
+    def diffraction_type(self) -> str:
+        return "TKD"
+
+    @property
+    def cl_parameters_group_name(self) -> str:
+        return "MCCLfoil"  # Monte Carlo openCL
+
+    @property
+    def energy_string(self) -> str:
+        return "EkeVs"
 
 
 def file_reader(
-    filename: Union[str, Path],
-    energy: Optional[range] = None,
+    filename: str | Path,
+    energy: range | None = None,
     projection: str = "stereographic",
     hemisphere: str = "upper",
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read simulated transmission kikuchi diffraction master patterns
     from EMsoft's HDF5 file format :cite:`callahan2013dynamical`.
 

--- a/src/kikuchipy/io/plugins/nordif.py
+++ b/src/kikuchipy/io/plugins/nordif.py
@@ -21,7 +21,7 @@ import logging
 import os
 from pathlib import Path
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 import warnings
 
 from matplotlib.pyplot import imread
@@ -29,6 +29,9 @@ import numpy as np
 from orix.crystal_map import CrystalMap
 
 from kikuchipy.detectors.ebsd_detector import EBSDDetector
+
+if TYPE_CHECKING:  # pragma: no cover
+    from kikuchipy.signals.ebsd import EBSD, LazyEBSD
 
 __all__ = ["file_reader", "file_writer"]
 
@@ -47,13 +50,13 @@ writes = [(2, 2), (2, 1), (2, 0)]
 
 
 def file_reader(
-    filename: Union[str, Path],
-    mmap_mode: Optional[str] = None,
-    scan_size: Union[None, int, Tuple[int, ...]] = None,
-    pattern_size: Optional[Tuple[int, ...]] = None,
-    setting_file: Optional[str] = None,
+    filename: str | Path,
+    mmap_mode: str | None = None,
+    scan_size: int | tuple[int, ...] | None = None,
+    pattern_size: tuple[int, ...] | None = None,
+    setting_file: str | None = None,
     lazy: bool = False,
-) -> List[Dict]:
+) -> list[dict]:
     """Read electron backscatter patterns from a NORDIF data file.
 
     Not meant to be used directly; use :func:`~kikuchipy.load`.
@@ -213,7 +216,7 @@ def file_reader(
 
 def _get_settings_from_file(
     filename: str, pattern_type: str = "acquisition"
-) -> Tuple[dict, dict, dict, dict]:
+) -> tuple[dict, dict, dict, dict]:
     """Return metadata with parameters from NORDIF setting file.
 
     Parameters
@@ -235,7 +238,7 @@ def _get_settings_from_file(
     detector
         Dictionary for creating an EBSD detector.
     """
-    f = open(filename, "r", encoding="latin-1")  # Avoid byte strings
+    f = open(filename, encoding="latin-1")  # Avoid byte strings
     content = f.read().splitlines()
 
     # Get line numbers of setting blocks
@@ -439,7 +442,7 @@ def _get_calibration_pattern_settings(
     return omd
 
 
-def file_writer(filename: str, signal: Union["EBSD", "LazyEBSD"]):
+def file_writer(filename: str, signal: "EBSD | LazyEBSD") -> None:
     """Write an :class:`~kikuchipy.signals.EBSD` or
     :class:`~kikuchipy.signals.LazyEBSD` instance to a NORDIF binary
     file.

--- a/src/kikuchipy/io/plugins/nordif_calibration_patterns.py
+++ b/src/kikuchipy/io/plugins/nordif_calibration_patterns.py
@@ -19,7 +19,6 @@
 
 import os
 from pathlib import Path
-from typing import List, Tuple, Union
 import warnings
 
 from matplotlib.pyplot import imread
@@ -43,7 +42,7 @@ default_extension = 0
 writes = False
 
 
-def file_reader(filename: Union[str, Path], lazy: bool = False) -> List[dict]:
+def file_reader(filename: str | Path, lazy: bool = False) -> list[dict]:
     """Reader electron backscatter patterns from .bmp files stored in a
     NORDIF project directory, their filenames listed in a text file.
 
@@ -116,7 +115,7 @@ def file_reader(filename: Union[str, Path], lazy: bool = False) -> List[dict]:
     return [scan]
 
 
-def _get_patterns(dirname: str, coordinates: List[Tuple[int]]) -> np.ndarray:
+def _get_patterns(dirname: str, coordinates: list[tuple[int, int]]) -> np.ndarray:
     patterns = []
     for y, x in coordinates:
         fname_pattern = f"Calibration ({x},{y}).bmp"

--- a/src/kikuchipy/io/plugins/oxford_binary.py
+++ b/src/kikuchipy/io/plugins/oxford_binary.py
@@ -26,7 +26,7 @@ import logging
 import os
 from pathlib import Path
 import struct
-from typing import BinaryIO, List, Tuple, Union
+from typing import BinaryIO
 
 import dask
 import dask.array as da
@@ -35,7 +35,6 @@ import numpy as np
 from kikuchipy.signals.util._dask import get_chunking
 
 __all__ = ["file_reader"]
-
 
 _logger = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ default_extension = 0
 writes = False
 
 
-def file_reader(filename: Union[str, Path], lazy: bool = False) -> List[dict]:
+def file_reader(filename: str | Path, lazy: bool = False) -> list[dict]:
     """Read EBSD patterns from an Oxford Instruments' binary .ebsp file.
 
     Only uncompressed patterns can be read. If only non-indexed patterns
@@ -111,7 +110,7 @@ class OxfordBinaryFileReader:
         ("n_bytes", np.int32, (1,)),
     ]
 
-    def __init__(self, file: BinaryIO):
+    def __init__(self, file: BinaryIO) -> None:
         """Prepare to read EBSD patterns from an open Oxford
         Instruments' binary .ebsp file.
         """
@@ -177,7 +176,7 @@ class OxfordBinaryFileReader:
         """Whether all or only non-indexed patterns are stored in the
         file.
         """
-        return self.pattern_is_present.all()
+        return bool(self.pattern_is_present.all())
 
     @property
     def data_shape(self) -> tuple:
@@ -269,7 +268,7 @@ class OxfordBinaryFileReader:
             offset=self.first_pattern_position,
         )
 
-    def get_navigation_shape_and_step_size(self) -> Tuple[int, int, int]:
+    def get_navigation_shape_and_step_size(self) -> tuple[int, int, int]:
         """Return the navigation shape and step size.
 
         An equal step size between rows and columns is assumed.
@@ -322,7 +321,7 @@ class OxfordBinaryFileReader:
         self.file.seek(self.pattern_starts_byte_position)
         return np.fromfile(self.file, dtype=np.int64, count=self.n_patterns)
 
-    def get_pattern_footer_dtype(self, offset: int) -> List[tuple]:
+    def get_pattern_footer_dtype(self, offset: int) -> list[tuple]:
         """Return the pattern footer data types to be used when memory
         mapping.
 
@@ -359,7 +358,7 @@ class OxfordBinaryFileReader:
             self.pattern_footer_size = 0
         return list(footer_dtype)
 
-    def get_patterns(self, lazy: bool) -> Union[np.ndarray, da.Array]:
+    def get_patterns(self, lazy: bool) -> np.ndarray | da.Array:
         """Return the EBSD patterns in the file.
 
         The patterns are read from the memory map. They are sorted into
@@ -416,7 +415,7 @@ class OxfordBinaryFileReader:
         self.file.seek(offset + self.pattern_header_size + self.n_bytes)
         return np.fromfile(self.file, dtype=self.pattern_footer_dtype, count=1)
 
-    def get_single_pattern_header(self, offset: int) -> Tuple[bool, int, int, int]:
+    def get_single_pattern_header(self, offset: int) -> tuple[bool, int, int, int]:
         """Return a single pattern header.
 
         Parameters

--- a/src/kikuchipy/io/plugins/oxford_h5ebsd.py
+++ b/src/kikuchipy/io/plugins/oxford_h5ebsd.py
@@ -20,7 +20,6 @@
 
 import logging
 from pathlib import Path
-from typing import List, Union
 
 import h5py
 import numpy as np
@@ -68,7 +67,7 @@ class OxfordH5EBSDReader(H5EBSDReader):
         Keyword arguments passed to :class:`h5py.File`.
     """
 
-    def __init__(self, filename: str, **kwargs):
+    def __init__(self, filename: str | Path, **kwargs) -> None:
         super().__init__(filename, **kwargs)
 
     def scan2dict(self, group: h5py.Group, lazy: bool = False) -> dict:
@@ -173,11 +172,11 @@ class OxfordH5EBSDReader(H5EBSDReader):
 
 
 def file_reader(
-    filename: Union[str, Path],
-    scan_group_names: Union[None, str, List[str]] = None,
+    filename: str | Path,
+    scan_group_names: str | list[str] | None = None,
     lazy: bool = False,
     **kwargs,
-) -> List[dict]:
+) -> list[dict]:
     """Read electron backscatter diffraction patterns, a crystal map,
     and an EBSD detector from an Oxford Instruments h5ebsd (H5OINA) file
     :cite:`jackson2014h5ebsd`.

--- a/src/kikuchipy/logging.py
+++ b/src/kikuchipy/logging.py
@@ -16,10 +16,9 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union
 
 
-def set_log_level(level: Union[int, str]):  # pragma: no cover
+def set_log_level(level: int | str):  # pragma: no cover
     """Set level of kikuchipy logging messages.
 
     Parameters

--- a/src/kikuchipy/pattern/_pattern.py
+++ b/src/kikuchipy/pattern/_pattern.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable
 
 from numba import njit
 import numpy as np
@@ -30,10 +30,10 @@ from kikuchipy.filters.window import Window
 
 def rescale_intensity(
     pattern: np.ndarray,
-    in_range: Optional[Tuple[Union[int, float], ...]] = None,
-    out_range: Optional[Tuple[Union[int, float], ...]] = None,
-    dtype_out: Union[str, np.dtype, type, None] = None,
-    percentiles: Union[None, Tuple[int, int], Tuple[float, float]] = None,
+    in_range: tuple[int | float, ...] | None = None,
+    out_range: tuple[int | float, ...] | None = None,
+    dtype_out: str | np.dtype | type | None = None,
+    percentiles: tuple[int, int] | tuple[float, float] | None = None,
 ) -> np.ndarray:
     """Rescale intensities in an EBSD pattern.
 
@@ -96,10 +96,10 @@ def rescale_intensity(
 @njit(cache=True, nogil=True, fastmath=True)
 def _rescale_with_min_max(
     pattern: np.ndarray,
-    imin: Union[int, float],
-    imax: Union[int, float],
-    omin: Union[int, float],
-    omax: Union[int, float],
+    imin: int | float,
+    imax: int | float,
+    omin: int | float,
+    omax: int | float,
 ) -> np.ndarray:
     """Rescale a pattern to a certain intensity range.
 
@@ -134,17 +134,17 @@ def _rescale_without_min_max_1d_float32(pattern: np.ndarray) -> np.ndarray:
 
 
 @njit("Tuple((float32[:], float32))(float32[:])", cache=True, nogil=True, fastmath=True)
-def _zero_mean_sum_square_1d_float32(pattern: np.ndarray) -> Tuple[np.ndarray, float]:
+def _zero_mean_sum_square_1d_float32(pattern: np.ndarray) -> tuple[np.ndarray, float]:
     pattern -= np.mean(pattern)
     return pattern, np.square(pattern).sum()
 
 
-def _zero_mean(patterns: np.ndarray, axis: Union[int, tuple]) -> np.ndarray:
+def _zero_mean(patterns: np.ndarray, axis: int | tuple[int, ...]) -> np.ndarray:
     patterns_mean = np.nanmean(patterns, axis=axis, keepdims=True)
     return patterns - patterns_mean
 
 
-def _normalize(patterns: np.ndarray, axis: Union[int, tuple]) -> np.ndarray:
+def _normalize(patterns: np.ndarray, axis: int | tuple[int, ...]) -> np.ndarray:
     patterns_squared = patterns**2
     patterns_norm = np.nansum(patterns_squared, axis=axis, keepdims=True)
     patterns_norm_squared = patterns_norm**0.5
@@ -155,7 +155,7 @@ def normalize_intensity(
     pattern: np.ndarray,
     num_std: int = 1,
     divide_by_square_root: bool = False,
-    dtype_out: Union[type, None] = None,
+    dtype_out: type | None = None,
 ) -> np.ndarray:
     """Normalize image intensities to a mean of zero and a given
     standard deviation.
@@ -212,7 +212,7 @@ def _normalize_intensity(
 
 def fft(
     pattern: np.ndarray,
-    apodization_window: Union[None, np.ndarray, Window] = None,
+    apodization_window: np.ndarray | Window | None = None,
     shift: bool = False,
     real_fft_only: bool = False,
     **kwargs,
@@ -311,8 +311,8 @@ def ifft(
 
 def fft_filter(
     pattern: np.ndarray,
-    transfer_function: Union[np.ndarray, Window],
-    apodization_window: Union[None, np.ndarray, Window] = None,
+    transfer_function: np.ndarray | Window,
+    apodization_window: np.ndarray | Window | None = None,
     shift: bool = False,
 ) -> np.ndarray:
     """Filter an EBSD patterns in the frequency domain.
@@ -362,7 +362,7 @@ def fft_spectrum(fft_pattern: np.ndarray) -> np.ndarray:
     return np.sqrt(fft_pattern.real**2 + fft_pattern.imag**2)
 
 
-def fft_frequency_vectors(shape: Tuple[int, int]) -> np.ndarray:
+def fft_frequency_vectors(shape: tuple[int, int]) -> np.ndarray:
     """Get the frequency vectors in a Fourier Transform spectrum.
 
     Parameters
@@ -394,8 +394,8 @@ def _remove_static_background_subtract(
     pattern: np.ndarray,
     static_bg: np.ndarray,
     dtype_out: np.dtype,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
     scale_bg: bool,
 ) -> np.ndarray:
     """Remove static background from a pattern by subtraction."""
@@ -417,8 +417,8 @@ def _remove_static_background_divide(
     pattern: np.ndarray,
     static_bg: np.ndarray,
     dtype_out: np.dtype,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
     scale_bg: bool,
 ) -> np.ndarray:
     """Remove static background from a pattern by division."""
@@ -440,8 +440,8 @@ def _remove_dynamic_background(
     filter_func: Callable,
     operation: str,
     dtype_out: np.dtype,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
     **kwargs,
 ) -> np.ndarray:
     """Remove dynamic background from a pattern.
@@ -485,8 +485,8 @@ def _remove_dynamic_background(
 def _remove_background_subtract(
     pattern: np.ndarray,
     background: np.ndarray,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
 ) -> np.ndarray:
     """Remove background from pattern by subtraction and rescale."""
     pattern -= background
@@ -499,8 +499,8 @@ def _remove_background_subtract(
 def _remove_background_divide(
     pattern: np.ndarray,
     background: np.ndarray,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
 ) -> np.ndarray:
     """Remove background from pattern by division and rescale."""
     pattern /= background
@@ -513,11 +513,11 @@ def remove_dynamic_background(
     pattern: np.ndarray,
     operation: str = "subtract",
     filter_domain: str = "frequency",
-    std: Union[None, int, float] = None,
-    truncate: Union[int, float] = 4.0,
-    dtype_out: Union[
-        str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-    ] = None,
+    std: int | float | None = None,
+    truncate: int | float = 4.0,
+    dtype_out: (
+        str | np.dtype | type | tuple[int, int] | tuple[float, float] | None
+    ) = None,
 ) -> np.ndarray:
     """Remove the dynamic background in an EBSD pattern.
 
@@ -602,11 +602,11 @@ def remove_dynamic_background(
 
 
 def _dynamic_background_frequency_space_setup(
-    pattern_shape: Union[List[int], Tuple[int, int]],
-    std: Union[int, float],
-    truncate: Union[int, float],
-) -> Tuple[
-    Tuple[int, int], Tuple[int, int], np.ndarray, Tuple[int, int], Tuple[int, int]
+    pattern_shape: list[int] | tuple[int, int],
+    std: int | float,
+    truncate: int | float,
+) -> tuple[
+    tuple[int, int], tuple[int, int], np.ndarray, tuple[int, int], tuple[int, int]
 ]:
     # Get Gaussian filtering window
     shape = (int(truncate * std),) * 2
@@ -634,8 +634,8 @@ def _dynamic_background_frequency_space_setup(
 def get_dynamic_background(
     pattern: np.ndarray,
     filter_domain: str = "frequency",
-    std: Union[None, int, float] = None,
-    truncate: Union[int, float] = 4.0,
+    std: int | float | None = None,
+    truncate: int | float = 4.0,
 ) -> np.ndarray:
     """Get the dynamic background in an EBSD pattern.
 
@@ -698,8 +698,8 @@ def get_dynamic_background(
 def get_image_quality(
     pattern: np.ndarray,
     normalize: bool = True,
-    frequency_vectors: Optional[np.ndarray] = None,
-    inertia_max: Union[None, int, float] = None,
+    frequency_vectors: np.ndarray | None = None,
+    inertia_max: int | float | None = None,
 ) -> float:
     """Return the image quality of an EBSD pattern.
 
@@ -795,8 +795,8 @@ def _bin2d(pattern: np.ndarray, factor: int) -> np.ndarray:
 def _downsample2d(
     pattern: np.ndarray,
     factor: int,
-    omin: Union[int, float],
-    omax: Union[int, float],
+    omin: int | float,
+    omax: int | float,
     dtype_out: np.dtype,
 ) -> np.ndarray:
     pattern = pattern.astype(np.float32)
@@ -809,8 +809,8 @@ def _downsample2d(
 
 def _adaptive_histogram_equalization(
     image: np.ndarray,
-    kernel_size: Union[Tuple[int, int], List[int]],
-    clip_limit: Union[int, float] = 0,
+    kernel_size: tuple[int, int] | list[int],
+    clip_limit: int | float = 0,
     nbins: int = 128,
 ) -> np.ndarray:
     """Local contrast enhancement with adaptive histogram equalization.

--- a/src/kikuchipy/pattern/chunk.py
+++ b/src/kikuchipy/pattern/chunk.py
@@ -19,24 +19,21 @@
 :class:`dask.array.Array` chunks of EBSD patterns.
 """
 
-from typing import Union
+from typing import Callable
 
 import dask.array as da
 from numba import njit
 import numpy as np
-from scipy.ndimage import correlate, gaussian_filter
+from scipy.ndimage import correlate
 
-from kikuchipy.filters.fft_barnes import fft_filter as fft_filter_barnes
 from kikuchipy.filters.window import Window
-from kikuchipy.pattern._pattern import _rescale_with_min_max
-from kikuchipy.pattern._pattern import fft_filter as fft_filter_pattern
-from kikuchipy.pattern._pattern import rescale_intensity
+from kikuchipy.pattern._pattern import _rescale_with_min_max, rescale_intensity
 
 
 def get_dynamic_background(
-    patterns: Union[np.ndarray, da.Array],
-    filter_func: Union[gaussian_filter, fft_filter_barnes],
-    dtype_out: Union[str, np.dtype, type, None] = None,
+    patterns: np.ndarray | da.Array,
+    filter_func: Callable,
+    dtype_out: str | np.dtype | type | None = None,
     **kwargs,
 ) -> np.ndarray:
     """Obtain the dynamic background in a chunk of EBSD patterns.
@@ -77,9 +74,9 @@ def get_dynamic_background(
 
 def fft_filter(
     patterns: np.ndarray,
-    filter_func: Union[fft_filter_pattern, fft_filter_barnes],
-    transfer_function: Union[np.ndarray, Window],
-    dtype_out: Union[str, np.dtype, type, None] = None,
+    filter_func: Callable,
+    transfer_function: np.ndarray | Window,
+    dtype_out: str | np.dtype | type | None = None,
     **kwargs,
 ) -> np.ndarray:
     """Filter a chunk of EBSD patterns in the frequency domain.
@@ -133,7 +130,7 @@ def fft_filter(
 def _average_neighbour_patterns(
     patterns: np.ndarray,
     window_sums: np.ndarray,
-    window: Union[np.ndarray, Window],
+    window: np.ndarray | Window,
     dtype_out: np.dtype,
     omin: float,
     omax: float,

--- a/src/kikuchipy/signals/_kikuchi_master_pattern.py
+++ b/src/kikuchipy/signals/_kikuchi_master_pattern.py
@@ -17,7 +17,7 @@
 
 from copy import deepcopy
 import logging
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 import hyperspy.api as hs
@@ -64,7 +64,7 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
 
     _custom_attributes = ["hemisphere", "phase", "projection"]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._hemisphere = kwargs.get("hemisphere")
         self._phase = kwargs.get("phase", Phase())
@@ -88,7 +88,7 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
         return self._hemisphere
 
     @hemisphere.setter
-    def hemisphere(self, value: str):
+    def hemisphere(self, value: str) -> None:
         self._hemisphere = value
 
     @property
@@ -104,7 +104,7 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
         return self._phase
 
     @phase.setter
-    def phase(self, value: Phase):
+    def phase(self, value: Phase) -> None:
         self._phase = value
 
     @property
@@ -120,10 +120,10 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
         return self._projection
 
     @projection.setter
-    def projection(self, value: str):
+    def projection(self, value: str) -> None:
         self._projection = value
 
-    def as_lambert(self, show_progressbar: Optional[bool] = None) -> Any:
+    def as_lambert(self, show_progressbar: bool | None = None) -> Any:
         """Return a new master pattern in the Lambert projection
         :cite:`callahan2013dynamical`.
 
@@ -205,12 +205,12 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
 
     def plot_spherical(
         self,
-        energy: Union[int, float, None] = None,
+        energy: int | float | None = None,
         return_figure: bool = False,
         style: str = "surface",
-        plotter_kwargs: Union[dict] = None,
-        show_kwargs: Union[dict] = None,
-    ) -> "Plotter":
+        plotter_kwargs: dict | None = None,
+        show_kwargs: dict | None = None,
+    ) -> "Plotter | None":
         """Plot the master pattern sphere.
 
         This requires the master pattern to be in the stereographic
@@ -310,8 +310,8 @@ class KikuchiMasterPattern(KikuchipySignal2D, hs.signals.Signal2D):
             pl.show(**show_kwargs)
 
     def _get_master_pattern_arrays_from_energy(
-        self, energy: Union[int, float, None] = None
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        self, energy: int | float | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Return upper and lower master patterns created with a single,
         given energy.
 

--- a/src/kikuchipy/signals/_kikuchipy_signal.py
+++ b/src/kikuchipy/signals/_kikuchipy_signal.py
@@ -20,7 +20,7 @@ import gc
 import logging
 import numbers
 import os
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 import warnings
 
 import dask.array as da
@@ -78,16 +78,16 @@ class KikuchipySignal2D(Signal2D):
     def rescale_intensity(
         self,
         relative: bool = False,
-        in_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        out_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        dtype_out: Union[
-            str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-        ] = None,
-        percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        show_progressbar: Optional[bool] = None,
+        in_range: tuple[int, int] | tuple[float, float] | None = None,
+        out_range: tuple[int, int] | tuple[float, float] | None = None,
+        dtype_out: (
+            str | np.dtype | type | tuple[int, int] | tuple[float, float] | None
+        ) = None,
+        percentiles: tuple[int, int] | tuple[float, float] | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, Any]:
+        lazy_output: bool | None = None,
+    ) -> Any | None:
         """Rescale image intensities.
 
         Output min./max. intensity is determined from ``out_range`` or
@@ -237,11 +237,11 @@ class KikuchipySignal2D(Signal2D):
         self,
         num_std: int = 1,
         divide_by_square_root: bool = False,
-        dtype_out: Union[str, np.dtype, type, None] = None,
-        show_progressbar: Optional[bool] = None,
+        dtype_out: str | np.dtype | type | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, Any]:
+        lazy_output: bool | None = None,
+    ) -> Any | None:
         """Normalize image intensities to a mean of zero with a given
         standard deviation.
 
@@ -329,13 +329,13 @@ class KikuchipySignal2D(Signal2D):
 
     def adaptive_histogram_equalization(
         self,
-        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
-        clip_limit: Union[int, float] = 0,
+        kernel_size: tuple[int, int] | list[int] | None = None,
+        clip_limit: int | float = 0.0,
         nbins: int = 128,
-        show_progressbar: Optional[bool] = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, Any]:
+        lazy_output: bool | None = None,
+    ) -> Any | None:
         """Enhance the local contrast using adaptive histogram
         equalization.
 
@@ -504,7 +504,7 @@ class KikuchipySignal2D(Signal2D):
         make_deepcopy: bool = False,
         make_lazy: bool = False,
         unmake_lazy: bool = False,
-    ):
+    ) -> None:
         """Set custom attributes not in ``Signal2D``.
 
         This is a quick way to set all custom attributes of a class
@@ -578,7 +578,7 @@ class KikuchipySignal2D(Signal2D):
 
         return s_new
 
-    def _assign_subclass(self):
+    def _assign_subclass(self) -> None:
         attrs = self._custom_attributes
 
         super()._assign_subclass()

--- a/src/kikuchipy/signals/ebsd_master_pattern.py
+++ b/src/kikuchipy/signals/ebsd_master_pattern.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import dask
 import dask.array as da
@@ -38,6 +38,9 @@ from kikuchipy.signals.util._master_pattern import (
     _project_patterns_from_master_pattern_with_fixed_pc,
     _project_patterns_from_master_pattern_with_varying_pc,
 )
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyvista import Plotter
 
 
 class EBSDMasterPattern(KikuchiMasterPattern):
@@ -93,12 +96,12 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         self,
         rotations: Rotation,
         detector: EBSDDetector,
-        energy: Union[int, float, None] = None,
-        dtype_out: Union[str, np.dtype, type] = "float32",
+        energy: int | float | None = None,
+        dtype_out: str | np.dtype | type = "float32",
         compute: bool = False,
-        show_progressbar: Optional[bool] = None,
+        show_progressbar: bool | None = None,
         **kwargs,
-    ) -> Union[EBSD, LazyEBSD]:
+    ) -> EBSD | LazyEBSD:
         """Return one or more EBSD patterns projected onto a detector
         from a master pattern in the square Lambert projection for
         rotation(s) relative to the EDAX TSL sample reference frame (RD,
@@ -384,7 +387,7 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         return super().hemisphere
 
     @hemisphere.setter
-    def hemisphere(self, value: str):
+    def hemisphere(self, value: str) -> None:
         super(EBSDMasterPattern, type(self)).hemisphere.fset(self, value)
 
     @property
@@ -392,7 +395,7 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         return super().phase
 
     @phase.setter
-    def phase(self, value: Phase):
+    def phase(self, value: Phase) -> None:
         super(EBSDMasterPattern, type(self)).phase.fset(self, value)
 
     @property
@@ -400,20 +403,20 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         return super().projection
 
     @projection.setter
-    def projection(self, value: str):
+    def projection(self, value: str) -> None:
         super(EBSDMasterPattern, type(self)).projection.fset(self, value)
 
-    def as_lambert(self, show_progressbar: Optional[bool] = None) -> EBSDMasterPattern:
+    def as_lambert(self, show_progressbar: bool | None = None) -> EBSDMasterPattern:
         return super().as_lambert(show_progressbar=show_progressbar)
 
     def plot_spherical(
         self,
-        energy: Union[int, float, None] = None,
+        energy: int | float | None = None,
         return_figure: bool = False,
         style: str = "surface",
-        plotter_kwargs: Union[dict] = None,
-        show_kwargs: Union[dict] = None,
-    ) -> "pyvista.Plotter":
+        plotter_kwargs: dict | None = None,
+        show_kwargs: dict | None = None,
+    ) -> "Plotter | None":
         return super().plot_spherical(
             energy=energy,
             return_figure=return_figure,
@@ -430,11 +433,11 @@ class EBSDMasterPattern(KikuchiMasterPattern):
         self,
         num_std: int = 1,
         divide_by_square_root: bool = False,
-        dtype_out: Union[str, np.dtype, type, None] = None,
-        show_progressbar: Optional[bool] = None,
+        dtype_out: str | np.dtype | type | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> EBSDMasterPattern | LazyEBSDMasterPattern | None:
         return super().normalize_intensity(
             num_std=num_std,
             divide_by_square_root=divide_by_square_root,
@@ -447,16 +450,16 @@ class EBSDMasterPattern(KikuchiMasterPattern):
     def rescale_intensity(
         self,
         relative: bool = False,
-        in_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        out_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        dtype_out: Union[
-            str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-        ] = None,
-        percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        show_progressbar: Optional[bool] = None,
+        in_range: tuple[int, int] | tuple[float, float] | None = None,
+        out_range: tuple[int, int] | tuple[float, float] | None = None,
+        dtype_out: (
+            str | np.dtype | type | tuple[int, int] | tuple[float, float] | None
+        ) = None,
+        percentiles: tuple[int, int] | tuple[float, float] | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> EBSDMasterPattern | LazyEBSDMasterPattern | None:
         return super().rescale_intensity(
             relative=relative,
             in_range=in_range,
@@ -470,13 +473,13 @@ class EBSDMasterPattern(KikuchiMasterPattern):
 
     def adaptive_histogram_equalization(
         self,
-        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
-        clip_limit: Union[int, float] = 0,
+        kernel_size: tuple[int, int] | list[int] | None = None,
+        clip_limit: int | float = 0.0,
         nbins: int = 128,
-        show_progressbar: Optional[bool] = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, EBSDMasterPattern, LazyEBSDMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> EBSDMasterPattern | LazyEBSDMasterPattern | None:
         return super().adaptive_histogram_equalization(
             kernel_size,
             clip_limit,

--- a/src/kikuchipy/signals/ecp_master_pattern.py
+++ b/src/kikuchipy/signals/ecp_master_pattern.py
@@ -17,13 +17,16 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from orix.crystal_map import Phase
 
 from kikuchipy.signals._kikuchi_master_pattern import KikuchiMasterPattern
 from kikuchipy.signals._kikuchipy_signal import LazyKikuchipySignal2D
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyvista import Plotter
 
 
 class ECPMasterPattern(KikuchiMasterPattern):
@@ -70,7 +73,7 @@ class ECPMasterPattern(KikuchiMasterPattern):
         return super().hemisphere
 
     @hemisphere.setter
-    def hemisphere(self, value: str):
+    def hemisphere(self, value: str) -> None:
         super(ECPMasterPattern, type(self)).hemisphere.fset(self, value)
 
     @property
@@ -78,7 +81,7 @@ class ECPMasterPattern(KikuchiMasterPattern):
         return super().phase
 
     @phase.setter
-    def phase(self, value: Phase):
+    def phase(self, value: Phase) -> None:
         super(ECPMasterPattern, type(self)).phase.fset(self, value)
 
     @property
@@ -86,20 +89,20 @@ class ECPMasterPattern(KikuchiMasterPattern):
         return super().projection
 
     @projection.setter
-    def projection(self, value: str):
+    def projection(self, value: str) -> None:
         super(ECPMasterPattern, type(self)).projection.fset(self, value)
 
-    def as_lambert(self, show_progressbar: Optional[bool] = None) -> ECPMasterPattern:
+    def as_lambert(self, show_progressbar: bool | None = None) -> ECPMasterPattern:
         return super().as_lambert(show_progressbar=show_progressbar)
 
     def plot_spherical(
         self,
-        energy: Union[int, float, None] = None,
+        energy: int | float | None = None,
         return_figure: bool = False,
         style: str = "surface",
-        plotter_kwargs: Union[dict] = None,
-        show_kwargs: Union[dict] = None,
-    ) -> "pyvista.Plotter":
+        plotter_kwargs: dict | None = None,
+        show_kwargs: dict | None = None,
+    ) -> "Plotter | None":
         return super().plot_spherical(
             energy=energy,
             return_figure=return_figure,
@@ -116,11 +119,11 @@ class ECPMasterPattern(KikuchiMasterPattern):
         self,
         num_std: int = 1,
         divide_by_square_root: bool = False,
-        dtype_out: Union[str, np.dtype, type, None] = None,
-        show_progressbar: Optional[bool] = None,
+        dtype_out: str | np.dtype | type | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> ECPMasterPattern | LazyECPMasterPattern | None:
         return super().normalize_intensity(
             num_std=num_std,
             divide_by_square_root=divide_by_square_root,
@@ -133,16 +136,16 @@ class ECPMasterPattern(KikuchiMasterPattern):
     def rescale_intensity(
         self,
         relative: bool = False,
-        in_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        out_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        dtype_out: Union[
-            str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-        ] = None,
-        percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        show_progressbar: Optional[bool] = None,
+        in_range: tuple[int, int] | tuple[float, float] | None = None,
+        out_range: tuple[int, int] | tuple[float, float] | None = None,
+        dtype_out: (
+            str | np.dtype | type | tuple[int, int] | tuple[float, float] | None
+        ) = None,
+        percentiles: tuple[int, int] | tuple[float, float] | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> ECPMasterPattern | LazyECPMasterPattern | None:
         return super().rescale_intensity(
             relative=relative,
             in_range=in_range,
@@ -156,13 +159,13 @@ class ECPMasterPattern(KikuchiMasterPattern):
 
     def adaptive_histogram_equalization(
         self,
-        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
-        clip_limit: Union[int, float] = 0,
+        kernel_size: tuple[int, int] | list[int] | None = None,
+        clip_limit: int | float = 0.0,
         nbins: int = 128,
-        show_progressbar: Optional[bool] = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, ECPMasterPattern, LazyECPMasterPattern]:
+        lazy_output: bool | None = None,
+    ) -> ECPMasterPattern | LazyECPMasterPattern | None:
         return super().adaptive_histogram_equalization(
             kernel_size,
             clip_limit,

--- a/src/kikuchipy/signals/util/_crystal_map.py
+++ b/src/kikuchipy/signals/util/_crystal_map.py
@@ -19,7 +19,6 @@
 and an :class:`~kikuchipy.signals.EBSD` signal.
 """
 
-from typing import Optional, Tuple, Union
 import warnings
 
 import numpy as np
@@ -62,7 +61,7 @@ def _xmap_is_compatible_with_signal(
 
 
 # TODO: Move to orix' Phase.__eq__
-def _equal_phase(phase1: Phase, phase2: Phase) -> Tuple[bool, Union[str, None]]:
+def _equal_phase(phase1: Phase, phase2: Phase) -> tuple[bool, str | None]:
     if phase1.name != phase2.name:
         return False, "names"
 
@@ -110,8 +109,8 @@ def _equal_phase(phase1: Phase, phase2: Phase) -> Tuple[bool, Union[str, None]]:
 
 def _get_indexed_points_in_data_in_xmap(
     xmap: CrystalMap,
-    navigation_mask: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, np.ndarray, int, Union[Tuple[int], Tuple[int, int], None]]:
+    navigation_mask: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, int, tuple[int] | tuple[int, int] | None]:
     in_data = xmap.is_in_data.copy()
 
     if navigation_mask is not None:

--- a/src/kikuchipy/signals/util/_dask.py
+++ b/src/kikuchipy/signals/util/_dask.py
@@ -16,7 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import dask.array as da
 import numpy as np
@@ -28,13 +28,13 @@ _logger = logging.getLogger(__name__)
 
 
 def get_chunking(
-    signal: Optional[Union["EBSD", "LazyEBSD"]] = None,
-    data_shape: Optional[tuple] = None,
-    nav_dim: Optional[int] = None,
-    sig_dim: Optional[int] = None,
-    chunk_shape: Optional[int] = None,
-    chunk_bytes: Union[int, float, str, None] = 30e6,
-    dtype: Union[str, np.dtype, type, None] = None,
+    signal: "EBSD | LazyEBSD | None" = None,
+    data_shape: tuple[int, ...] | None = None,
+    nav_dim: int | None = None,
+    sig_dim: int | None = None,
+    chunk_shape: int | None = None,
+    chunk_bytes: int | float | str | None = 30e6,
+    dtype: str | np.dtype | type | None = None,
 ) -> tuple:
     """Get a chunk tuple based on the shape of the signal data.
 
@@ -109,9 +109,7 @@ def get_chunking(
 
 
 def get_dask_array(
-    signal: Union["EBSD", "LazyEBSD"],
-    dtype: Union[str, np.dtype, type, None] = None,
-    **kwargs,
+    signal: "EBSD |LazyEBSD", dtype: str | np.dtype | type | None = None, **kwargs
 ) -> da.Array:
     """Return dask array of patterns with appropriate chunking.
 
@@ -161,8 +159,8 @@ def get_dask_array(
 
 def _reduce_chunks(
     dask_array: da.Array,
-    chunk_bytes: Union[int, float] = 8e6,
-    dtype_out: Union[str, np.dtype, type] = "float32",
+    chunk_bytes: int | float = 8e6,
+    dtype_out: str | np.dtype | type = "float32",
 ) -> tuple:
     dtype_out = np.dtype(dtype_out)
 
@@ -216,9 +214,9 @@ def _get_chunk_overlap_depth(window, axes_manager, chunksize: tuple) -> dict:
 
 
 def _rechunk_learning_results(
-    factors: Union[np.ndarray, da.Array],
-    loadings: Union[np.ndarray, da.Array],
-    mbytes_chunk: Union[int, float] = 100,
+    factors: np.ndarray | da.Array,
+    loadings: np.ndarray | da.Array,
+    mbytes_chunk: int | float = 100,
 ) -> list:
     """Return suggested data chunks for learning results.
 
@@ -281,9 +279,9 @@ def _rechunk_learning_results(
 
 def _update_learning_results(
     learning_results,
-    components: Union[None, int, List[int]],
-    dtype_out: Union[str, np.dtype, type],
-) -> Tuple[Union[np.ndarray, da.Array], Union[np.ndarray, da.Array]]:
+    components: int | list[int] | None,
+    dtype_out: str | np.dtype | type,
+) -> tuple[np.ndarray | da.Array, np.ndarray | da.Array]:
     """Update learning results before calling
     :meth:`hyperspy.learn.mva.MVA.get_decomposition_model` by
     changing data type, keeping only desired components and rechunking

--- a/src/kikuchipy/signals/util/_map_helper.py
+++ b/src/kikuchipy/signals/util/_map_helper.py
@@ -19,7 +19,7 @@
 and their neighbours in a map of a 1D or 2D navigation shape.
 """
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable
 
 import numpy as np
 from scipy.ndimage import generic_filter
@@ -35,9 +35,9 @@ from kikuchipy.pattern._pattern import _normalize, _zero_mean
 def _map_helper(
     patterns: np.ndarray,
     map_function: Callable,
-    window: Union[np.ndarray, Window],
+    window: np.ndarray | Window,
     nav_shape: tuple,
-    dtype_out: np.dtype = np.float32,
+    dtype_out: np.dtype | type = np.float32,
     **kwargs,
 ) -> np.ndarray:
     """Return output of :func:`scipy.ndimage.generic_filter` after
@@ -102,9 +102,9 @@ def _neighbour_dot_products(
     center_index: int,
     zero_mean: bool,
     normalize: bool,
-    flat_window_truthy_indices: Optional[np.ndarray] = None,
-    output: Optional[np.ndarray] = None,
-) -> Union[float, int, np.ndarray]:
+    flat_window_truthy_indices: np.ndarray | None = None,
+    output: np.ndarray | None = None,
+) -> float | int | np.ndarray:
     """Return either an average of a dot product matrix between a
     pattern and it's neighbours, or the matrix.
 
@@ -308,7 +308,7 @@ def _get_average_dot_product_map(
     return adp
 
 
-def _setup_window_indices(window: Window) -> Tuple[np.ndarray, np.ndarray, int]:
+def _setup_window_indices(window: Window) -> tuple[np.ndarray, np.ndarray, int]:
     # Index of window origin in flattened window
     flat_window_origin = np.ravel_multi_index(window.origin, window.shape)
 

--- a/src/kikuchipy/signals/util/_master_pattern.py
+++ b/src/kikuchipy/signals/util/_master_pattern.py
@@ -58,7 +58,7 @@
 patterns into a detector.
 """
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numba as nb
 from numba import njit
@@ -79,7 +79,7 @@ TWO_OVER_SQRT_PI = 2 / SQRT_PI
 
 
 def _get_direction_cosines_from_detector(
-    detector: "EBSDDetector", signal_mask: Optional[np.ndarray] = None
+    detector: "EBSDDetector", signal_mask: np.ndarray | None = None
 ) -> np.ndarray:
     """Return direction cosines for one or more projection centers
     (PCs).
@@ -131,7 +131,7 @@ def _get_direction_cosines_from_detector(
 )
 def _get_cosine_sine_of_alpha_and_azimuthal(
     sample_tilt: float, tilt: float, azimuthal: float
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     alpha = (np.pi / 2) - np.deg2rad(sample_tilt) + np.deg2rad(tilt)
     azimuthal = np.deg2rad(azimuthal)
     return np.cos(alpha), np.sin(alpha), np.cos(azimuthal), np.sin(azimuthal)
@@ -352,9 +352,9 @@ def _project_patterns_from_master_pattern_with_fixed_pc(
     npy: int,
     scale: float,
     rescale: bool,
-    out_min: Union[int, float],
-    out_max: Union[int, float],
-    dtype_out: Optional[type] = np.float32,
+    out_min: int | float,
+    out_max: int | float,
+    dtype_out: np.dtype | type | None = np.float32,
 ) -> np.ndarray:
     """Return one or more simulated EBSD patterns projected from a
     master pattern with a fixed projection center (PC).
@@ -427,9 +427,9 @@ def _project_patterns_from_master_pattern_with_varying_pc(
     npy: int,
     scale: float,
     rescale: bool,
-    out_min: Union[int, float],
-    out_max: Union[int, float],
-    dtype_out: Optional[type] = np.float32,
+    out_min: int | float,
+    out_max: int | float,
+    dtype_out: np.dtype | type | None = np.float32,
 ) -> np.ndarray:
     """Return simulated EBSD patterns projected from a master pattern
     with varying projection centers (PCs).
@@ -502,8 +502,8 @@ def _project_single_pattern_from_master_pattern(
     npy: int,
     scale: float,
     rescale: bool,
-    out_min: Union[int, float],
-    out_max: Union[int, float],
+    out_min: int | float,
+    out_max: int | float,
     dtype_out: type,
 ) -> np.ndarray:
     """Return a single 1D EBSD pattern projected from a master pattern.
@@ -629,7 +629,7 @@ def _get_lambert_interpolation_parameters(
     npx: int,
     npy: int,
     scale: float,
-) -> Tuple[
+) -> tuple[
     np.ndarray,
     np.ndarray,
     np.ndarray,

--- a/src/kikuchipy/signals/util/_overwrite_hyperspy_methods.py
+++ b/src/kikuchipy/signals/util/_overwrite_hyperspy_methods.py
@@ -20,12 +20,12 @@
 import functools
 import inspect
 import re
-from typing import Callable, List, Union
+from typing import Callable
 
 
 def get_parameters(
-    method: Callable, params_of_interest: List[str], args: tuple, kwargs: dict
-) -> Union[dict, None]:
+    method: Callable, params_of_interest: list[str], args: tuple, kwargs: dict
+) -> dict | None:
     sig = inspect.signature(method)
 
     params = {}
@@ -73,12 +73,12 @@ class insert_doc_disclaimer:
         Method, e.g. rebin.
     """
 
-    def __init__(self, cls, meth):
+    def __init__(self, cls, meth: Callable) -> None:
         self.cls_name = cls.__name__
         self.doc = meth.__doc__
         self.name = meth.__name__
 
-    def __call__(self, func):
+    def __call__(self, func: Callable) -> Callable:
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
@@ -86,7 +86,7 @@ class insert_doc_disclaimer:
         wrapper.__doc__ = self._insert_doc_disclaimer()
         return wrapper
 
-    def _insert_doc_disclaimer(self):
+    def _insert_doc_disclaimer(self) -> str | None:
         doc = self.doc
         if doc is None:
             return doc

--- a/src/kikuchipy/signals/util/array_tools.py
+++ b/src/kikuchipy/signals/util/array_tools.py
@@ -15,16 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Tuple, Union
-
 import numpy as np
 
 
 def grid_indices(
-    grid_shape: Union[Tuple[int, int], int],
-    nav_shape: Union[Tuple[int, int], int],
+    grid_shape: tuple[int, int] | int,
+    nav_shape: tuple[int, int] | int,
     return_spacing: bool = False,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Return indices of a grid evenly spaced in a larger grid of max.
     two dimensions.
 

--- a/src/kikuchipy/signals/virtual_bse_image.py
+++ b/src/kikuchipy/signals/virtual_bse_image.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
-
 import numpy as np
 
 from kikuchipy.signals._kikuchipy_signal import KikuchipySignal2D, LazyKikuchipySignal2D
@@ -42,16 +40,16 @@ class VirtualBSEImage(KikuchipySignal2D):
     def rescale_intensity(
         self,
         relative: bool = False,
-        in_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        out_range: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        dtype_out: Union[
-            str, np.dtype, type, Tuple[int, int], Tuple[float, float], None
-        ] = None,
-        percentiles: Union[Tuple[int, int], Tuple[float, float], None] = None,
-        show_progressbar: Optional[bool] = None,
+        in_range: tuple[int, int] | tuple[float, float] | None = None,
+        out_range: tuple[int, int] | tuple[float, float] | None = None,
+        dtype_out: (
+            str | np.dtype | type | tuple[int, int] | tuple[float, float] | None
+        ) = None,
+        percentiles: tuple[int, int] | tuple[float, float] | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        lazy_output: bool | None = None,
+    ) -> VirtualBSEImage | LazyVirtualBSEImage | None:
         return super().rescale_intensity(
             relative,
             in_range,
@@ -67,11 +65,11 @@ class VirtualBSEImage(KikuchipySignal2D):
         self,
         num_std: int = 1,
         divide_by_square_root: bool = False,
-        dtype_out: Union[str, np.dtype, type, None] = None,
-        show_progressbar: Optional[bool] = None,
+        dtype_out: str | np.dtype | type | None = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        lazy_output: bool | None = None,
+    ) -> VirtualBSEImage | LazyVirtualBSEImage | None:
         return super().normalize_intensity(
             num_std,
             divide_by_square_root,
@@ -83,13 +81,13 @@ class VirtualBSEImage(KikuchipySignal2D):
 
     def adaptive_histogram_equalization(
         self,
-        kernel_size: Optional[Union[Tuple[int, int], List[int]]] = None,
-        clip_limit: Union[int, float] = 0,
+        kernel_size: tuple[int, int] | list[int] | None = None,
+        clip_limit: int | float = 0.0,
         nbins: int = 128,
-        show_progressbar: Optional[bool] = None,
+        show_progressbar: bool | None = None,
         inplace: bool = True,
-        lazy_output: Optional[bool] = None,
-    ) -> Union[None, VirtualBSEImage, LazyVirtualBSEImage]:
+        lazy_output: bool | None = None,
+    ) -> VirtualBSEImage | LazyVirtualBSEImage | None:
         return super().adaptive_histogram_equalization(
             kernel_size,
             clip_limit,

--- a/src/kikuchipy/simulations/_kikuchi_pattern_features.py
+++ b/src/kikuchipy/simulations/_kikuchi_pattern_features.py
@@ -25,8 +25,8 @@ class KikuchiPatternFeature:
         vector: Miller,
         vector_detector: Vector3d,
         in_pattern: np.ndarray,
-        max_r_gnomonic: float = 10,
-    ):
+        max_r_gnomonic: float = 10.0,
+    ) -> None:
         self.vector = vector
         self.vector_detector = vector_detector
         self.in_pattern = np.atleast_2d(in_pattern)
@@ -57,8 +57,8 @@ class KikuchiPatternLine(KikuchiPatternFeature):
         hkl: Miller,
         hkl_detector: Vector3d,
         in_pattern: np.ndarray,
-        max_r_gnomonic: float = 10,
-    ):
+        max_r_gnomonic: float = 10.0,
+    ) -> None:
         super().__init__(hkl, hkl_detector, in_pattern, max_r_gnomonic)
         self._set_hesse_distance()
         self._set_within_r_gnomonic(np.abs(self.hesse_distance))
@@ -78,16 +78,16 @@ class KikuchiPatternLine(KikuchiPatternFeature):
         """x0, y0, x1, y1"""
         return self._plane_trace_coordinates
 
-    def _set_hesse_distance(self):
+    def _set_hesse_distance(self) -> None:
         hesse_distance = np.tan(0.5 * np.pi - self.vector_detector.polar)
         self._hesse_distance = np.atleast_2d(hesse_distance)
 
-    def _set_hesse_alpha(self):
+    def _set_hesse_alpha(self) -> None:
         hesse_distance = self.hesse_distance
         hesse_distance[~self.within_r_gnomonic] = np.nan
         self._hesse_alpha = np.arccos(hesse_distance / self.max_r_gnomonic)
 
-    def _set_plane_trace_coordinates(self):
+    def _set_plane_trace_coordinates(self) -> None:
         # Get alpha1 and alpha2 angles (NaN for bands outside gnomonic radius)
         azimuth = np.atleast_2d(self.vector_detector.azimuth)
         hesse_alpha = self.hesse_alpha
@@ -108,8 +108,8 @@ class KikuchiPatternZoneAxis(KikuchiPatternFeature):
         uvw: Miller,
         uvw_detector: Vector3d,
         in_pattern: np.ndarray,
-        max_r_gnomonic: float = 10,
-    ):
+        max_r_gnomonic: float = 10.0,
+    ) -> None:
         super().__init__(uvw, uvw_detector, in_pattern, max_r_gnomonic)
         self._set_r_gnomonic()
         self._set_within_r_gnomonic(self.r_gnomonic)
@@ -119,10 +119,10 @@ class KikuchiPatternZoneAxis(KikuchiPatternFeature):
     def r_gnomonic(self) -> np.ndarray:
         return self._r_gnomonic
 
-    def _set_r_gnomonic(self):
+    def _set_r_gnomonic(self) -> None:
         self._r_gnomonic = np.sqrt(self.x_gnomonic**2 + self.y_gnomonic**2)
 
-    def _set_xy_within_r_gnomonic(self):
+    def _set_xy_within_r_gnomonic(self) -> None:
         xy = np.stack((self.x_gnomonic, self.y_gnomonic))
         xy = np.moveaxis(xy, 0, -1)
         xy[~self.within_r_gnomonic] = np.nan

--- a/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -17,14 +17,13 @@
 
 from copy import deepcopy
 import re
-from typing import List, Optional, Union
 
 from diffsims.crystallography import ReciprocalLatticeVector
 from hyperspy.drawing.marker import MarkerBase
 from hyperspy.utils.markers import line_segment, point, text
 import matplotlib.collections as mcollections
+import matplotlib.figure as mfigure
 import matplotlib.path as mpath
-import matplotlib.pyplot as plt
 import matplotlib.text as mtext
 import numpy as np
 from orix.quaternion import Rotation
@@ -67,7 +66,7 @@ class GeometricalKikuchiPatternSimulation:
         reflectors: ReciprocalLatticeVector,
         lines: KikuchiPatternLine,
         zone_axes: KikuchiPatternZoneAxis,
-    ):
+    ) -> None:
         self._detector = detector.deepcopy()
         self._rotations = deepcopy(rotations)
         self._reflectors = reflectors.deepcopy()
@@ -113,14 +112,14 @@ class GeometricalKikuchiPatternSimulation:
 
     def as_collections(
         self,
-        index: Union[int, tuple, None] = None,
+        index: int | tuple[int, ...] | None = None,
         coordinates: str = "detector",
         lines: bool = True,
         zone_axes: bool = False,
         zone_axes_labels: bool = False,
-        lines_kwargs: dict = None,
-        zone_axes_kwargs: dict = None,
-        zone_axes_labels_kwargs: dict = None,
+        lines_kwargs: dict | None = None,
+        zone_axes_kwargs: dict | None = None,
+        zone_axes_labels_kwargs: dict | None = None,
     ) -> list:
         """Get a single simulation as a list of Matplotlib objects.
 
@@ -196,11 +195,11 @@ class GeometricalKikuchiPatternSimulation:
         zone_axes: bool = False,
         zone_axes_labels: bool = False,
         pc: bool = False,
-        lines_kwargs: Optional[dict] = None,
-        zone_axes_kwargs: Optional[dict] = None,
-        zone_axes_labels_kwargs: Optional[dict] = None,
-        pc_kwargs: Optional[dict] = None,
-    ) -> List[MarkerBase]:
+        lines_kwargs: dict | None = None,
+        zone_axes_kwargs: dict | None = None,
+        zone_axes_labels_kwargs: dict | None = None,
+        pc_kwargs: dict | None = None,
+    ) -> list[MarkerBase]:
         """Return a list of simulation markers.
 
         Parameters
@@ -258,7 +257,7 @@ class GeometricalKikuchiPatternSimulation:
 
     def lines_coordinates(
         self,
-        index: Union[int, tuple, None] = None,
+        index: int | tuple | None = None,
         coordinates: str = "detector",
         exclude_nan: bool = True,
     ) -> np.ndarray:
@@ -299,20 +298,20 @@ class GeometricalKikuchiPatternSimulation:
 
     def plot(
         self,
-        index: Union[int, tuple, None] = None,
+        index: int | tuple | None = None,
         coordinates: str = "detector",
-        pattern: Optional[np.ndarray] = None,
+        pattern: np.ndarray | None = None,
         lines: bool = True,
         zone_axes: bool = True,
         zone_axes_labels: bool = True,
         pc: bool = True,
-        pattern_kwargs: Optional[dict] = None,
-        lines_kwargs: Optional[dict] = None,
-        zone_axes_kwargs: Optional[dict] = None,
-        zone_axes_labels_kwargs: Optional[dict] = None,
-        pc_kwargs: Optional[dict] = None,
+        pattern_kwargs: dict | None = None,
+        lines_kwargs: dict | None = None,
+        zone_axes_kwargs: dict | None = None,
+        zone_axes_labels_kwargs: dict | None = None,
+        pc_kwargs: dict | None = None,
         return_figure: bool = False,
-    ) -> plt.Figure:
+    ) -> mfigure.Figure | None:
         """Plot a single simulation on the detector.
 
         Parameters
@@ -396,7 +395,7 @@ class GeometricalKikuchiPatternSimulation:
 
     def zone_axes_coordinates(
         self,
-        index: Union[int, tuple, None] = None,
+        index: int | tuple | None = None,
         coordinates: str = "detector",
         exclude_nan: bool = True,
     ) -> np.ndarray:
@@ -436,7 +435,7 @@ class GeometricalKikuchiPatternSimulation:
         return coords.copy()
 
     def _lines_as_collection(
-        self, index: Union[int, tuple], coordinates: str, **kwargs
+        self, index: int | tuple[int, ...], coordinates: str, **kwargs
     ) -> mcollections.LineCollection:
         """Get Kikuchi lines as a Matplotlib collection.
 
@@ -470,7 +469,7 @@ class GeometricalKikuchiPatternSimulation:
         kw.update(kwargs)
         return mcollections.LineCollection(segments=list(coords), **kw)
 
-    def _lines_as_markers(self, **kwargs) -> List[line_segment]:
+    def _lines_as_markers(self, **kwargs) -> list[line_segment]:
         """Get Kikuchi lines as a list of HyperSpy markers.
 
         Parameters
@@ -611,7 +610,7 @@ class GeometricalKikuchiPatternSimulation:
         self._zone_axes_detector_coordinates = coords_d
 
     def _zone_axes_as_collection(
-        self, index: Union[int, tuple], coordinates: str, **kwargs
+        self, index: int | tuple[int, ...], coordinates: str, **kwargs
     ) -> mcollections.PathCollection:
         """Get zone axes as a Matplotlib collection.
 
@@ -646,7 +645,7 @@ class GeometricalKikuchiPatternSimulation:
         return mcollections.PathCollection(circles, **kw)
 
     def _zone_axes_labels_as_list(
-        self, index: Union[int, tuple], coordinates: str, **kwargs
+        self, index: int | tuple[int, ...], coordinates: str, **kwargs
     ) -> list:
         """Get zone axes labels as a list of texts.
 

--- a/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
+++ b/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
@@ -55,12 +55,13 @@
 # ######################################################################
 
 import sys
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import dask.array as da
 from dask.diagnostics import ProgressBar
 from diffsims.crystallography import ReciprocalLatticeVector
 import matplotlib.colors as mcolors
+import matplotlib.figure as mfigure
 import matplotlib.pyplot as plt
 import numpy as np
 from orix import projections
@@ -80,6 +81,9 @@ from kikuchipy.simulations._kikuchi_pattern_simulation import (
     GeometricalKikuchiPatternSimulation,
 )
 
+if TYPE_CHECKING:  # pragma: no cover
+    from pyvista import Plotter
+
 
 class KikuchiPatternSimulator:
     """Setup and calculation of geometrical or kinematical Kikuchi
@@ -92,7 +96,7 @@ class KikuchiPatternSimulator:
         dimension.
     """
 
-    def __init__(self, reflectors: ReciprocalLatticeVector):
+    def __init__(self, reflectors: ReciprocalLatticeVector) -> None:
         self._reflectors = reflectors.deepcopy().flatten()
 
     @property
@@ -111,9 +115,9 @@ class KikuchiPatternSimulator:
 
     def calculate_master_pattern(
         self,
-        half_size: Optional[int] = 500,
-        hemisphere: Optional[str] = "upper",
-        scaling: Optional[str] = "linear",
+        half_size: int = 500,
+        hemisphere: str = "upper",
+        scaling: str | None = "linear",
     ) -> EBSDMasterPattern:
         r"""Calculate a kinematical master pattern in the stereographic
         projection.
@@ -137,8 +141,7 @@ class KikuchiPatternSimulator:
         scaling
             Intensity scaling of the band kinematical intensities,
             either ``"linear"`` (default), :math:`|F|`, ``"square"``,
-            :math:`|F|^2`, or ``"None"``, giving all bands an intensity
-            of ``1``.
+            :math:`|F|^2`, or None, giving all bands an intensity of 1.
 
         Returns
         -------
@@ -418,17 +421,17 @@ class KikuchiPatternSimulator:
 
     def plot(
         self,
-        projection: Optional[str] = "stereographic",
-        mode: Optional[str] = "lines",
-        hemisphere: Optional[str] = "upper",
-        scaling: Optional[str] = "linear",
-        figure: Union[None, plt.Figure, "pyvista.Plotter"] = None,
+        projection: str | None = "stereographic",
+        mode: str | None = "lines",
+        hemisphere: str | None = "upper",
+        scaling: str | None = "linear",
+        figure: "mfigure.Figure | Plotter | None" = None,
         return_figure: bool = False,
         backend: str = "matplotlib",
         show_plotter: bool = True,
         color: str = "k",
         **kwargs,
-    ) -> Union[plt.Figure, "pyvista.Plotter"]:
+    ) -> "mfigure.Figure | Plotter | None":
         """Plot reflectors as lines or bands in the stereographic or
         spherical projection.
 
@@ -631,11 +634,11 @@ def _plot_spherical(
     ref: ReciprocalLatticeVector,
     color: np.ndarray,
     backend: str,
-    figure,
+    figure: "mfigure.Figure | Plotter | None",
     show_plotter: bool,
     scaling_title: str,
     intensity: np.ndarray,
-):
+) -> None:
     v = Vector3d(ref).unit
 
     steps = 101

--- a/tests/test_indexing/test_ebsd_refinement.py
+++ b/tests/test_indexing/test_ebsd_refinement.py
@@ -832,8 +832,7 @@ class TestEBSDRefinePC(EBSDRefineTestSetup):
         assert det_ref.pc.shape == nav_shape + (3,)
         assert num_evals_ref.shape == nav_shape
 
-        # TODO: Change to == 10 once Python 3.7 is unsopprted.
-        assert num_evals_ref.max() < 50
+        assert num_evals_ref.max() == 10
 
     @pytest.mark.parametrize(
         (


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Core dependency orix dropped Python 3.8 and 3.9 compatibility in v0.13.1, so it's fine for us to do the same.

This also means we can use types like list, tuple, dict etc. for type hints and replace `Union[X, Y]` with `X | Y` and `Optional[int]` with `int | None` etc. Makes reading and writing types much easier.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
