### PR TITLE
Make post release for 0.11.1 to include tests in build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 List entries are sorted in descending chronological order. Contributors to each release
 were listed in alphabetical order by first name until version 0.7.0.
 
-0.11.1 (2024-11-24)
+0.11.1 (2024-11-30)
 ===================
 
 Added

--- a/conftest.py
+++ b/conftest.py
@@ -55,8 +55,7 @@ if constants.installed["pyvista"]:
     pv.global_theme.interactive = False
 
 
-DATA_PATH = Path(__file__).parent / "src/kikuchipy/data"
-DATA_PATH = DATA_PATH.resolve()
+DATA_PATH = Path(kp.data.__file__).parent.resolve()
 
 # ------------------------------ Setup ------------------------------ #
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ src = ""
 [tool.hatch.build.targets.wheel]
 include = ["src/kikuchipy"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"tests/" = "kikuchipy/tests"
+"conftest.py" = "kikuchipy/conftest.py"
+
 [tool.coverage.report]
 precision = 2
 

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -30,7 +30,7 @@ credits = [
     "Carter Francis",
     "Magnus Nord",
 ]
-__version__ = "0.11.1"
+__version__ = "0.11.1.post0"
 
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 

--- a/tests/test_signals/test_ebsd_hough_indexing.py
+++ b/tests/test_signals/test_ebsd_hough_indexing.py
@@ -316,7 +316,7 @@ class TestPCOptimization:
         assert np.isclose(det.tilt, det0.tilt)
         assert np.isclose(det.px_size, det0.px_size)
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=3)
     def test_optimize_pc_pso(self, worker_id):
         det0 = self.signal.detector
 

--- a/tests/test_signals/test_ebsd_master_pattern.py
+++ b/tests/test_signals/test_ebsd_master_pattern.py
@@ -192,10 +192,7 @@ class TestProjectFromLambert:
     def test_get_direction_cosines(self):
         det = self.detector
         dc = _get_direction_cosines_from_detector(det)
-        assert dc.shape == (
-            det.size,
-            3,
-        )
+        assert dc.shape == (det.size, 3)
         assert np.max(dc) <= 1
 
         dc2 = _get_direction_cosines_for_fixed_pc.py_func(
@@ -493,7 +490,7 @@ class TestProjectFromLambert:
         value = _get_pixel_from_master_pattern.py_func(
             mp, nii[0], nij[0], niip[0], nijp[0], di[0], dj[0], dim[0], djm[0]
         )
-        assert value == 1.0
+        assert np.isclose(value, 1)
 
     def test_get_cosine_sine_of_alpha_and_azimuthal(self):
         """Make sure the Numba function is covered."""

--- a/tests/test_simulations/test_kikuchi_pattern_simulator.py
+++ b/tests/test_simulations/test_kikuchi_pattern_simulator.py
@@ -111,12 +111,13 @@ class TestCalculateMasterPattern:
         with pytest.raises(ValueError, match="Unknown scaling 'cubic', options are"):
             _ = simulator.calculate_master_pattern(scaling="cubic")
 
+    @pytest.mark.flaky(reruns=3)
     def test_shape(self):
         """Output shape as expected."""
         simulator = self.simulator
         mp = simulator.calculate_master_pattern(half_size=100, hemisphere="both")
         assert mp.data.shape == (2, 201, 201)
-        assert np.allclose(mp.data[0], mp.data[1], atol=1e-7)
+        assert np.allclose(mp.data[0], mp.data[1], atol=1e-4)
 
         axes_names = [a["name"] for a in mp.axes_manager.as_dictionary().values()]
         assert axes_names == ["hemisphere", "height", "width"]


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
Include our test suite in the wheel built with Hatch.

Fixes issue reported in https://github.com/hyperspy/hyperspy-extensions-list/pull/65.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
Allows doing `pytest --pyargs kikuchipy` in an environment where kikuchipy is installed from the wheel (such as from PyPI).

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
