### PR TITLE
Detector orientation with euler angles: simulations from master patterns and GeometricalKikuchiPatternSimulation

### DIFF
--- a/src/kikuchipy/_utils/_detector_coordinates.py
+++ b/src/kikuchipy/_utils/_detector_coordinates.py
@@ -73,7 +73,7 @@ def get_coordinate_conversions(gnomonic_bounds: np.ndarray, bounds: np.ndarray) 
 
     >>> import numpy as np
     >>> import kikuchipy as kp
-    >>> from kp._utils._detector_coordinates import get_coordinate_conversions
+    >>> from kikuchipy._utils._detector_coordinates import get_coordinate_conversions
     >>> det = kp.detectors.EBSDDetector(
     ...     shape=(60, 60),
     ...     pc=np.ones((10, 20, 3)) * (0.421, 0.779, 0.505),
@@ -190,7 +190,7 @@ def convert_coordinates(
 
     >>> import numpy as np
     >>> import kikuchipy as kp
-    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> from kikuchipy._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
     >>> s = kp.data.nickel_ebsd_small()
     >>> det = s.detector
     >>> det.navigation_shape
@@ -207,7 +207,7 @@ def convert_coordinates(
 
     >>> import numpy as np
     >>> import kikuchipy as kp
-    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> from kikuchipy._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
     >>> s = kp.data.nickel_ebsd_small()
     >>> det = s.detector
     >>> det.navigation_shape
@@ -224,7 +224,7 @@ def convert_coordinates(
 
     >>> import numpy as np
     >>> import kikuchipy as kp
-    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> from kikuchipy._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
     >>> s = kp.data.nickel_ebsd_small()
     >>> det = s.detector
     >>> det.navigation_shape
@@ -241,7 +241,7 @@ def convert_coordinates(
 
     >>> import numpy as np
     >>> import kikuchipy as kp
-    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> from kikuchipy._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
     >>> s = kp.data.nickel_ebsd_small()
     >>> det = s.detector
     >>> det.navigation_shape

--- a/src/kikuchipy/_utils/_detector_coordinates.py
+++ b/src/kikuchipy/_utils/_detector_coordinates.py
@@ -1,0 +1,357 @@
+# Copyright 2019-2024 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Functions for converting between pixel and gnomonic detector coordinates."""
+
+from typing import Union
+
+import numpy as np
+
+
+def get_coordinate_conversions(gnomonic_bounds: np.ndarray, bounds: np.ndarray) -> dict:
+    """
+    Get factors for converting between pixel and gnomonic coordinates.
+
+    Return a dict 'conversions' containing the keys
+    "pix_to_gn", containing factors for converting
+    pixel to gnomonic coordinates, and "gn_to_pix",
+    containing factors for converting gnomonic to pixel
+    coordinates.
+    Under each of these keys is a further dict with the
+    keys: "m_x", "c_x", "m_y" and "c_y". These are the
+    slope (m) and y-intercept (c) corresponding to
+    y = mx + c, which describes the linear conversion
+    of the coordinates. A (different) linear relationship
+    is required for x (column) and y(row) coordinates,
+    hence the two sets of m and c parameters.
+
+    Parameters
+    ----------
+    gnomonic_bounds
+        Array of shape at least (4,) containing the
+        gnomonic bounds of the EBSD detector screen.
+        Typically obtained as the "gnomonic_bounds"
+        property of an EBSDDetector.
+    bounds
+        Array of four ints giving the detector bounds
+        [x0, x1, y0, y1] in pixel coordinates. Typically
+        obtained from the "bounds" property of an
+        EBSDDetector.
+
+    Returns
+    -------
+    conversions
+        Contains the keys "pix_to_gn", containing factors
+        for converting pixel to gnomonic coordinates, and
+        "gn_to_pix", containing factors for converting
+        gnomonic to pixel coordinates.
+        Under each of these keys is a further dict with the
+        keys: "m_x", "c_x", "m_y" and "c_y". These are the
+        slope (m) and y-intercept (c) corresponding to
+        y = mx + c, which describes the linear conversion
+        of the coordinates. A (different) linear relationship
+        is required for x (column) and y(row) coordinates,
+        hence the two sets of m and c parameters.
+
+    Examples
+    --------
+    Create an EBSD detector and get the coordinate conversion factors.
+
+    >>> import numpy as np
+    >>> import kikuchipy as kp
+    >>> from kp._utils._detector_coordinates import get_coordinate_conversions
+    >>> det = kp.detectors.EBSDDetector(
+    ...     shape=(60, 60),
+    ...     pc=np.ones((10, 20, 3)) * (0.421, 0.779, 0.505),
+    ...     convention="edax",
+    ...     px_size=70,
+    ...     binning=8,
+    ...     tilt=5,
+    ...     sample_tilt=70,
+    ... )
+    >>> det
+    EBSDDetector(shape=(60, 60), pc=(0.421, 0.221, 0.505), sample_tilt=70.0, tilt=5.0, azimuthal=0.0, twist=0.0, binning=8.0, px_size=70.0 um)
+    >>> det.navigation_shape
+    (10, 20)
+    >>> det.bounds
+    array([ 0, 59,  0, 59])
+    >>> det.gnomonic_bounds[0, 0]
+    array([-0.83366337,  1.14653465, -1.54257426,  0.43762376])
+    >>> conversions = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+    >>> conversions["pix_to_gn"]["m_x"].shape
+    (10, 20)
+    """
+    gnomonic_bounds = np.atleast_2d(gnomonic_bounds)
+
+    m_pix_to_gn_x = (gnomonic_bounds[..., 1] - gnomonic_bounds[..., 0]) / (
+        bounds[1] + 1
+    )
+    c_pix_to_gn_x = gnomonic_bounds[..., 0]
+
+    m_pix_to_gn_y = (gnomonic_bounds[..., 2] - gnomonic_bounds[..., 3]) / (
+        bounds[3] + 1
+    )
+    c_pix_to_gn_y = gnomonic_bounds[..., 3]
+
+    m_gn_to_pix_x = 1 / m_pix_to_gn_x
+    c_gn_to_pix_x = -c_pix_to_gn_x / m_pix_to_gn_x
+
+    m_gn_to_pix_y = 1 / m_pix_to_gn_y
+    c_gn_to_pix_y = -c_pix_to_gn_y / m_pix_to_gn_y
+
+    conversions = {
+        "pix_to_gn": {
+            "m_x": m_pix_to_gn_x,
+            "c_x": c_pix_to_gn_x,
+            "m_y": m_pix_to_gn_y,
+            "c_y": c_pix_to_gn_y,
+        },
+        "gn_to_pix": {
+            "m_x": m_gn_to_pix_x,
+            "c_x": c_gn_to_pix_x,
+            "m_y": m_gn_to_pix_y,
+            "c_y": c_gn_to_pix_y,
+        },
+    }
+
+    return conversions
+
+
+def convert_coordinates(
+    coords: np.ndarray,
+    direction: str,
+    conversions: dict,
+    detector_index: Union[None, tuple, int] = None,
+) -> np.ndarray:
+    """
+    Convert between gnomonic and pixel coordinates.
+
+    Parameters
+    ----------
+    coords
+        An array of coordinates of any shape whereby the
+        x and y coordinates to be converted are stored in
+        the last axis.
+    direction
+        Either "pix_to_gn" or "gn_to_pix", depending on the
+        direction of conversion needed.
+    conversions
+        Dict containing the conversion parameters. Usually
+        the output of get_coordinate_conversions().
+        Contains the keys "pix_to_gn", containing factors
+        for converting pixel to gnomonic coordinates, and
+        "gn_to_pix", containing factors for converting
+        gnomonic to pixel coordinates.
+        Under each of these keys is a further dict with the
+        keys: "m_x", "c_x", "m_y" and "c_y". These are the
+        slope (m) and y-intercept (c) corresponding to
+        y = mx + c, which describes the linear conversion
+        of the coordinates. A (different) linear relationship
+        is required for x (column) and y(row) coordinates,
+        hence the two sets of m and c parameters.
+        The shape of each array of conversion factors
+        typically corresponds to the navigation shape
+        of an EBSDDetector.
+    detector_index
+        Index showing which conversion factors in *conversions[direction]*
+        should be applied to *coords*.
+        If None, **all** conversion factors in *conversions[direction]*
+        are applied to *coords*.
+        If an int is supplied, this refers to an index in a 1D dataset.
+        A 1D tuple *e.g.* (3,) can also be passed for a 1D dataset.
+        A 2D index can be specified by supplying a tuple *e.g.* (2, 3).
+        The default value is None.
+
+    Returns
+    -------
+    coords_out
+        Array of coords but with values converted as specified
+        by direction. The shape is either the same as the input
+        or is the navigation shape then the shape of the input.
+
+    Examples
+    --------
+
+    Convert 300 xy coordinates for all patterns in a dataset.
+
+    >>> import numpy as np
+    >>> import kikuchipy as kp
+    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> s = kp.data.nickel_ebsd_small()
+    >>> det = s.detector
+    >>> det.navigation_shape
+    (3, 3)
+    >>> coords_2d = np.random.randint(0, 60, (300, 2))
+    >>> coords_2d.shape
+    (300, 2)
+    >>> conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+    >>> coords_out = convert_coordinates(coords_2d, "pix_to_gn", conv, None)
+    >>> coords_out.shape
+    (3, 3, 300, 2)
+
+    Convert 300 xy coordinates for the pattern at index (1, 2) in a dataset.
+
+    >>> import numpy as np
+    >>> import kikuchipy as kp
+    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> s = kp.data.nickel_ebsd_small()
+    >>> det = s.detector
+    >>> det.navigation_shape
+    (3, 3)
+    >>> coords_2d = np.random.randint(0, 60, (300, 2))
+    >>> coords_2d.shape
+    (300, 2)
+    >>> conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+    >>> coords_out = convert_coordinates(coords_2d, "pix_to_gn", conv, (1, 2))
+    >>> coords_out.shape
+    (300, 2)
+
+    Convert 17 sets of 300 xy coordinates, different for each pattern in a dataset.
+
+    >>> import numpy as np
+    >>> import kikuchipy as kp
+    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> s = kp.data.nickel_ebsd_small()
+    >>> det = s.detector
+    >>> det.navigation_shape
+    (3, 3)
+    >>> coords_2d = np.random.randint(0, 60, (3, 3, 17, 300, 2))
+    >>> coords_2d.shape
+    (3, 3, 17, 300, 2)
+    >>> conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+    >>> coords_out = convert_coordinates(coords_2d, "pix_to_gn", conv, None)
+    >>> coords_out.shape
+    (3, 3, 17, 300, 2)
+
+    Convert 17 sets of 300 xy coordinates, the same for all pattern in a dataset.
+
+    >>> import numpy as np
+    >>> import kikuchipy as kp
+    >>> from kp._utils._detector_coordinates import (get_coordinate_conversions, convert_coordinates)
+    >>> s = kp.data.nickel_ebsd_small()
+    >>> det = s.detector
+    >>> det.navigation_shape
+    (3, 3)
+    >>> coords_2d = np.random.randint(0, 60, (17, 300, 2))
+    >>> coords_2d.shape
+    (17, 300, 2)
+    >>> conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+    >>> coords_out = convert_coordinates(coords_2d, "pix_to_gn", conv, None)
+    >>> coords_out.shape
+    (3, 3, 17, 300, 2)
+    """
+    coords = np.atleast_2d(coords)
+
+    nav_shape = conversions[direction]["m_x"].shape
+    nav_ndim = len(nav_shape)
+
+    if isinstance(detector_index, type(None)):
+        detector_index = ()
+        if coords.ndim >= nav_ndim + 2 and coords.shape[:nav_ndim] == nav_shape:
+            # one or more sets of coords, different for each image
+            out_shape = coords.shape
+        else:
+            # one or more sets of coords, the same for each image
+            out_shape = nav_shape + coords.shape
+
+        extra_axes = list(range(nav_ndim, len(out_shape) - 1))
+
+        coords_out = _convert_coordinates(
+            coords,
+            out_shape,
+            detector_index,
+            np.expand_dims(conversions[direction]["m_x"], extra_axes),
+            np.expand_dims(conversions[direction]["c_x"], extra_axes),
+            np.expand_dims(conversions[direction]["m_y"], extra_axes),
+            np.expand_dims(conversions[direction]["c_y"], extra_axes),
+        )
+
+    else:
+        if isinstance(detector_index, int):
+            detector_index = tuple([detector_index])
+
+        out_shape = coords.shape
+
+        coords_out = _convert_coordinates(
+            coords,
+            out_shape,
+            detector_index,
+            conversions[direction]["m_x"],
+            conversions[direction]["c_x"],
+            conversions[direction]["m_y"],
+            conversions[direction]["c_y"],
+        )
+
+    return coords_out
+
+
+def _convert_coordinates(
+    coords: np.ndarray,
+    out_shape: tuple,
+    detector_index: tuple,
+    m_x: Union[np.ndarray, float],
+    c_x: Union[np.ndarray, float],
+    m_y: Union[np.ndarray, float],
+    c_y: Union[np.ndarray, float],
+) -> np.ndarray:
+    """
+    Return converted coordinate depending on arguments.
+
+    This function is usually called by convert_coordinates().
+
+    Parameters
+    ----------
+    coords
+        An array of coordinates whereby the x and y coordinates
+        to be converted are stored in the last axis
+    direction
+        Either "pix_to_gn" or "gn_to_pix", depending on the
+        direction of conversion needed.
+    conversions
+        dict
+
+
+    Parameters
+    ----------
+    coords
+        An array of coordinates whereby the x and y coordinates
+        to be converted are stored in the last axis.
+    out_shape
+        Tuple of ints giving the output shape.
+    detector_index
+        Tuple giving the detector index..
+    m_x
+        Conversion factor m for x coordinate.
+    c_x
+        Conversion factor c for x coordinate.
+    m_y
+        Conversion factor m for y coordinate.
+    c_y
+        Conversion factor c for y coordinate.
+
+    Returns
+    -------
+    coords_out
+        Array of coords the same shape as the input but
+        with converted values.
+    """
+    coords_out = np.zeros(out_shape, dtype=float)
+
+    coords_out[..., 0] = m_x[detector_index] * coords[..., 0] + c_x[detector_index]
+    coords_out[..., 1] = m_y[detector_index] * coords[..., 1] + c_y[detector_index]
+
+    return coords_out

--- a/src/kikuchipy/_utils/_gnonomic_bounds.py
+++ b/src/kikuchipy/_utils/_gnonomic_bounds.py
@@ -1,0 +1,63 @@
+# Copyright 2019-2024 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+"""Function to calculate gnomonic bounds of an EBSDDetector"""
+
+import numpy as np
+
+
+def get_gnomonic_bounds(
+    nrows: int, ncols: int, pcx: float, pcy: float, pcz: float
+) -> np.ndarray:
+    """
+    Get a 1D array of gnomonic bounds for a single PC.
+
+    This function is used in by the objective functions
+    for refining orientations and PCs.
+
+    Parameters
+    ----------
+    nrows
+        Number of rows on the EBSD pattern.
+        Same as EBSDDetector.nrows
+    ncols
+        Number of columns on the EBSD pattern.
+        Same as EBSDDetector.ncols.
+    pcx
+        The x-coordinate of the pattern centre.
+        Same as EBSDDetector.pcx
+    pcy
+        The y-coordinate of the pattern centre.
+        Same as EBSDDetector.pcy
+    pcz
+        The z-coordinate of the pattern centre.
+        Same as EBSDDetector.pcz
+
+    Returns
+    -------
+    gnomonic_bounds
+        Array of the gnomonic bounds
+        [x_min, x_max, y_min, y_max].
+    """
+    aspect_ratio = ncols / nrows
+    x_min = -aspect_ratio * (pcx / pcz)
+    x_max = aspect_ratio * (1 - pcx) / pcz
+    y_min = -(1 - pcy) / pcz
+    y_max = pcy / pcz
+    gnomonic_bounds = np.array([x_min, x_max, y_min, y_max])
+
+    return gnomonic_bounds

--- a/src/kikuchipy/detectors/ebsd_detector.py
+++ b/src/kikuchipy/detectors/ebsd_detector.py
@@ -237,6 +237,7 @@ class EBSDDetector:
         sample_tilt = np.round(self.sample_tilt, decimals)
         tilt = np.round(self.tilt, decimals)
         azimuthal = np.round(self.azimuthal, decimals)
+        twist = np.round(self.twist, decimals)
         px_size = np.round(self.px_size, decimals)
         return (
             f"{type(self).__name__}"
@@ -245,6 +246,7 @@ class EBSDDetector:
             f"sample_tilt={sample_tilt}, "
             f"tilt={tilt}, "
             f"azimuthal={azimuthal}, "
+            f"twist={twist}, "
             f"binning={self.binning}, "
             f"px_size={px_size} um)"
         )
@@ -537,15 +539,6 @@ class EBSDDetector:
             Rotation.from_axes_angles((0, 0, -1), -np.pi / 2) * u_s_bruker
         )
         return sample_to_detector
-
-    @property
-    def u_s_inv(self) -> np.ndarray:
-        """Return the orientation matrix, u_s_inv, which transforms
-        vectors in the detector reference frame, CSd, to the
-        sample reference frame, CSs, i.e. the inverse of u_s,
-        providing the opposite rotation.
-        """
-        return np.linalg.inv(self.u_s)
 
     @classmethod
     def load(cls, fname: Path | str) -> EBSDDetector:

--- a/src/kikuchipy/detectors/ebsd_detector.py
+++ b/src/kikuchipy/detectors/ebsd_detector.py
@@ -189,7 +189,7 @@ class EBSDDetector:
     ...     sample_tilt=70,
     ... )
     >>> det
-    EBSDDetector(shape=(60, 60), pc=(0.421, 0.221, 0.505), sample_tilt=70.0, tilt=5.0, azimuthal=0.0, binning=8.0, px_size=70.0 um)
+    EBSDDetector(shape=(60, 60), pc=(0.421, 0.221, 0.505), sample_tilt=70.0, tilt=5.0, azimuthal=0.0, twist=0.0, binning=8.0, px_size=70.0 um)
     >>> det.navigation_shape
     (10, 20)
     >>> det.bounds
@@ -689,11 +689,11 @@ class EBSDDetector:
         array([[[ 0.36223464,  0.00664684],
                 [ 0.35762801, -0.00304659],
                 [ 0.35361398, -0.00042112]],
-
+        <BLANKLINE>
                [[ 0.36432453,  0.00973461],
                 [ 0.35219231,  0.00567801],
                 [ 0.34417285,  0.00404584]],
-
+        <BLANKLINE>
                [[ 0.36296371,  0.00072557],
                 [ 0.34447751,  0.00538137],
                 [ 0.36136688,  0.00180754]]])
@@ -743,9 +743,9 @@ class EBSDDetector:
         >>> import kikuchipy as kp
         >>> det = kp.detectors.EBSDDetector((6, 6), pc=[3 / 6, 2 / 6, 0.5])
         >>> det
-        EBSDDetector(shape=(6, 6), pc=(0.5, 0.333, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, binning=1.0, px_size=1.0 um)
+        EBSDDetector(shape=(6, 6), pc=(0.5, 0.333, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, twist=0.0, binning=1.0, px_size=1.0 um)
         >>> det.crop((1, 5, 2, 6))
-        EBSDDetector(shape=(4, 4), pc=(0.25, 0.25, 0.75), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, binning=1.0, px_size=1.0 um)
+        EBSDDetector(shape=(4, 4), pc=(0.25, 0.25, 0.75), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, twist=0.0, binning=1.0, px_size=1.0 um)
 
         Plot a cropped detector with the PC on a cropped pattern
 
@@ -1681,12 +1681,12 @@ class EBSDDetector:
         ... shape=(480, 640), pc=(0.4, 0.3, 0.5), px_size=70, sample_tilt=70
         ... )
         >>> det0
-        EBSDDetector(shape=(480, 640), pc=(0.4, 0.3, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, binning=1.0, px_size=70.0 um)
+        EBSDDetector(shape=(480, 640), pc=(0.4, 0.3, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, twist=0.0, binning=1.0, px_size=70.0 um)
         >>> det = det0.extrapolate_pc(
         ... pc_indices=[0, 0], navigation_shape=(5, 10), step_sizes=(20, 20)
         ... )
         >>> det
-        EBSDDetector(shape=(480, 640), pc=(0.398, 0.299, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, binning=1.0, px_size=70.0 um)
+        EBSDDetector(shape=(480, 640), pc=(0.398, 0.299, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, twist=0.0, binning=1.0, px_size=70.0 um)
 
         Plot PC values in maps
 

--- a/src/kikuchipy/indexing/_refinement/_refinement.py
+++ b/src/kikuchipy/indexing/_refinement/_refinement.py
@@ -397,9 +397,7 @@ def _refine_orientation(
             pcz,
             nrows=detector.nrows,
             ncols=detector.ncols,
-            tilt=detector.tilt,
-            azimuthal=detector.azimuthal,
-            sample_tilt=detector.sample_tilt,
+            om_detector_to_sample=(~detector.sample_to_detector).to_matrix().squeeze(),
             signal_mask=signal_mask,
             solver_kwargs=ref.solver_kwargs,
             n_pseudo_symmetry_ops=ref.n_pseudo_symmetry_ops,
@@ -451,9 +449,7 @@ def _refine_orientation_chunk_scipy(
     direction_cosines: np.ndarray | None = None,
     nrows: int | None = None,
     ncols: int | None = None,
-    tilt: float | None = None,
-    azimuthal: float | None = None,
-    sample_tilt: float | None = None,
+    om_detector_to_sample: np.ndarray | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ):
     """Refine orientations from patterns in one dask array chunk using
@@ -483,9 +479,7 @@ def _refine_orientation_chunk_scipy(
                 pcz=float(pcz[i, 0, 0]),
                 nrows=nrows,
                 ncols=ncols,
-                tilt=tilt,
-                azimuthal=azimuthal,
-                sample_tilt=sample_tilt,
+                om_detector_to_sample=om_detector_to_sample,
                 signal_mask=signal_mask,
                 n_pseudo_symmetry_ops=n_pseudo_symmetry_ops,
                 **solver_kwargs,
@@ -519,9 +513,7 @@ def _refine_orientation_chunk_nlopt(
     direction_cosines: np.ndarray | None = None,
     nrows: int | None = None,
     ncols: int | None = None,
-    tilt: float | None = None,
-    azimuthal: float | None = None,
-    sample_tilt: float | None = None,
+    om_detector_to_sample: np.ndarray | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ):
     """Refine orientations from patterns in one dask array chunk using
@@ -556,9 +548,7 @@ def _refine_orientation_chunk_nlopt(
                 pcz=float(pcz[i, 0, 0]),
                 nrows=nrows,
                 ncols=ncols,
-                tilt=tilt,
-                azimuthal=azimuthal,
-                sample_tilt=sample_tilt,
+                om_detector_to_sample=om_detector_to_sample,
                 n_pseudo_symmetry_ops=n_pseudo_symmetry_ops,
                 **solver_kwargs,
             )
@@ -1184,9 +1174,7 @@ class _RefinementSetup:
                 signal_mask,
                 nrows,
                 ncols,
-                detector.tilt,
-                detector.azimuthal,
-                detector.sample_tilt,
+                (~detector.sample_to_detector).to_matrix().squeeze(),
             )
 
         self.fixed_parameters = params

--- a/src/kikuchipy/indexing/_refinement/_solvers.py
+++ b/src/kikuchipy/indexing/_refinement/_solvers.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Callable
 from numba import njit
 import numpy as np
 
+from kikuchipy._utils._gnonomic_bounds import get_gnomonic_bounds
 from kikuchipy.indexing._refinement import SUPPORTED_OPTIMIZATION_METHODS
 from kikuchipy.indexing._refinement._objective_functions import (
     _refine_orientation_objective_function,
@@ -88,9 +89,7 @@ def _refine_orientation_solver_scipy(
     pcz: float | None = None,
     nrows: int | None = None,
     ncols: int | None = None,
-    tilt: float | None = None,
-    azimuthal: float | None = None,
-    sample_tilt: float | None = None,
+    om_detector_to_sample: np.ndarray | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ) -> (
     tuple[float, int, float, float, float] | tuple[float, int, int, float, float, float]
@@ -139,15 +138,12 @@ def _refine_orientation_solver_scipy(
     ncols
         Number of detector columns. Must be passed if
         ``direction_cosines`` is not given.
-    tilt
-        Detector tilt from horizontal in degrees. Must be passed if
-        ``direction_cosines`` is not given.
-    azimuthal
-        Sample tilt about the sample RD axis in degrees. Must be passed
+    om_detector_to_sample
+        Orientation matrix used for transforming from the detector
+        reference frame to the sample reference frame. This is the
+        inverse of EBSDDetector.sample_to_detector expressed as a
+        3x3 numpy array rather than an orix Rotation. Must be passed
         if ``direction_cosines`` is not given.
-    sample_tilt
-        Sample tilt from horizontal in degrees. Must be passed if
-        ``direction_cosines`` is not given.
     n_pseudo_symmetry_ops
         Number of pseudo-symmetry operators. Default is 0.
 
@@ -163,15 +159,14 @@ def _refine_orientation_solver_scipy(
     pattern, squared_norm = _prepare_pattern(pattern, rescale)
 
     if direction_cosines is None:
+        gn_bds = get_gnomonic_bounds(nrows, ncols, pcx, pcy, pcz)
+
         direction_cosines = _get_direction_cosines_for_fixed_pc(
-            pcx=pcx,
-            pcy=pcy,
+            gnomonic_bounds=gn_bds,
             pcz=pcz,
             nrows=nrows,
             ncols=ncols,
-            tilt=tilt,
-            azimuthal=azimuthal,
-            sample_tilt=sample_tilt,
+            om_detector_to_sample=om_detector_to_sample,
             signal_mask=signal_mask,
         )
 
@@ -478,9 +473,7 @@ def _refine_orientation_solver_nlopt(
     pcz: float | None = None,
     nrows: int | None = None,
     ncols: int | None = None,
-    tilt: float | None = None,
-    azimuthal: float | None = None,
-    sample_tilt: float | None = None,
+    om_detector_to_sample: np.ndarray | None = None,
     n_pseudo_symmetry_ops: int = 0,
 ) -> (
     tuple[float, int, float, float, float] | tuple[float, int, int, float, float, float]
@@ -489,15 +482,14 @@ def _refine_orientation_solver_nlopt(
 
     # Get direction cosines if a unique PC per pattern is used
     if direction_cosines is None:
+        gn_bds = get_gnomonic_bounds(nrows, ncols, pcx, pcy, pcz)
+
         direction_cosines = _get_direction_cosines_for_fixed_pc(
-            pcx=pcx,
-            pcy=pcy,
+            gnomonic_bounds=gn_bds,
             pcz=pcz,
             nrows=nrows,
             ncols=ncols,
-            tilt=tilt,
-            azimuthal=azimuthal,
-            sample_tilt=sample_tilt,
+            om_detector_to_sample=om_detector_to_sample,
             signal_mask=signal_mask,
         )
 

--- a/src/kikuchipy/signals/ebsd.py
+++ b/src/kikuchipy/signals/ebsd.py
@@ -153,7 +153,7 @@ class EBSD(KikuchipySignal2D):
     >>> s
     <EBSD, title: patterns Scan 1, dimensions: (3, 3|60, 60)>
     >>> s.detector
-    EBSDDetector(shape=(60, 60), pc=(0.425, 0.213, 0.501), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, binning=8.0, px_size=1.0 um)
+    EBSDDetector(shape=(60, 60), pc=(0.425, 0.213, 0.501), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, twist=0.0, binning=8.0, px_size=1.0 um)
     >>> s.static_background
     array([[84, 87, 90, ..., 27, 29, 30],
            [87, 90, 93, ..., 27, 28, 30],

--- a/src/kikuchipy/signals/util/_master_pattern.py
+++ b/src/kikuchipy/signals/util/_master_pattern.py
@@ -123,20 +123,6 @@ def _get_direction_cosines_from_detector(
 
 
 @njit(
-    "Tuple((float64, float64, float64, float64))(float64, float64, float64)",
-    cache=True,
-    nogil=True,
-    fastmath=True,
-)
-def _get_cosine_sine_of_alpha_and_azimuthal(
-    sample_tilt: float, tilt: float, azimuthal: float
-) -> tuple[float, float, float, float]:
-    alpha = (np.pi / 2) - np.deg2rad(sample_tilt) + np.deg2rad(tilt)
-    azimuthal = np.deg2rad(azimuthal)
-    return np.cos(alpha), np.sin(alpha), np.cos(azimuthal), np.sin(azimuthal)
-
-
-@njit(
     ("float64[:, :]" "(float64[:], float64, int64, int64, float64[:, ::1], bool_[:])"),
     cache=True,
     nogil=True,

--- a/src/kikuchipy/signals/util/_master_pattern.py
+++ b/src/kikuchipy/signals/util/_master_pattern.py
@@ -99,9 +99,11 @@ def _get_direction_cosines_from_detector(
     """
     if detector.navigation_shape == (1,):
         pcx, pcy, pcz = detector.pc.squeeze().astype(np.float64)
+        gnomonic_bounds = detector.gnomonic_bounds.squeeze().astype(np.float64)
         func = _get_direction_cosines_for_fixed_pc
     else:
         pcx, pcy, pcz = detector.pc_flattened.T.astype(np.float64)
+        gnomonic_bounds = detector.gnomonic_bounds.reshape((-1, 4)).astype(np.float64)
         func = _get_direction_cosines_for_varying_pc
 
     if signal_mask is None:
@@ -109,14 +111,11 @@ def _get_direction_cosines_from_detector(
         signal_mask = np.ones(detector.size, dtype=bool)
 
     dc = func(
-        pcx=pcx,
-        pcy=pcy,
+        gnomonic_bounds=gnomonic_bounds,
         pcz=pcz,
         nrows=detector.nrows,
         ncols=detector.ncols,
-        tilt=detector.tilt,
-        azimuthal=detector.azimuthal,
-        sample_tilt=detector.sample_tilt,
+        om_detector_to_sample=(~detector.sample_to_detector).to_matrix().squeeze(),
         signal_mask=signal_mask,
     )
 
@@ -138,47 +137,39 @@ def _get_cosine_sine_of_alpha_and_azimuthal(
 
 
 @njit(
-    (
-        "float64[:, :]"
-        "(float64, float64, float64, int64, int64, float64, float64, float64, bool_[:])"
-    ),
+    ("float64[:, :]" "(float64[:], float64, int64, int64, float64[:, ::1], bool_[:])"),
     cache=True,
     nogil=True,
     fastmath=True,
 )
 def _get_direction_cosines_for_fixed_pc(
-    pcx: float,
-    pcy: float,
+    gnomonic_bounds: np.ndarray,
     pcz: float,
     nrows: int,
     ncols: int,
-    tilt: float,
-    azimuthal: float,
-    sample_tilt: float,
+    om_detector_to_sample: np.ndarray,
     signal_mask: np.ndarray,
 ) -> np.ndarray:
     """Return direction cosines for a single projection center (PC).
 
-    Algorithm adapted from EMsoft, see :cite:`callahan2013dynamical`.
+    Algorithm adapted from that used in :cite:`britton2016tutorial`.
 
     Parameters
     ----------
-    pcx
-        PC x coordinate.
-    pcy
-        PC y coordinate.
+    gnomonic_bounds
+        Bounds of the detector in gnomonic coordinates.
     pcz
         PC z coordinate.
     nrows
         Number of detector rows.
     ncols
         Number of detector columns.
-    tilt
-        Detector tilt from horizontal in degrees.
-    azimuthal
-        Sample tilt about the sample RD axis in degrees.
-    sample_tilt
-        Sample tilt from horizontal in degrees.
+    om_detector_to_sample
+        The orientation matrix which transforms
+        vectors in the detector reference frame, CSd,
+        to the sample reference frame, CSs. This is
+        the inverse rotation of the
+        EBSDDetector.sample_to_detector property.
     signal_mask
         1D signal mask with ``True`` values for pixels to get direction
         cosines for.
@@ -197,35 +188,33 @@ def _get_direction_cosines_for_fixed_pc(
     -----
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
+
+    A previous version of this algorithm was adapted from EMsoft,
+    see :cite:`callahan2013dynamical`.
     """
-    nrows_array = np.arange(nrows - 1, -1, -1)
-    ncols_array = np.arange(ncols)
+    x_scale = (gnomonic_bounds[1] - gnomonic_bounds[0]) / ncols
+    y_scale = (gnomonic_bounds[3] - gnomonic_bounds[2]) / nrows
 
-    # Bruker to EMsoft's v5 PC convention
-    xpc = ncols * (0.5 - pcx)
-    ypc = nrows * (0.5 - pcy)
-    zpc = nrows * pcz
+    det_gn_x = np.arange(gnomonic_bounds[0], gnomonic_bounds[1], x_scale)
 
-    det_x = xpc + (1 - ncols) * 0.5 + ncols_array
-    det_y = ypc - (1 - nrows) * 0.5 - nrows_array
-
-    ca, sa, cw, sw = _get_cosine_sine_of_alpha_and_azimuthal(
-        sample_tilt=sample_tilt,
-        tilt=tilt,
-        azimuthal=azimuthal,
-    )
-    Ls = -sw * det_x + zpc * cw
-    Lc = cw * det_x + zpc * sw
+    det_gn_y = np.arange(gnomonic_bounds[3], gnomonic_bounds[2], -y_scale)
 
     idx_1d = np.arange(nrows * ncols)[signal_mask]
     rows = idx_1d // ncols
     cols = np.mod(idx_1d, ncols)
+
     n_pixels = idx_1d.size
     r_g_array = np.zeros((n_pixels, 3), dtype=np.float64)
+
+    x_half_step = np.true_divide(x_scale, 2)
+    y_half_step = np.true_divide(y_scale, 2)
+
     for i in nb.prange(n_pixels):
-        r_g_array[i, 0] = det_y[rows[i]] * ca + sa * Ls[cols[i]]
-        r_g_array[i, 1] = Lc[cols[i]]
-        r_g_array[i, 2] = -sa * det_y[rows[i]] + ca * Ls[cols[i]]
+        r_g_array[i, 0] = (det_gn_x[cols[i]] + x_half_step) * pcz
+        r_g_array[i, 1] = (det_gn_y[rows[i]] - y_half_step) * pcz
+        r_g_array[i, 2] = pcz
+
+    r_g_array = np.dot(r_g_array, om_detector_to_sample)
 
     # Normalize
     norm = np.sqrt(np.sum(np.square(r_g_array), axis=-1))
@@ -238,46 +227,42 @@ def _get_direction_cosines_for_fixed_pc(
 @njit(
     (
         "float64[:, :, :]"
-        "(float64[:], float64[:], float64[:], int64, int64, float64, float64, float64, bool_[:])"
+        "(float64[:, :], float64[:], int64, int64, float64[:, ::1], bool_[:])"
     ),
     cache=True,
     nogil=True,
     fastmath=True,
 )
 def _get_direction_cosines_for_varying_pc(
-    pcx: np.ndarray,
-    pcy: np.ndarray,
+    gnomonic_bounds: np.ndarray,
     pcz: np.ndarray,
     nrows: int,
     ncols: int,
-    tilt: float,
-    azimuthal: float,
-    sample_tilt: float,
+    om_detector_to_sample: np.ndarray,
     signal_mask: np.ndarray,
 ) -> np.ndarray:
     """Return sets of direction cosines for varying projection centers
     (PCs).
 
-    Algorithm adapted from EMsoft, see :cite:`callahan2013dynamical`.
+    Algorithm adapted from that used in :cite:`britton2016tutorial`.
 
     Parameters
     ----------
-    pcx
-        PC x coordinates. Must be a 1D array.
-    pcy
-        PC y coordinates. Must be a 1D array.
+    gnomonic_bounds
+        Bounds of the detector in gnomonic coordinates, one for
+        each PC.
     pcz
-        PC z coordinates. Must be a 1D array.
+        PC z coordinate for each PC.
     nrows
         Number of detector rows.
     ncols
         Number of detector columns.
-    tilt
-        Detector tilt from horizontal in degrees.
-    azimuthal
-        Sample tilt about the sample RD axis in degrees.
-    sample_tilt
-        Sample tilt from horizontal in degrees.
+    om_detector_to_sample
+        The orientation matrix which transforms
+        vectors in the detector reference frame, CSd, to the
+        sample reference frame, CSs. One matrix valid for
+        ALL PCs. This is the inverse rotation of the
+        EBSDDetector.sample_to_detector property.
     signal_mask
         1D signal mask with ``True`` values for pixels to get direction
         cosines for.
@@ -297,42 +282,35 @@ def _get_direction_cosines_for_varying_pc(
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    nrows_array = np.arange(nrows - 1, -1, -1)
-    ncols_array = np.arange(ncols)
-
-    ca, sa, cw, sw = _get_cosine_sine_of_alpha_and_azimuthal(
-        sample_tilt=sample_tilt,
-        tilt=tilt,
-        azimuthal=azimuthal,
-    )
-
-    det_x_factor = (1 - ncols) * 0.5
-    det_y_factor = (1 - nrows) * 0.5
-
     idx_1d = np.arange(nrows * ncols)[signal_mask]
     rows = idx_1d // ncols
     cols = np.mod(idx_1d, ncols)
 
-    n_pcs = pcx.size
+    n_pcs = pcz.size
     n_pixels = idx_1d.size
     r_g_array = np.zeros((n_pcs, n_pixels, 3), dtype=np.float64)
 
     for i in nb.prange(n_pcs):
-        # Bruker to EMsoft's v5 PC convention
-        xpc = ncols * (0.5 - pcx[i])
-        ypc = nrows * (0.5 - pcy[i])
-        zpc = nrows * pcz[i]
+        x_scale = (gnomonic_bounds[i, 1] - gnomonic_bounds[i, 0]) / ncols
+        y_scale = (gnomonic_bounds[i, 3] - gnomonic_bounds[i, 2]) / nrows
 
-        det_x = xpc + det_x_factor + ncols_array
-        det_y = ypc - det_y_factor - nrows_array
+        det_gn_x = np.arange(gnomonic_bounds[i, 0], gnomonic_bounds[i, 1], x_scale)
 
-        Ls = -sw * det_x + zpc * cw
-        Lc = cw * det_x + zpc * sw
+        det_gn_y = np.arange(gnomonic_bounds[i, 3], gnomonic_bounds[i, 2], -y_scale)
+
+        x_half_step = np.true_divide(x_scale, 2)
+        y_half_step = np.true_divide(y_scale, 2)
+
+        r_g_a = np.zeros((n_pixels, 3), dtype=np.float64)
 
         for j in nb.prange(n_pixels):
-            r_g_array[i, j, 0] = det_y[rows[j]] * ca + sa * Ls[cols[j]]
-            r_g_array[i, j, 1] = Lc[cols[j]]
-            r_g_array[i, j, 2] = -sa * det_y[rows[j]] + ca * Ls[cols[j]]
+            r_g_a[j, 0] = (det_gn_x[cols[j]] + x_half_step) * pcz[i]
+            r_g_a[j, 1] = (det_gn_y[rows[j]] - y_half_step) * pcz[i]
+            r_g_a[j, 2] = pcz[i]
+
+        r_g_a = np.dot(r_g_a, om_detector_to_sample)
+
+        r_g_array[i] = r_g_a
 
     # Normalize
     norm = np.sqrt(np.sum(np.square(r_g_array), axis=-1))

--- a/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
+++ b/src/kikuchipy/simulations/kikuchi_pattern_simulator.py
@@ -255,8 +255,11 @@ class KikuchiPatternSimulator:
 
         # Transformation from detector reference frame CSd to sample
         # reference frame CSs
-        total_tilt = np.deg2rad(detector.sample_tilt - 90 - detector.tilt)
-        u_s_bruker = Rotation.from_axes_angles((-1, 0, 0), total_tilt)
+        u_sample = Rotation.from_euler([0, detector.sample_tilt, 0], degrees=True)
+        u_d = Rotation.from_euler(detector.euler, degrees=True)
+        u_d_g = u_d.to_matrix().squeeze()
+        u_detector = Rotation.from_matrix(u_d_g.T)
+        u_s_bruker = u_sample * u_detector
         u_s_rot = Rotation.from_axes_angles((0, 0, -1), -np.pi / 2) * u_s_bruker
         u_s = da.from_array(u_s_rot.to_matrix().squeeze())
 

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -112,11 +112,11 @@ class TestEBSDDetector:
     def test_repr(self, pc1):
         """Expected string representation."""
         det = kp.detectors.EBSDDetector(
-            shape=(1, 2), px_size=3, binning=4, tilt=5, azimuthal=2, pc=pc1
+            shape=(1, 2), px_size=3, binning=4, tilt=5, azimuthal=2, twist=1.02, pc=pc1
         )
         assert repr(det) == (
             "EBSDDetector(shape=(1, 2), pc=(0.421, 0.779, 0.505), sample_tilt=70.0, "
-            "tilt=5.0, azimuthal=2.0, binning=4.0, px_size=3.0 um)"
+            "tilt=5.0, azimuthal=2.0, twist=1.02, binning=4.0, px_size=3.0 um)"
         )
 
     def test_deepcopy(self, pc1):

--- a/tests/test_detectors/test_ebsd_detector.py
+++ b/tests/test_detectors/test_ebsd_detector.py
@@ -1084,12 +1084,12 @@ class TestGetIndexer:
 
 class TestSaveLoadDetector:
     @pytest.mark.parametrize(
-        "nav_shape, shape, convention, sample_tilt, tilt, px_size, binning, azimuthal",
+        "nav_shape, shape, convention, sample_tilt, tilt, px_size, binning, azimuthal, twist",
         [
-            ((3, 4), (10, 20), "bruker", 70, 0, 70, 1, 0),
-            ((1, 5), (5, 5), "tsl", 69.5, 3.14, 57.2, 2, 3.7),
-            ((4, 3), (6, 7), "emsoft", -69.5, -3.14, 57.2, 2, -3.7),
-            ((3, 2), (5, 7), "oxford", 71.3, 1.2, 90.3, 3, 0.1),
+            ((3, 4), (10, 20), "bruker", 70, 0, 70, 1, 0, 0),
+            ((1, 5), (5, 5), "tsl", 69.5, 3.14, 57.2, 2, 3.7, 0.003),
+            ((4, 3), (6, 7), "emsoft", -69.5, -3.14, 57.2, 2, -3.7, -1.23),
+            ((3, 2), (5, 7), "oxford", 71.3, 1.2, 90.3, 3, 0.1, 0.0465),
         ],
     )
     def test_save_load_detector(
@@ -1103,6 +1103,7 @@ class TestSaveLoadDetector:
         px_size,
         binning,
         azimuthal,
+        twist,
     ):
         det0 = kp.detectors.EBSDDetector(
             shape=shape,
@@ -1112,6 +1113,7 @@ class TestSaveLoadDetector:
             px_size=px_size,
             binning=binning,
             azimuthal=azimuthal,
+            twist=twist,
             convention=convention,
         )
         det1 = det0.extrapolate_pc(
@@ -1133,6 +1135,7 @@ class TestSaveLoadDetector:
         assert np.isclose(det2.px_size, det1.px_size)
         assert det2.binning == det1.binning
         assert np.isclose(det2.azimuthal, det1.azimuthal)
+        assert np.isclose(det2.twist, det1.twist)
 
     def test_save_detector_raises(self, tmp_path):
         det = kp.detectors.EBSDDetector()

--- a/tests/test_indexing/test_ebsd_refinement.py
+++ b/tests/test_indexing/test_ebsd_refinement.py
@@ -1220,6 +1220,7 @@ class TestEBSDRefineOrientationPC(EBSDRefineTestSetup):
         # Global: Differential evolution
         _, _ = s.refine_orientation_projection_center(
             method="differential_evolution",
+            trust_region=[2, 2, 2, 0.05, 0.05, 0.05],
             navigation_mask=nav_mask,
             **ref_kw,
         )

--- a/tests/test_io/test_nordif.py
+++ b/tests/test_io/test_nordif.py
@@ -294,7 +294,7 @@ class TestNORDIF:
         assert isinstance(s.data, np.ndarray)
         assert not isinstance(s.data, np.memmap)
 
-    def test_load_readonly(self, nordif_path):
+    def test_load_memmap(self, nordif_path):
         s = kp.load(nordif_path / "Pattern.dat", lazy=True)
         keys = ["array-original", "original-array"]
         k = next(
@@ -305,7 +305,6 @@ class TestNORDIF:
         )
         mm = s.data.dask[k]
         assert isinstance(mm, np.memmap)
-        assert not mm.flags["WRITEABLE"]
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_load_inplace(self, nordif_path, assert_dictionary_func, lazy):

--- a/tests/test_signals/test_ebsd_master_pattern.py
+++ b/tests/test_signals/test_ebsd_master_pattern.py
@@ -25,7 +25,6 @@ import pytest
 
 import kikuchipy as kp
 from kikuchipy.signals.util._master_pattern import (
-    _get_cosine_sine_of_alpha_and_azimuthal,
     _get_direction_cosines_for_fixed_pc,
     _get_direction_cosines_for_varying_pc,
     _get_direction_cosines_from_detector,
@@ -491,13 +490,6 @@ class TestProjectFromLambert:
             mp, nii[0], nij[0], niip[0], nijp[0], di[0], dj[0], dim[0], djm[0]
         )
         assert np.isclose(value, 1)
-
-    def test_get_cosine_sine_of_alpha_and_azimuthal(self):
-        """Make sure the Numba function is covered."""
-        values = _get_cosine_sine_of_alpha_and_azimuthal.py_func(
-            sample_tilt=70, tilt=10, azimuthal=5
-        )
-        assert np.allclose(values, [0.866, 0.5, 0.996, 0.087], atol=1e-3)
 
     def test_get_direction_cosines_for_multiple_pcs(self):
         """Make sure the Numba function is covered."""

--- a/tests/test_signals/test_ebsd_master_pattern.py
+++ b/tests/test_signals/test_ebsd_master_pattern.py
@@ -16,6 +16,7 @@
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
 import dask.array as da
+from diffsims.crystallography import ReciprocalLatticeVector
 from hyperspy._signals.signal2d import Signal2D
 import hyperspy.api as hs
 import numpy as np
@@ -24,6 +25,11 @@ from orix.quaternion import Rotation
 import pytest
 
 import kikuchipy as kp
+from kikuchipy._utils._detector_coordinates import (
+    convert_coordinates,
+    get_coordinate_conversions,
+)
+from kikuchipy._utils.numba import rotate_vector
 from kikuchipy.signals.util._master_pattern import (
     _get_direction_cosines_for_fixed_pc,
     _get_direction_cosines_for_varying_pc,
@@ -769,3 +775,388 @@ class TestLambertProjection:
         ]
         assert np.allclose(_vector2lambert.py_func(xyz), lambert_xy)
         assert np.allclose(_vector2lambert(xyz), lambert_xy)
+
+
+class TestFitPatternDetectorOrientation:
+    """
+    Test the fit between an EBSD pattern generated
+    from a master pattern and an associated
+    GeometricalKikuchiPatternSimulation for different
+    detector orientations.
+    """
+
+    detector = kp.detectors.EBSDDetector(
+        shape=(480, 640), px_size=50, pc=(20, 20, 15000), convention="emsoft4"
+    )
+
+    phase = kp.data.nickel_ebsd_master_pattern_small().phase
+
+    hkl = [(1, 1, 1), (2, 0, 0), (2, 2, 0), (3, 1, 1)]
+
+    ref = ReciprocalLatticeVector(phase=phase, hkl=hkl)
+    ref = ref.symmetrise()
+
+    simulator = kp.simulations.KikuchiPatternSimulator(ref)
+
+    rotations = Rotation.from_euler([23, 14, 5], degrees=True)
+
+    # Transformation from CSs to cartesian crystal reference frame CSc
+    u_o = rotations.to_matrix().squeeze()
+
+    # Transformation from CSc to direct crystal reference frame CSk
+    u_a = phase.structure.lattice.base
+
+    def setup_detector_sim_and_u_os(self, tilt, azimuthal, twist):
+        det = self.detector.deepcopy()
+        det.tilt = tilt
+        det.azimuthal = azimuthal
+        det.twist = twist
+
+        sim_lines = self.simulator.on_detector(det, self.rotations)
+
+        u_os = np.matmul(self.u_o, det.sample_to_detector.to_matrix().squeeze())
+
+        return det, sim_lines, u_os
+
+    def setup_za_and_cds(self, zone_axes, sim_lines, det):
+        """Find the indices of the zone_axes in the
+        GeometricalKikuchiPatternSimulation (sim_lines).
+        Find the gnomonic coordinates of these zone axes.
+        Then obtain convert these into pixel coordinates
+        on the detector and round to the nearest pixel.
+        Return the indices of the zone axes, the
+        conversion dict from pix to gn and back, and
+        the coordinates of the nearest detector pixels
+        to the three zone axes.
+        """
+        za_idx = [
+            index_row_in_array(sim_lines._zone_axes.vector.uvw, i) for i in zone_axes
+        ]
+
+        x_gn = sim_lines._zone_axes.x_gnomonic[0, za_idx]
+        y_gn = sim_lines._zone_axes.y_gnomonic[0, za_idx]
+        cds_gn = np.stack((x_gn, y_gn), axis=1)
+
+        conversions = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+        cds_px = convert_coordinates(cds_gn, "gn_to_pix", conversions)
+
+        cds_px_int = np.squeeze(np.around(cds_px, decimals=0).astype(int))
+
+        return za_idx, conversions, cds_px_int
+
+    def get_a_angles(self, sim_lines, za_idx, u_os):
+        """Check that the GeometricalKikuchiPatternSimulation
+        is self-consistent. We do this by taking the vectors
+        in the detector reference frame of 3 zone axes in
+        the simulation, transforming these vectors from CSd
+        to the cartesian crystal reference frame, CSc, and
+        measuring the angle between these and vectors
+        transformed from the uvw indices of the zone axes
+        into the cartesian crystal reference frame
+        i.e. CSk to CSc. These angles (a_ang) should all be
+        zero if the GeometricalKikuchiPatternSimulation is
+        self-consistent. This is tested later.
+        The a_ang are returned.
+        """
+        # CSk to CSc:
+        uvw = sim_lines._zone_axes.vector.uvw[za_idx]
+        d_vec = np.matmul(uvw, self.u_a)
+        N1 = np.sqrt(np.sum(np.square(d_vec), axis=1))
+        d_vec_n = d_vec / np.expand_dims(N1, 1)
+
+        # CSd to CSc:
+        za_vec = sim_lines._zone_axes.vector_detector[0, za_idx].data
+        za_vec_trans = np.matmul(za_vec, np.linalg.inv(u_os)).squeeze()
+        N2 = np.sqrt(np.sum(np.square(za_vec_trans), axis=1))
+        za_vec_trans_n = za_vec_trans / np.expand_dims(N2, 1)
+
+        # angles between the two sets of vectors:
+        a_ang = np.array(
+            [
+                np.rad2deg(
+                    np.arccos(
+                        np.around(
+                            np.dot(za_vec_trans_n[i, :], d_vec_n[i, :]), decimals=8
+                        )
+                    )
+                )
+                for i in range(3)
+            ]
+        )
+
+        return a_ang, d_vec_n
+
+    def get_d_ang(self, cds_px_int, conversions, u_os, d_vec_n, det):
+        """Find the gnomonic coordinates of the nearest
+        pixel centre to each of the 3 zone axes. Turn them
+        into vectors and transform them from CSd to CSc using
+        the same transformation as the
+        GeometricalKikuchiPatternSimulation. Then
+        calculate the angles (d_ang) between these vectors
+        and the vectors representing the zone axes in CSc but
+        calculated from CSk to CSc (d_vec_n).
+        """
+        # Here we add 0.5 because pixel centres are used by the direction
+        # cosines method and we need to take the same coords for this
+        # alternative approach.
+        cds_gn_int = np.squeeze(
+            convert_coordinates(cds_px_int + 0.5, "pix_to_gn", conversions)
+        )
+
+        vecs = np.hstack(
+            (
+                cds_gn_int * det.pcz,
+                np.repeat(np.atleast_2d(det.pcz), cds_gn_int.shape[0], axis=0),
+            )
+        )
+        N3 = np.sqrt(np.sum(np.square(vecs), axis=1))
+        vecs_n = vecs / np.expand_dims(N3, 1)
+
+        # CSd to CSc:
+        dddd = np.matmul(vecs_n, np.linalg.inv(u_os)).squeeze()
+
+        d_ang = np.array(
+            [
+                np.rad2deg(
+                    np.arccos(np.around(np.dot(dddd[i, :], d_vec_n[i, :]), decimals=8))
+                )
+                for i in range(3)
+            ]
+        )
+
+        return d_ang, dddd
+
+    def get_r_ang_and_n_ang(self, cds_px_int, det, d_vec_n, dddd):
+        """Calculate the direction cosines of all the
+        detector pixels then rotate them to account
+        for the crystal orientation. The resulting
+        vectors are in CSc. Select the vectors
+        corresponding to the pixel centres representing the 3
+        zone axes. Then calculate the angles (r_ang) between
+        these vectors and the vectors representing the
+        zone axes in CSc but calculated from CSk to CSc
+        (d_vec_n). Finally calculate the angles (n_ang) between
+        the two sets of vectors representing the centres of the
+        nearest pixels to the zone axes (one set is from the direction
+        cosines of the detecotr, the other is from the
+        GeometricalKikuchiPatternSimulation). The angles are
+        zero if the transformations used for the direction
+        cosines and for the GeometricalKikuchiPatternSimulation
+        are the same (this is tested later).
+        """
+        # swap columns for i,j array indexing:
+        cds_px_int_ij = cds_px_int[:, ::-1]
+
+        # all detector pixels:
+        r_g_array = _get_direction_cosines_from_detector(det)
+        r_g_array_rot = rotate_vector(self.rotations.data[0], r_g_array)
+        rgarrrot_reshaped = r_g_array_rot.reshape((*self.detector.shape, 3))
+
+        # select vectors corresponding to the nearest pixels to the chosen zone axes
+        rgrar_vec = rgarrrot_reshaped[cds_px_int_ij[:, 0], cds_px_int_ij[:, 1]]
+
+        r_ang = np.array(
+            [
+                np.rad2deg(
+                    np.arccos(
+                        np.around(np.dot(d_vec_n[i, :], rgrar_vec[i, :]), decimals=8)
+                    )
+                )
+                for i in range(3)
+            ]
+        )
+
+        n_ang = np.array(
+            [
+                np.rad2deg(
+                    np.arccos(
+                        np.around(np.dot(dddd[i, :], rgrar_vec[i, :]), decimals=8)
+                    )
+                )
+                for i in range(3)
+            ]
+        )
+
+        return r_ang, n_ang
+
+    def calculate_fit(self, tilt, azimuthal, twist, zone_axes):
+        """
+         Calculates four sets of angles with which the fit
+         between the EBSD pattern simulated from a master
+         pattern, and the GeometricalKikuchiPatternSimulation
+         generated using the same parameters, can be evaluated.
+         The function can be tested with different values of
+         the detector tilt, azimuthal and euler_2 angles and
+         appropriate zone axes (indices uvw) which appear on
+         the pattern under those conditions.
+
+         The approach has several steps:
+
+         1. Check that the GeometricalKikuchiPatternSimulation
+         is self-consistent. We do this by taking the vectors
+         in the detector reference frame of 3 zone axes in
+         the simulation, transforming these vectors from CSd
+         to the cartesian crystal reference frame, CSc, and
+         measuring the angle between these and vectors
+         transformed from the uvw indices of the zone axes
+         into the cartesian crystal reference frame
+         i.e. CSk to CSc. These angles (a_ang) should all be
+         zero if the GeometricalKikuchiPatternSimulation is
+         self-consistent.
+
+         2. Find the gnomonic coordinates of the nearest
+         pixel centre to the 3 zone axes. This enables us
+         to check the vectors corresponding to the detector
+         pixels. We do two things with these coordinates.
+         a) turn them into vectors and transform them
+         from CSd to CSc using the same transformation as
+         the GeometricalKikuchiPatternSimulation. Then
+         calculate the angles (d_ang) between these vectors
+         and the vectors representing the zone axes in CSc.
+         b) calculate the direction cosines of all the
+         detector pixels then rotate them to account
+         for the crystal orientation. The resulting
+         vectors are in CSc but calculated using
+         different functions. Select the vectors
+         corresponding to the pixels representing the 3
+         zone axes. Then calculate the angles (r_ang) between
+         these vectors and the vectors representing the
+         zone axes in CSc.
+         These angles should be the same for a) and b),
+         meaning that the angle between the zone axes
+         and the centre of the nearest pixel is the
+         same for both transformation routes.
+
+         3. Finally calculate the angles (n_ang) between the two
+         sets of vectors representing the centres of the
+         nearest pixels to the zone axes. The angles are
+         zero if the transformations used for the direction
+         cosines and for the GeometricalKikuchiPatternSimulation
+         are the same.
+
+
+         Parameters
+         ----------
+         tilt : Float
+             The detector tilt angle in degrees (i.e. detector.tilt).
+             Detector Euler angle PHI (EBSDDetector.euler[1]) == 90 + tilt
+         azimuthal : Float
+             The detector azimuthal angle in degrees (i.e. detector.azimuthal).
+             Detector Euler angle phi1 (EBSDDetector.euler[0]) == azimuthal
+        twist : Float
+             The detector twist angle (EBSDDetector.euler[2]) in deg.
+         zone_axes : List or np.ndarray
+             List/array containing three lists, each containing a set
+             of uvw indices describing a zone axis on the pattern,
+             e.g. [[0,0,1], [1,1,0], [1,2,3]].
+
+         Returns
+         -------
+         a_ang : np.ndarray
+             The angles in degrees, between vectors in CSc calculated
+             1) from uvw indeces in CSk and 2) from vectors in CSd.
+             These should all be zero for self-consistency of
+             the GeometricalKikuchiPatternSimulation.
+         d_ang : np.ndarray
+             The angles in degrees, between vectors representing
+             3 zone axes on the pattern and vectors representing
+             the nearest pixel centres to the same zone axes.
+             Both sets of vectors are transformed into CSc.
+             The transformation for both sets was the one used
+             by the GeometricalKikuchiPatternSimulation.
+         r_ang : np.ndarray
+             The angles in degrees, between vectors representing
+             3 zone axes on the pattern and vectors representing
+             the nearest pixel centres to the same zone axes but
+             this time, the pixel centre vectors use the
+             transformation of the direction cosines of the
+             detector pixels.
+         n_ang : np.ndarray
+             The angles in degrees between the two sets of vectors
+             representing the centres of the nearest pixels to 3
+             zone axes on the pattern. Both sets of vectors are
+             in CSc. The transformation for one set was the one
+             used by the GeometricalKikuchiPatternSimulation,
+             and the one used by the other set was for the
+             direction cosines of the detector. These angles
+             should all be zero if the pattern and simulation
+             match.
+        """
+        det, sim_lines, u_os = self.setup_detector_sim_and_u_os(tilt, azimuthal, twist)
+        za_idx, conversions, cds_px_int = self.setup_za_and_cds(
+            zone_axes, sim_lines, det
+        )
+        a_ang, d_vec_n = self.get_a_angles(sim_lines, za_idx, u_os)
+        d_ang, dddd = self.get_d_ang(cds_px_int, conversions, u_os, d_vec_n, det)
+        r_ang, n_ang = self.get_r_ang_and_n_ang(cds_px_int, det, d_vec_n, dddd)
+
+        return a_ang, d_ang, r_ang, n_ang
+
+    @pytest.mark.parametrize(
+        "tilt, azimuthal, twist, zone_axes",
+        [
+            (0.0, 0.0, 0.0, [[1, 0, 1], [0, 0, 1], [1, 1, 2]]),
+            (0.0, 0.0, 1.2, [[1, 0, 1], [0, 0, 1], [1, 1, 2]]),
+            (40.0, 0.0, 0.0, [[1, 0, 1], [1, 0, 0], [1, -2, 1]]),
+            (40.0, 0.0, 1.2, [[1, 0, 1], [1, 0, 0], [1, -2, 1]]),
+            (0.0, 40.0, 0.0, [[1, 0, 1], [1, 1, 0], [1, 2, 1]]),
+            (0.0, 40.0, 1.2, [[1, 0, 1], [1, 1, 0], [1, 2, 1]]),
+            (40.0, 40.0, 0.0, [[1, 0, 1], [1, 0, 0], [3, 1, 0]]),
+            (40.0, 40.0, 1.2, [[1, 0, 1], [1, 0, 0], [3, 1, 0]]),
+        ],
+    )
+    def test_fit_detector_orientation(self, tilt, azimuthal, twist, zone_axes):
+        """
+        Check that the EBSD pattern simulated from a master
+        pattern and the associated
+        GeometricalKikuchiPatternSimulation match perfectly,
+        for various detector orientations.
+
+        4 sets of angles are returned by self.calculate_fit().
+        See the doctstring of that function for details.
+
+        Here we assert that the first set of angles are all
+        zero, that the second and third sets are equal, and
+        that the fourth set are all zero. If these conditions
+        are all met, the GeometricalKikuchiPatternSimulation
+        should match the EBSD pattern simulated from a
+        master pattern perfectly for the given detector
+        orientations.
+
+
+        Parameters
+        ----------
+        tilt : Float
+            The detector tilt angle in degrees (i.e. detector.tilt).
+            Detector Euler angle PHI (EBSDDetector.euler[1]) == 90 + tilt
+        azimuthal : Float
+            The detector azimuthal angle in degrees (i.e. detector.azimuthal).
+            Detector Euler angle phi1 (EBSDDetector.euler[0]) == azimuthal
+        twist : Float
+            The detector twist angle (EBSDDetector.euler[2]) in deg.
+        zone_axes : List or np.ndarray
+            List/array containing three lists, each containing a set
+            of uvw indices describing a zone axis on the pattern,
+            e.g. [[0,0,1], [1,1,0], [1,2,3]].
+
+        Returns
+        -------
+        None.
+
+        """
+        angles = self.calculate_fit(tilt, azimuthal, twist, zone_axes)
+
+        assert np.allclose(angles[0], 0.0)
+        assert np.allclose(angles[1], angles[2])
+        assert np.allclose(angles[3], 0.0)
+
+
+def index_row_in_array(myarray, myrow):
+    """Check if the row "myrow" is present in the array "myarray".
+    If it is, return an int containing the row index of the first
+    occurrence. If the row is not present, return None.
+    """
+    loc = np.where((myarray == myrow).all(-1))[0]
+    if len(loc) > 0:
+        return loc[0]
+    return None

--- a/tests/test_utils/test_detector_coordinates.py
+++ b/tests/test_utils/test_detector_coordinates.py
@@ -1,0 +1,319 @@
+# Copyright 2019-2024 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+import kikuchipy as kp
+from kikuchipy._utils._detector_coordinates import (
+    _convert_coordinates,
+    convert_coordinates,
+    get_coordinate_conversions,
+)
+
+
+class TestDetectorCoordinates:
+    s = kp.data.nickel_ebsd_small()
+    det_1d = kp.detectors.EBSDDetector(shape=(60, 60), pc=s.detector.pc[0,])
+    det_2d = s.detector.deepcopy()
+    conv_1d = get_coordinate_conversions(det_1d.gnomonic_bounds, det_1d.bounds)
+    conv_2d = get_coordinate_conversions(det_2d.gnomonic_bounds, det_2d.bounds)
+    coords_5d = np.random.randint(0, 60, (3, 3, 17, 300, 2))
+    coords_4d = coords_5d[:, :, 0]  # (3, 3, 300, 2)
+    coords_3d = coords_5d[0, 0]  # (17, 300, 2)
+    coords_2d = coords_5d[0, 0, 0]  # (300, 2)
+
+    def test_get_conversion_factors(self):
+        conv_1d = get_coordinate_conversions(
+            self.det_1d.gnomonic_bounds, self.det_1d.bounds
+        )
+
+        exp_res_1d = {
+            "pix_to_gn": {
+                "m_x": np.array([0.03319923, 0.03326385, 0.03330547]),
+                "c_x": np.array([-0.83957734, -0.84652344, -0.85204404]),
+                "m_y": np.array([-0.03319923, -0.03326385, -0.03330547]),
+                "c_y": np.array([0.42827701, 0.41940433, 0.42255835]),
+            },
+            "gn_to_pix": {
+                "m_x": np.array([30.12118421, 30.06266362, 30.02509794]),
+                "c_x": np.array([25.28906376, 25.4487495, 25.58270568]),
+                "m_y": np.array([-30.12118421, -30.06266362, -30.02509794]),
+                "c_y": np.array([12.90021062, 12.60841133, 12.6873559]),
+            },
+        }
+
+        for i in ["pix_to_gn", "gn_to_pix"]:
+            for j in ["m_x", "c_x", "m_y", "c_y"]:
+                assert np.allclose(conv_1d[i][j], exp_res_1d[i][j])
+
+    @pytest.mark.parametrize(
+        "coords, detector_index, desired_coords",
+        [
+            (
+                np.array([[36.2, 12.7]]),
+                None,
+                np.array(
+                    [
+                        [[[0.36223463, 0.00664684]], [[0.357628, -0.00304659]]],
+                        [[[0.36432453, 0.00973462]], [[0.35219232, 0.00567801]]],
+                    ]
+                ),
+            ),
+            (
+                np.array([[36.2, 12.7], [2.5, 43.7], [8.2, 27.7]]),
+                (0, 1),
+                np.array(
+                    [
+                        [0.35762801, -0.00304659],
+                        [-0.76336381, -1.03422601],
+                        [-0.57375985, -0.50200438],
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_coordinate_conversions_correct(
+        self, coords, detector_index, desired_coords
+    ):
+        """Coordinate conversion factors have expected values."""
+        pc = np.array(
+            [
+                [
+                    [0.4214844, 0.21500351, 0.50201974],
+                    [0.42414583, 0.21014019, 0.50104439],
+                ],
+                [
+                    [0.42088203, 0.2165417, 0.50079336],
+                    [0.42725023, 0.21450546, 0.49996293],
+                ],
+            ]
+        )
+        det = kp.detectors.EBSDDetector(shape=(60, 60), pc=pc)
+        conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+        cds_out = convert_coordinates(coords, "pix_to_gn", conv, detector_index)
+        cds_back = convert_coordinates(cds_out, "gn_to_pix", conv, detector_index)
+        assert np.allclose(cds_out, desired_coords)
+        assert np.allclose(cds_back[..., :], coords[..., :])
+
+    @pytest.mark.parametrize(
+        "coords, detector_index, desired_coords",
+        [
+            (
+                np.array([[36.2, 12.7]]),
+                None,
+                np.array(
+                    [
+                        [[[0.36223463, 0.00664684]], [[0.357628, -0.00304659]]],
+                        [[[0.36432453, 0.00973462]], [[0.35219232, 0.00567801]]],
+                    ]
+                ),
+            ),
+            (
+                np.array([[36.2, 12.7], [2.5, 43.7], [8.2, 27.7]]),
+                (0, 1),
+                np.array(
+                    [
+                        [0.35762801, -0.00304659],
+                        [-0.76336381, -1.03422601],
+                        [-0.57375985, -0.50200438],
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_coordinate_conversions_correct_worker(
+        self, coords, detector_index, desired_coords
+    ):
+        """Worker function coordinate conversion factors have expected values."""
+        pc = np.array(
+            [
+                [
+                    [0.4214844, 0.21500351, 0.50201974],
+                    [0.42414583, 0.21014019, 0.50104439],
+                ],
+                [
+                    [0.42088203, 0.2165417, 0.50079336],
+                    [0.42725023, 0.21450546, 0.49996293],
+                ],
+            ]
+        )
+        det = kp.detectors.EBSDDetector(shape=(60, 60), pc=pc)
+        conv = get_coordinate_conversions(det.gnomonic_bounds, det.bounds)
+        nav_shape = conv["pix_to_gn"]["m_x"].shape
+        nav_ndim = len(nav_shape)
+
+        if isinstance(detector_index, type(None)):
+            detector_index = ()
+            if coords.ndim >= nav_ndim + 2 and coords.shape[:nav_ndim] == nav_shape:
+                # one or more sets of coords, different for each image
+                out_shape = coords.shape
+            else:
+                # one or more sets of coords, the same for each image
+                out_shape = nav_shape + coords.shape
+
+            extra_axes = list(range(nav_ndim, len(out_shape) - 1))
+            cds_out = _convert_coordinates(
+                coords,
+                out_shape,
+                detector_index,
+                np.expand_dims(conv["pix_to_gn"]["m_x"], extra_axes),
+                np.expand_dims(conv["pix_to_gn"]["c_x"], extra_axes),
+                np.expand_dims(conv["pix_to_gn"]["m_y"], extra_axes),
+                np.expand_dims(conv["pix_to_gn"]["c_y"], extra_axes),
+            )
+
+            cds_back = _convert_coordinates(
+                cds_out,
+                out_shape,
+                detector_index,
+                np.expand_dims(conv["gn_to_pix"]["m_x"], extra_axes),
+                np.expand_dims(conv["gn_to_pix"]["c_x"], extra_axes),
+                np.expand_dims(conv["gn_to_pix"]["m_y"], extra_axes),
+                np.expand_dims(conv["gn_to_pix"]["c_y"], extra_axes),
+            )
+
+        else:
+            out_shape = coords.shape
+
+            cds_out = _convert_coordinates(
+                coords,
+                out_shape,
+                detector_index,
+                conv["pix_to_gn"]["m_x"],
+                conv["pix_to_gn"]["c_x"],
+                conv["pix_to_gn"]["m_y"],
+                conv["pix_to_gn"]["c_y"],
+            )
+
+            cds_back = _convert_coordinates(
+                cds_out,
+                out_shape,
+                detector_index,
+                conv["gn_to_pix"]["m_x"],
+                conv["gn_to_pix"]["c_x"],
+                conv["gn_to_pix"]["m_y"],
+                conv["gn_to_pix"]["c_y"],
+            )
+
+        assert np.allclose(cds_out, desired_coords)
+        assert np.allclose(cds_back[..., :], coords[..., :])
+
+    def test_coordinate_conversions_indexing(self):
+        """Converting from pixel to gnomonic coords and back."""
+        # conversions
+        cds_out5d_1 = convert_coordinates(
+            self.coords_5d, "pix_to_gn", self.conv_2d, None
+        )
+        cds_out5d_2 = convert_coordinates(
+            self.coords_5d, "pix_to_gn", self.conv_2d, (1, 2)
+        )
+
+        cds_out4d_1 = convert_coordinates(
+            self.coords_4d, "pix_to_gn", self.conv_2d, None
+        )
+        cds_out4d_2 = convert_coordinates(
+            self.coords_4d, "pix_to_gn", self.conv_2d, (1, 2)
+        )
+
+        cds_out3d_1 = convert_coordinates(
+            self.coords_3d, "pix_to_gn", self.conv_2d, None
+        )
+        cds_out3d_2 = convert_coordinates(
+            self.coords_3d, "pix_to_gn", self.conv_2d, (1, 2)
+        )
+
+        cds_out2d_1 = convert_coordinates(
+            self.coords_2d, "pix_to_gn", self.conv_2d, None
+        )
+        cds_out2d_2 = convert_coordinates(
+            self.coords_2d, "pix_to_gn", self.conv_2d, (1, 2)
+        )
+
+        cds_out5d_3 = convert_coordinates(
+            self.coords_5d, "pix_to_gn", self.conv_1d, None
+        )
+        cds_out5d_4 = convert_coordinates(
+            self.coords_5d, "pix_to_gn", self.conv_1d, (1)
+        )
+        cds_out5d_5 = convert_coordinates(self.coords_5d, "pix_to_gn", self.conv_1d, 1)
+
+        cds_out4d_3 = convert_coordinates(
+            self.coords_4d, "pix_to_gn", self.conv_1d, None
+        )
+        cds_out4d_4 = convert_coordinates(
+            self.coords_4d, "pix_to_gn", self.conv_1d, (1,)
+        )
+        cds_out4d_5 = convert_coordinates(self.coords_4d, "pix_to_gn", self.conv_1d, 1)
+
+        cds_out3d_3 = convert_coordinates(
+            self.coords_3d, "pix_to_gn", self.conv_1d, None
+        )
+        cds_out3d_4 = convert_coordinates(
+            self.coords_3d, "pix_to_gn", self.conv_1d, (1,)
+        )
+        cds_out3d_5 = convert_coordinates(self.coords_3d, "pix_to_gn", self.conv_1d, 1)
+
+        cds_out2d_3 = convert_coordinates(
+            self.coords_2d, "pix_to_gn", self.conv_1d, None
+        )
+        cds_out2d_4 = convert_coordinates(
+            self.coords_2d, "pix_to_gn", self.conv_1d, (1,)
+        )
+        cds_out2d_5 = convert_coordinates(self.coords_2d, "pix_to_gn", self.conv_1d, 1)
+
+        # convert back
+        cds_back_5d_1 = convert_coordinates(
+            cds_out5d_1, "gn_to_pix", self.conv_2d, None
+        )
+        cds_back_4d_1 = convert_coordinates(
+            cds_out4d_1, "gn_to_pix", self.conv_2d, None
+        )
+        cds_back_3d_1 = convert_coordinates(
+            cds_out3d_1, "gn_to_pix", self.conv_2d, None
+        )
+        cds_back_2d_1 = convert_coordinates(
+            cds_out2d_1, "gn_to_pix", self.conv_2d, None
+        )
+
+        # indexing checks
+        assert np.allclose(cds_out5d_2[1, 2], cds_out5d_1[1, 2])
+        assert np.allclose(cds_out4d_2[1, 2], cds_out4d_1[1, 2])
+        assert np.allclose(cds_out3d_2, cds_out3d_1[1, 2])
+        assert np.allclose(cds_out2d_2, cds_out2d_1[1, 2])
+
+        assert np.allclose(cds_out5d_4[1], cds_out5d_3[1])
+        assert np.allclose(cds_out5d_5, cds_out5d_4)
+        assert np.allclose(cds_out4d_4[1], cds_out4d_3[1])
+        assert np.allclose(cds_out4d_5, cds_out4d_4)
+        assert np.allclose(cds_out3d_4, cds_out3d_3[1])
+        assert np.allclose(cds_out3d_5, cds_out3d_4)
+        assert np.allclose(cds_out2d_4, cds_out2d_3[1])
+        assert np.allclose(cds_out2d_5, cds_out2d_4)
+
+        # back-conversion checks
+        assert np.allclose(cds_back_5d_1, self.coords_5d)
+        assert np.allclose(cds_back_4d_1, self.coords_4d)
+        assert np.allclose(cds_back_3d_1, self.coords_3d)
+        assert np.allclose(cds_back_2d_1, self.coords_2d)
+
+        for i in range(3):
+            for j in range(3):
+                q = convert_coordinates(
+                    self.coords_5d[i, j], "pix_to_gn", self.conv_2d, (i, j)
+                )
+                assert np.allclose(q, cds_out5d_1[i, j])

--- a/tests/test_utils/test_gnomonic_bounds.py
+++ b/tests/test_utils/test_gnomonic_bounds.py
@@ -1,0 +1,36 @@
+# Copyright 2019-2024 The kikuchipy developers
+#
+# This file is part of kikuchipy.
+#
+# kikuchipy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kikuchipy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+import kikuchipy as kp
+from kikuchipy._utils._gnonomic_bounds import get_gnomonic_bounds
+
+
+class TestGnomonicBounds:
+    s = kp.data.nickel_ebsd_small()
+    det_1d = kp.detectors.EBSDDetector(shape=(1024, 1244), pc=s.detector.pc[0, 0])
+    nrows = det_1d.nrows
+    ncols = det_1d.ncols
+    pcx = det_1d.pcx[0]
+    pcy = det_1d.pcy[0]
+    pcz = det_1d.pcz[0]
+
+    def test_gnomonic_bounds(self):
+        gn_b = get_gnomonic_bounds(self.nrows, self.ncols, self.pcx, self.pcy, self.pcz)
+
+        assert np.allclose(gn_b, np.squeeze(self.det_1d.gnomonic_bounds))

--- a/tests/test_utils/test_rotation.py
+++ b/tests/test_utils/test_rotation.py
@@ -35,15 +35,15 @@ class TestRotationVectorTools:
         """
         rot = np.array([0.7071, 0.7071, 0, 0])
         sig_shape = (20, 30)
+        det = kp.detectors.EBSDDetector(
+            shape=sig_shape, pc=(0.5, 0.5, 0.5), sample_tilt=70, tilt=10, azimuthal=0
+        )
         dc = _get_direction_cosines_for_fixed_pc.py_func(
-            pcx=0.5,
-            pcy=0.5,
-            pcz=0.5,
-            nrows=sig_shape[0],
-            ncols=sig_shape[1],
-            tilt=10,
-            azimuthal=0,
-            sample_tilt=70,
+            gnomonic_bounds=det.gnomonic_bounds.squeeze().astype(np.float64),
+            pcz=det.pc.squeeze().astype(np.float64)[2],
+            nrows=det.nrows,
+            ncols=det.ncols,
+            om_detector_to_sample=(~det.sample_to_detector).to_matrix().squeeze(),
             signal_mask=np.ones(sig_shape[0] * sig_shape[1], dtype=bool),
         )
 


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Hi @hakonanes and the kikuchipy team,
firstly, many thanks for kikuchipy - it's a great library which we use a lot in our work!

The focus of this PR is to include the detector Euler angles as a means of describing the full orientation of the detector and to use these in simulating EBSD patterns from master patterns and in producing lines to overlay on those patterns using `KikuchiPatternSimulator.on_detector()`.

To achieve this, the following main changes have been made:

1. Added a property "euler" to `EBSDDetector`, which is used to describe the full orientation of the detector via the Euler angles (in degrees). 
    - As `EBSDDetector.euler[0]` is the same as `EBSDDetector.azimuthal` and `EBSDDetector.euler[1]` is the same as `EBSDDetector.tilt + 90`, getters and setters for `EBSDDetector.tilt`, `EBSDDetector.azimuthal` and `EBSDDetector.euler` have been added, which ensure consistency with the other properties when setting one of them. 
    - Tests have been added to check the consistency when setting these properties. 
    - Added the euler to `EBSDDetector.__repr__()`. 
    - Added properties "u_s" and "u_s_inv" to `EBSDDetector`, which are orientation matrices used to transform from CSs to CSd and the reverse. The matrix "u_s_inv" is used in the new functions for getting the direction cosines of the detector (see 3.).
2. Modified `KikuchiPatternSimulator.on_detector()` so that the euler angles of the detector are now used in calculating the orientation matrix "u_s_bruker". Previously, only the  `EBSDDetector.tilt` seemed to be considered.
3. Modified functions for getting direction cosines of the detector pixels (these are in kikuchipy/signals/util/_master_pattern.py). The new approach uses the gnomonic coordinates of the `EBSDDetector` and orientation matrices, which consider all three detector euler angles (previously only tilt and azimuthal were considered). 
    - Removed the now unneeded function,  `_get_cosine_sine_of_alpha_and_azimuthal()`, 
    - updated all tests calling the functions for direction cosines and 
    - updated the signatures of the direction cosine functions in the objective functions and solvers for indexing.
4. Added a new test class `TestFitPatternDetectorOrientation` to tests/test_signals/test_ebsd_master_pattern.py. This checks the fit between an EBSD pattern simulated from a master pattern and the associated `GeometricalKikuchiPatternSimulation`. This seemed to be worth testing because with the current version of the functions to get the direction cosines from the detector, there was a rotation of the EBSD simulation from the master pattern compared to the `GeometricalKikuchiPatternSimulation` if *both* tilt and azimuthal were non-zero:
![current_method_tilt_40_azimuthal_40](https://github.com/user-attachments/assets/979db514-0218-4997-aa3d-24f284f3c3f0)
Whereas with the new method for getting the direction cosines in this PR, the EBSD pattern and `GeometricalKikuchiPatternSimulation` fit perfectly for *any* combination of detector euler angles:
![new_method_tilt_40_azimuthal_40](https://github.com/user-attachments/assets/a7d2b758-3dc5-4d04-ad4e-43f66380e9e3)


The entire kikuchipy test suite passes. I was not able to build the documentation on Windows but I think everything should be fine with the tutorial notebooks.



#### Progress of the  #PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> import kikuchipy as kp
>>> det = kp.detectors.EBSDDetector()
>>> det
<EBSDDetector(shape=(1, 1), pc=(0.5, 0.5, 0.5), sample_tilt=70.0, tilt=0.0, azimuthal=0.0, euler=(0.0, 90.0, 0.0), binning=1.0, px_size=1.0 um)>
>>> det.euler = [3.4, 96.6, 0.7]
>>> det
<EBSDDetector(shape=(1, 1), pc=(0.5, 0.5, 0.5), sample_tilt=70.0, tilt=6.6, azimuthal=3.4, euler=(3.4, 96.6, 0.7), binning=1.0, px_size=1.0 um)>
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
