### PR TITLE
Update _emsoft_master_pattern.py to allow OpenCL MP data

### DIFF
--- a/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
+++ b/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
@@ -245,7 +245,7 @@ def check_file_format(file: h5py.File, diffraction_type: str) -> None:
     try:
         program_name_path = f"EMheader/{diffraction_type}master/ProgramName"
         program_name = file[program_name_path][:][0].decode()
-        if program_name != f"EM{diffraction_type}master.f90":
+        if program_name != f"EM{diffraction_type}master.f90" and program_name != f"EM{diffraction_type}masterOpenCL.f90":
             raise KeyError
     except KeyError:
         raise IOError(f"{file.filename!r} is not in EMsoft's master pattern format")


### PR DESCRIPTION
Update _emsoft_master_pattern.py to allow loading of MP data generated by EMEBSDmasterOpenCL.f90 program

#### Description of the change
Update _emsoft_master_pattern.py to allow loading of MP data generated by EMEBSDmasterOpenCL.f90 program


#### Minimal example of the bug fix or new feature
```python
        if program_name != f"EM{diffraction_type}master.f90":
            raise KeyError
```
changed into:
```python
        if program_name != f"EM{diffraction_type}master.f90" and program_name != f"EM{diffraction_type}masterOpenCL.f90":
            raise KeyError
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
