### PR TITLE
Fix getting Matplotlib zone axes collections in gnomonic coordinates from simulator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,5 +39,6 @@ repos:
 # https://pre-commit.ci/#configuration
 ci:
   autofix_prs: false
+  autoupdate_schedule: monthly
   # TODO: Remove skip once (nearly) all files are formatted with the license template
   skip: [licenseheaders]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,9 @@ Fixed
 - Removed possibility for a silent out-of-bounds array indexing with Numba when
   projecting a single pattern from a master pattern in the Lambert projection to the
   detector. (`#718 <https://github.com/pyxem/kikuchipy/pull/718>`_)
+- Getting Matplotlib collections of zone axes and zone axes labels in geometrical EBSD
+  simulations with a 2D navigation shape.
+  (`#720 <https://github.com/pyxem/kikuchipy/pull/720>`_)
 
 Deprecated
 ----------
@@ -821,9 +824,9 @@ Deprecated
 
 Removed
 -------
-- *make_similarity_metric()* function is replaced by the need to create a class inheriting
-  from a new abstract *SimilarityMetric* class, which provides more freedom over
-  preparations of arrays before dictionary indexing.
+- *make_similarity_metric()* function is replaced by the need to create a class
+  inheriting from a new abstract *SimilarityMetric* class, which provides more freedom
+  over preparations of arrays before dictionary indexing.
   (`#419 <https://github.com/pyxem/kikuchipy/pull/419>`_)
 - *EBSD.match_patterns()* is removed, use *EBSD.dictionary_indexing()* instead.
   (`#419 <https://github.com/pyxem/kikuchipy/pull/419>`_)

--- a/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -543,7 +543,7 @@ class GeometricalKikuchiPatternSimulation:
                 idx = (0,)
             else:
                 idx = index
-            nrows = np.diff(self.detector.x_range)[idx][0]
+            nrows = np.diff(self.detector.x_range[idx])[0]
         scatter_size = 0.01 * nrows
 
         circles = []
@@ -573,7 +573,7 @@ class GeometricalKikuchiPatternSimulation:
                 idx = (0,)
             else:
                 idx = index
-            coords[..., 1] += y_offset * np.diff(self.detector.y_range)[idx][0]
+            coords[..., 1] += y_offset * np.diff(self.detector.y_range[idx])[0]
 
         kw = {
             "color": ZONE_AXES_LABEL_COLOR,

--- a/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 from copy import deepcopy
 import re
@@ -537,7 +539,11 @@ class GeometricalKikuchiPatternSimulation:
         if coordinate_fmt == "detector":
             scatter_size = offset * self.detector.nrows
         else:  # gnomonic
-            scatter_size = offset * np.diff(self.detector.x_range)[0]
+            if self.detector.navigation_shape == (1,):
+                idx = (0,)
+            else:
+                idx = index
+            scatter_size = offset * np.diff(self.detector.x_range)[idx][0]
         circles = []
         for x, y in coords:
             circle = mpath.Path.circle((x, y), scatter_size)
@@ -558,7 +564,11 @@ class GeometricalKikuchiPatternSimulation:
         if coordinates == "detector":
             coords[..., 1] -= y_offset * self.detector.nrows
         else:  # gnomonic
-            coords[..., 1] += y_offset * np.diff(self.detector.y_range)[0]
+            if self.detector.navigation_shape == (1,):
+                idx = (0,)
+            else:
+                idx = index
+            coords[..., 1] += y_offset * np.diff(self.detector.y_range)[idx][0]
         kw = {
             "color": ZONE_AXES_LABEL_COLOR,
             "horizontalalignment": "center",

--- a/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
+++ b/src/kikuchipy/simulations/_kikuchi_pattern_simulation.py
@@ -106,7 +106,7 @@ class GeometricalKikuchiPatternSimulation:
         return self._reflectors
 
     @property
-    def navigation_shape(self) -> tuple:
+    def navigation_shape(self) -> tuple[int, ...]:
         """Return the navigation shape of the simulations, equal to the
         shape of :attr:`rotations`.
         """
@@ -535,21 +535,25 @@ class GeometricalKikuchiPatternSimulation:
         **kwargs,
     ) -> mcollections.PathCollection:
         coords = self.zone_axes_coordinates(index, coordinate_fmt)
-        offset = 0.01
+
         if coordinate_fmt == "detector":
-            scatter_size = offset * self.detector.nrows
+            nrows = self.detector.nrows
         else:  # gnomonic
             if self.detector.navigation_shape == (1,):
                 idx = (0,)
             else:
                 idx = index
-            scatter_size = offset * np.diff(self.detector.x_range)[idx][0]
+            nrows = np.diff(self.detector.x_range)[idx][0]
+        scatter_size = 0.01 * nrows
+
         circles = []
         for x, y in coords:
             circle = mpath.Path.circle((x, y), scatter_size)
             circles.append(circle)
+
         kw = {"ec": "k", "fc": ZONE_AXES_COLOR, "zorder": 1, "label": "zone_axes"}
         kw.update(kwargs)
+
         return mcollections.PathCollection(circles, **kw)
 
     def _zone_axes_labels_as_list(
@@ -560,6 +564,7 @@ class GeometricalKikuchiPatternSimulation:
     ) -> list[mtext.Text]:
         labels = self._zone_axes_labels_as_array().tolist()
         coords = self.zone_axes_coordinates(index, coordinates, exclude_nan=False)
+
         y_offset = 0.03
         if coordinates == "detector":
             coords[..., 1] -= y_offset * self.detector.nrows
@@ -569,17 +574,20 @@ class GeometricalKikuchiPatternSimulation:
             else:
                 idx = index
             coords[..., 1] += y_offset * np.diff(self.detector.y_range)[idx][0]
+
         kw = {
             "color": ZONE_AXES_LABEL_COLOR,
             "horizontalalignment": "center",
             "bbox": {"boxstyle": "square", "fc": "w", "pad": 0.1},
         }
         kw.update(kwargs)
+
         texts = []
         for (x, y), label in zip(coords, labels):
             if ~np.isnan(x):
                 text_i = mtext.Text(x, y, label, **kw)
                 texts.append(text_i)
+
         return texts
 
     def _lines_as_markers(self, **kwargs) -> hs.plot.markers.Lines:

--- a/tests/test_simulations/test_kikuchi_pattern_simulation.py
+++ b/tests/test_simulations/test_kikuchi_pattern_simulation.py
@@ -237,6 +237,17 @@ class TestAsCollections:
         za_labels_coords2 = coll2[2][0]
         assert np.allclose(za_labels_coords2.get_position(), [0, 0.42], atol=0.01)
 
+    def test_as_collections_gnomonic_2d(self):
+        s = kp.data.nickel_ebsd_small()
+        g = ReciprocalLatticeVector(s.xmap.phases[0], [[1, 1, 1]])
+        g = g.symmetrise()
+        simulator = kp.simulations.KikuchiPatternSimulator(g)
+        rot = s.xmap.rotations.reshape(*s.xmap.shape)
+        sim = simulator.on_detector(s.detector, rot)
+        coll = sim.as_collections(
+            (0, 1), "gnomonic", zone_axes=True, zone_axes_labels=True
+        )
+
 
 class TestAsMarkers:
     """Getting lines, zone axes, zone axes labels and PC as HyperSpy

--- a/tests/test_simulations/test_kikuchi_pattern_simulation.py
+++ b/tests/test_simulations/test_kikuchi_pattern_simulation.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 import logging
 
@@ -140,6 +142,28 @@ class TestGeometricalKikuchiPatternSimulation:
         filters = logging.getLogger("matplotlib.text").filters
         assert filters == [kp.simulations.DisableMatplotlibWarningFilter]
 
+    def test_as_collections_gnomonic(self):
+        s = kp.data.nickel_ebsd_small()
+
+        g = ReciprocalLatticeVector(s.xmap.phases[0], [[1, 1, 1]])
+        g = g.symmetrise()
+        simulator = kp.simulations.KikuchiPatternSimulator(g)
+
+        rot = s.xmap.rotations.reshape(*s.xmap.shape)
+
+        det_2d = s.detector
+        det_single = det_2d.deepcopy()
+        det_single.pc = det_2d.pc[0, 1]
+
+        sim_single = simulator.on_detector(det_single, rot[0, 1])
+        sim_single_rot_2d = simulator.on_detector(det_single, rot)
+
+        za_coords_single = sim_single.zone_axes_coordinates(coordinates="gnomonic")
+        za_coords_single_rot_2d = sim_single_rot_2d.zone_axes_coordinates(
+            (0, 1), coordinates="gnomonic"
+        )
+        assert np.all(np.isin(za_coords_single, za_coords_single_rot_2d))
+
 
 class TestAsCollections:
     """Getting lines, zone axes, zone axes labels and PC as Matplotlib
@@ -237,16 +261,53 @@ class TestAsCollections:
         za_labels_coords2 = coll2[2][0]
         assert np.allclose(za_labels_coords2.get_position(), [0, 0.42], atol=0.01)
 
-    def test_as_collections_gnomonic_2d(self):
+    def test_zone_axes_as_collections_gnomonic(self):
         s = kp.data.nickel_ebsd_small()
+
+        # Indices into zone axes paths later on depend on reflectors and
+        # their order!
         g = ReciprocalLatticeVector(s.xmap.phases[0], [[1, 1, 1]])
         g = g.symmetrise()
         simulator = kp.simulations.KikuchiPatternSimulator(g)
+
         rot = s.xmap.rotations.reshape(*s.xmap.shape)
-        sim = simulator.on_detector(s.detector, rot)
-        coll = sim.as_collections(
-            (0, 1), "gnomonic", zone_axes=True, zone_axes_labels=True
-        )
+
+        idx = (0, 1)
+        idx_single = 0
+        idx_2d = 3
+
+        det_2d = s.detector
+        det_single = det_2d.deepcopy()
+        det_single.pc = det_2d.pc[idx]
+
+        sim_2d = simulator.on_detector(det_2d, rot)
+        sim_single = simulator.on_detector(det_single, rot[idx])
+        sim_single_rot_2d = simulator.on_detector(det_single, rot)
+
+        kw = {
+            "coordinates": "gnomonic",
+            "lines": False,
+            "zone_axes": True,
+            "zone_axes_labels": True,
+        }
+
+        coll_2d = sim_2d.as_collections(idx, **kw)
+        coll_single = sim_single.as_collections((0,), **kw)
+        coll_single_rot_2d = sim_single_rot_2d.as_collections(idx, **kw)
+
+        # Zone axes labels
+        za_labels_2d = [label.get_text() for label in coll_2d[1]]
+        za_labels_single = [label.get_text() for label in coll_single[1]]
+        za_labels_single_rot_2d = [label.get_text() for label in coll_single_rot_2d[1]]
+        assert np.all(za_labels_2d == za_labels_single_rot_2d)
+        assert np.all(za_labels_2d[2:][::-1] == za_labels_single)
+
+        # Zone axes
+        za_2d_scatter_verts = coll_2d[0].get_paths()[idx_2d].vertices
+        za_single_verts = coll_single[0].get_paths()[idx_single].vertices
+        za_single_rot_2d_verts = coll_single_rot_2d[0].get_paths()[idx_2d].vertices
+        assert np.allclose(za_2d_scatter_verts, za_single_verts)
+        assert np.allclose(za_single_verts, za_single_rot_2d_verts)
 
 
 class TestAsMarkers:


### PR DESCRIPTION
**Problem**: calling GeometricalKikuchiPatternSimulation.plot() with the kwarg coordinates="gnomonic" and an EBSDDetector with navigation_dimension > 1 fails with a ValueError.

#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
**Details**: plot() calls as_collections(), which calls _zone_axes_as_collection() and _zone_axis_labels_as_list(). The ValueError comes from the definition of scatter_size in the "else" branch of _zone_axes_as_collection() AND because of the application of the y_offset to the "coords" in the "else" branch of _zone_axis_labels_as_list(). For an EBSDDetector with navigation_dimension > 1, the call np.diff(self.detector.x_range)[0] results in a 2D output, whereas a float is needed to calculate the offsets,

**Solution**: add the "index" to each of these lines so that the specific x_range and y_range for the pattern specified by "index" is chosen. Leave the "[0]" there so that we select a float rather than a np.ndarray. The case that a 1d detector is supplied together with a >1d rotation is also handled.


#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> from diffsims.crystallography import ReciprocalLatticeVector
>>> from diffpy.structure import Lattice, Structure
>>> from orix.crystal_map import Phase
>>> from orix.quaternion import Rotation
>>> import kikuchipy as kp
>>> from kikuchipy.detectors import EBSDDetector
>>> # get Euler angles as rotations
>>> rot_2d = Rotation.from_euler(np.array([[[0.6, 0.1, 0.2],
... [0.7, 0.2, 0.4]],
... [[0.8, 0.5, 0.5],
... [0.9, 0.8, 0.6]]])
... )
>>> lattice = Lattice(5.431, 5.431, 5.431, 90.0, 90.0, 90.0)
>>> phase = Phase(name="Si", 
... space_group=227, 
... structure=Structure(atoms=None, lattice=lattice)
... )
>>> poles = np.array([[2,2,0], 
... [4,0,0], 
... [2,2,4], 
... [4,0,4], 
... [2,0,6]]
... )
>>> ref = ReciprocalLatticeVector(phase=phase, hkl=poles)
>>> ref = ref.symmetrise()
>>> simulator = kp.simulations.KikuchiPatternSimulator(ref)
>>> # make several different EBSDDetector instances
>>> pc = np.array([[[0.52, 0.22, 0.67], 
... [0.55, 0.20, 0.65]], 
... [[0.45, 0.24, 0.63], 
... [0.40, 0.23, 0.61]]]
... )
>>> shape = (1024, 1244)
>>> detector_2d = EBSDDetector(shape, pc=pc, convention='bruker')
>>> detector_1d = EBSDDetector(shape, pc=pc[0], convention='bruker')
>>> detector_0d = EBSDDetector(shape, pc=pc[0, 1], convention='bruker')
>>> # Project simulations onto the detectors
>>> sim_2d = simulator.on_detector(detector_2d, rot_2d)
>>> sim_1d = simulator.on_detector(detector_1d, rot_2d[0,])
>>> sim_0d = simulator.on_detector(detector_0d, rot_2d[0, 1])
>>> sim_0d_rot_2d = simulator.on_detector(detector_0d, rot_2d)
>>> # make collections
>>> # works on both the main and PR branches
>>> collections_0d = sim_0d.as_collections(
... (0,), 
... "gnomonic", 
... zone_axes=True, 
... zone_axes_labels=True
... )
>>> # works on both branches: the detector is still 0d
>>> collections_0d_rot_2d = sim_0d_rot_2d.as_collections(
... (0, 1), 
... "gnomonic", 
... zone_axes=True, 
... zone_axes_labels=True
... )
>>> # works on both branches but on the main branch, the zone axes are from index 0 not index 1
>>> collections_1d = sim_1d.as_collections(
... (1,),
... "gnomonic",
... zone_axes=True,
... zone_axes_labels=True
... )
>>> # fails on the current main branch
>>> try:
... collections_2d = sim_2d.as_collections((0, 1), "gnomonic", zone_axes=True, zone_axes_labels=True )
... print("as_collections() with an EBSDDetector (2, 2) passed")
>>> except ValueError:
... collections_2d = None
... print("as_collections() with an EBSDDetector (2, 2) failed with a ValueError")
>>> # check the vertices of the patches marking the zone axes are the same
>>> q1 = (collections_0d[1].get_paths()[0].vertices == collections_0d_rot_2d[1].get_paths()[0].vertices).all()
>>> q2 = (collections_0d[1].get_paths()[0].vertices == collections_1d[1].get_paths()[0].vertices).all()
>>> if collections_2d:
... q3 = (collections_0d[1].get_paths()[0].vertices == collections_2d[1].get_paths()[0].vertices).all()
>>> else:
... q3 = False
>>> print(f"0d == 0d with 2d rotation: {q1}")
>>> print(f"0d == 1d[(1,)]: {q2}")
>>> print(f"0d == 2d[(0, 1)]: {q3}")
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
