### PR TITLE
Allow reading master pattern generated with EMsoft's EMEBSDmasterOpenCL.f90 program

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@
 repos:
   # https://docs.astral.sh/ruff/configuration
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.11.0
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -46,6 +46,11 @@
       "name": "Magnus Nord",
       "orcid": "0000-0001-7981-5293",
       "affiliation": "Norwegian University of Science and Technology"
+    },
+    {
+      "name": "Tijmen Vermeij",
+      "orcid": "0000-0002-5434-6280",
+      "affiliation": "Empa"
     }
   ]
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Unreleased
 
 Added
 -----
+- Can now read simulated master patterns from EMsoft's EMEBSDmasterOpenCL.f90 program.
+  (`#730 <https://github.com/pyxem/kikuchipy/pull/730>`_)
 
 Changed
 -------

--- a/doc/dev/using_git.rst
+++ b/doc/dev/using_git.rst
@@ -9,7 +9,7 @@ want to fix a bug, branch off of ``main`` instead.
 
 To create a new feature branch that tracks the upstream development branch::
 
-    git checkout develop -b your-awesome-feature-name upstream/develop
+    git switch -c your-awesome-feature-name upstream/develop
 
 When you've made some changes you can view them with::
 
@@ -33,7 +33,7 @@ branch. If you are fixing a bug, merge ``main`` into your bug fix branch instead
 
 To update a feature branch, switch to the ``develop`` branch::
 
-    git checkout develop
+    git switch develop
 
 Fetch changes from the upstream branch and update ``develop``::
 
@@ -41,7 +41,7 @@ Fetch changes from the upstream branch and update ``develop``::
 
 Update your feature branch::
 
-    git checkout your-awesome-feature-name
+    git switch your-awesome-feature-name
     git merge develop
 
 Sharing your changes

--- a/doc/tutorials/load_save_data.ipynb
+++ b/doc/tutorials/load_save_data.ipynb
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or, load the stereographic projection of the upper hemisphere of an EBSD master pattern for a 20 keV beam energy from a modified version of *EMsoft*'s master pattern file, returned from their `EMEBSDmaster.f90` program"
+    "Or, load the stereographic projection of the upper hemisphere of an EBSD master pattern for a 20 keV beam energy from a modified version of *EMsoft*'s master pattern file, returned from their *EMEBSDmaster.f90* or *EMEBSDmasterOpenCL.f90* programs"
    ]
   },
   {
@@ -570,7 +570,7 @@
    "source": [
     "### EMsoft EBSD master pattern HDF5\n",
     "\n",
-    "Master patterns returned by EMsoft's `EMEBSDmaster.f90` program as HDF5 files can be read as an [EBSDMasterPattern](../reference/generated/kikuchipy.signals.EBSDMasterPattern.rst) signal"
+    "Master patterns returned by EMsoft's *EMEBSDmaster.f90* or *EMEBSDmasterOpenCL.f90* programs as HDF5 files can be read as an [EBSDMasterPattern](../reference/generated/kikuchipy.signals.EBSDMasterPattern.rst) signal"
    ]
   },
   {
@@ -634,7 +634,7 @@
    "source": [
     "### EMsoft ECP master pattern HDF5\n",
     "\n",
-    "Master patterns returned by EMsoft's `EMECPmaster.f90` program as HDF5 files can be read as an [ECPMasterPattern](../reference/generated/kikuchipy.signals.ECPMasterPattern.rst) signal just like an EBSD master pattern.\n",
+    "Master patterns returned by EMsoft's *EMECPmaster.f90* program as HDF5 files can be read as an [ECPMasterPattern](../reference/generated/kikuchipy.signals.ECPMasterPattern.rst) signal just like an EBSD master pattern.\n",
     "The EMsoft ECP master pattern [file_reader()](../reference/generated/kikuchipy.io.plugins.emsoft_ecp_master_pattern.file_reader.rst) is used, which supports the same parameters as the [EMsoft EBSD master pattern reader](#EMsoft-EBSD-master-pattern-HDF5)."
    ]
   },
@@ -645,7 +645,7 @@
    "source": [
     "### EMsoft TKD master pattern HDF5\n",
     "\n",
-    "Master patterns returned by EMsoft's `EMTKDmaster.f90` program as HDF5 files can be read as an [EBSDMasterPattern](../reference/generated/kikuchipy.signals.EBSDMasterPattern.rst) signal just like an EBSD master pattern.\n",
+    "Master patterns returned by EMsoft's *EMTKDmaster.f90* program as HDF5 files can be read as an [EBSDMasterPattern](../reference/generated/kikuchipy.signals.EBSDMasterPattern.rst) signal just like an EBSD master pattern.\n",
     "The EMsoft TKD master pattern [file_reader()](../reference/generated/kikuchipy.io.plugins.emsoft_tkd_master_pattern.file_reader.rst) is used, which supports the same parameters as the [EMsoft EBSD master pattern reader](#EMsoft-EBSD-master-pattern-HDF5)."
    ]
   },

--- a/src/kikuchipy/__init__.py
+++ b/src/kikuchipy/__init__.py
@@ -32,6 +32,7 @@ credits = [
     "Zhou Xu",
     "Carter Francis",
     "Magnus Nord",
+    "Tijmen Vermeij",
 ]
 __version__ = "0.12.dev2"
 

--- a/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
+++ b/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
@@ -245,7 +245,7 @@ def check_file_format(file: h5py.File, diffraction_type: str) -> None:
     try:
         program_name_path = f"EMheader/{diffraction_type}master/ProgramName"
         program_name = file[program_name_path][:][0].decode()
-        if program_name != f"EM{diffraction_type}master.f90":
+        if program_name != f"EM{diffraction_type}master.f90" and program_name != f"EM{diffraction_type}masterOpenCL.f90":
             raise KeyError
     except KeyError:
         raise IOError(f"{file.filename!r} is not in EMsoft's master pattern format")

--- a/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
+++ b/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
@@ -240,7 +240,8 @@ def check_file_format(file: h5py.File, diffraction_type: str) -> None:
     ------
     KeyError
         If the program that created the file is not named
-        "EM<diffraction_type>master.f90".
+        "EM<diffraction_type>master.f90" or
+        "EM<diffraction_type>masterOpenCL.f90".
     IOError
         If the file is not in the EMsoft master pattern file format.
     """

--- a/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
+++ b/src/kikuchipy/io/plugins/_emsoft_master_pattern.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 import abc
 import os
@@ -245,10 +247,16 @@ def check_file_format(file: h5py.File, diffraction_type: str) -> None:
     try:
         program_name_path = f"EMheader/{diffraction_type}master/ProgramName"
         program_name = file[program_name_path][:][0].decode()
-        if program_name != f"EM{diffraction_type}master.f90" and program_name != f"EM{diffraction_type}masterOpenCL.f90":
+        if program_name not in [
+            f"EM{diffraction_type}master.f90",
+            f"EM{diffraction_type}masterOpenCL.f90",
+        ]:
             raise KeyError
     except KeyError:
-        raise IOError(f"{file.filename!r} is not in EMsoft's master pattern format")
+        raise IOError(
+            f"File {file.filename!r} is not created with one of the supported EMsoft "
+            "programs"
+        )
 
 
 def get_data_shape_slices(

--- a/tests/test_io/test_emsoft_master_pattern.py
+++ b/tests/test_io/test_emsoft_master_pattern.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 from h5py import File
 import numpy as np
@@ -34,7 +36,7 @@ class TestEMsoftEBSDMasterPatternReader:
             g2.create_dataset(
                 "ProgramName", data=np.array([b"EMEBSDmasterr.f90"], dtype="S17")
             )
-            with pytest.raises(IOError, match=".* is not in EMsoft's master "):
+            with pytest.raises(IOError, match="File .* is not created with one of the"):
                 check_file_format(f, "EBSD")
 
     @pytest.mark.parametrize(

--- a/tests/test_io/test_emsoft_tkd_master_pattern.py
+++ b/tests/test_io/test_emsoft_tkd_master_pattern.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -15,7 +16,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
+import h5py
+import numpy as np
 import pytest
 
 import kikuchipy as kp
@@ -36,3 +40,11 @@ class TestEMsoftTKDMasterPatternReader:
     def test_file_reader(self, emsoft_tkd_master_pattern_file, lazy, class_type):
         s = kp.load(emsoft_tkd_master_pattern_file, lazy=lazy)
         assert isinstance(s, class_type)
+
+    def test_read_opencl_file(self, emsoft_tkd_master_pattern_file):
+        with h5py.File(emsoft_tkd_master_pattern_file, "r+") as f:
+            path = "EMheader/TKDmaster/ProgramName"
+            del f[path]
+            f[path] = np.array([b"EMTKDmasterOpenCL.f90"], dtype="S21")
+        s = kp.load(emsoft_tkd_master_pattern_file)
+        assert isinstance(s, kp.signals.EBSDMasterPattern)


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->

Fix #729.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
