### PR TITLE
Fix reading of Oxford Instrument's *.ebsp files with format version 6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,24 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
+Unreleased
+==========
+
+Added
+-----
+
+Changed
+-------
+
+Removed
+-------
+
+Deprecated
+----------
+
+Fixed
+-----
+
 0.11.0 (2024-11-10)
 ===================
 

--- a/conftest.py
+++ b/conftest.py
@@ -512,6 +512,9 @@ def oxford_binary_file(tmpdir, request) -> Generator[TextIOWrapper, None, None]:
 
     for i in new_order:
         r, c = np.unravel_index(i, (nr, nc))
+        if ver > 4:
+            extra_pattern_header = np.array([c, r], dtype=np.int32)
+            extra_pattern_header.tofile(f)
         pattern_header.tofile(f)
         data[r, c].tofile(f)
         if ver > 1:

--- a/conftest.py
+++ b/conftest.py
@@ -51,6 +51,7 @@ if constants.installed["pyvista"]:
 
 
 DATA_PATH = Path(__file__).parent / "src/kikuchipy/data"
+DATA_PATH = DATA_PATH.resolve()
 
 # ------------------------------ Setup ------------------------------ #
 

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -30,7 +30,7 @@ credits = [
     "Carter Francis",
     "Magnus Nord",
 ]
-__version__ = "0.11.0"
+__version__ = "0.12.dev0"
 
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 

--- a/tests/test_io/test_oxford_binary.py
+++ b/tests/test_io/test_oxford_binary.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import dask.array as da
 import numpy as np
 import pytest
@@ -113,3 +115,30 @@ class TestOxfordBinaryReader:
         with open(oxford_binary_file.name, mode="rb") as f:
             fox = OxfordBinaryFileReader(f)
             assert fox.n_patterns == n_patterns
+
+    @pytest.mark.parametrize(
+        "oxford_binary_file",
+        [
+            ((2, 3), (50, 50), np.uint8, 5, False, True),
+            ((2, 3), (50, 50), np.uint8, 6, False, True),
+        ],
+        indirect=["oxford_binary_file"],
+    )
+    def test_version_5(self, oxford_binary_file):
+        with open(oxford_binary_file.name, mode="rb") as f:
+            fox = OxfordBinaryFileReader(f)
+            assert fox.n_patterns == 6
+
+    @pytest.mark.parametrize(
+        "oxford_binary_file, file_size",
+        [
+            (((2, 3), (50, 50), np.uint8, 5, False, True), 15309),
+            (((2, 3), (50, 50), np.uint8, 4, False, True), 15261),
+        ],
+        indirect=["oxford_binary_file"],
+    )
+    def test_estimated_file_size(self, oxford_binary_file, file_size):
+        with open(oxford_binary_file.name, mode="rb") as f:
+            fox = OxfordBinaryFileReader(f)
+            assert fox.get_estimated_file_size() == file_size
+            assert os.path.getsize(oxford_binary_file.name) == file_size


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR fixes #690.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)
- [ ] Update IO tutorial

#### Minimal example of the bug fix or new feature
The map (x, y) integer positions are new files with format version 6

```python
>>> import kikuchipy as kp
>>> s = kp.load("file.ebsp")
>>> s.original_metadata
├── beam_x = array([-28.11170417, -26.11170417, -24.11170417, -22.11170417,
       -20.1117 ...    1.88829583,
         3.88829583,   5.88829583,   7.88829583,   9.88829583])
├── beam_y = array([34.11170417, 34.11170417, 34.11170417, 34.11170417, 34.11170417,
       ... 9583,
       -3.88829583, -3.88829583, -3.88829583, -3.88829583, -3.88829583])
├── file_order = array([  1,   0,   2,   4,   3,   6,   9,   5,   7,   8,  13,  10,  11,
       ...  386, 387, 388, 389,
       391, 390, 392, 393, 396, 394, 395, 397, 398, 399])
├── map1d_id = array([  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,
       ...  386, 387, 388, 389,
       390, 391, 392, 393, 394, 395, 396, 397, 398, 399])
├── map_x = array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
    ... ,  6,  7,  8,  9, 10,
       11, 12, 13, 14, 15, 16, 17, 18, 19], dtype=int32)
└── map_y = array([ 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
    ... , 19, 19, 19, 19, 19,
       19, 19, 19, 19, 19, 19, 19, 19, 19], dtype=int32)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
