### PR TITLE
Fix documentation build by disallowing numpydoc v1.9.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,11 +10,12 @@
 #
 # kikuchipy is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with kikuchipy.  If not, see <http://www.gnu.org/licenses/>.#
+# along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 # Configuration file for the Sphinx documentation app.
 # See the documentation for a full list of configuration options:
@@ -96,7 +97,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pyvista": ("https://docs.pyvista.org", None),
     "pyxem": ("https://pyxem.readthedocs.io/en/latest", None),
-    "readthedocs": ("https://docs.readthedocs.io/en/stable", None),
+    "readthedocs": ("https://docs.readthedocs.com/platform/stable/objects.inv", None),
     "rosettasciio": ("https://rosettasciio.readthedocs.io/en/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "skimage": ("https://scikit-image.org/docs/stable", None),

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -7,6 +7,7 @@ kikuchipy can be installed with `pip <https://pypi.org/project/kikuchipy/>`__,
 :ref:`hyperspy:hyperspy-bundle`, or from source, and supports Python >= 3.10.
 All alternatives are available on Windows, macOS and Linux.
 
+
 .. _install-with-pip:
 
 With pip
@@ -25,6 +26,7 @@ To update kikuchipy to the latest release::
 To install a specific version of kikuchipy (say version 0.8.5)::
 
     pip install kikuchipy==0.8.5
+
 
 .. _install-with-anaconda:
 
@@ -54,6 +56,7 @@ To install a specific version of kikuchipy (say version 0.8.5)::
 
     conda install kikuchipy==0.8.5
 
+
 .. _install-with-hyperspy-bundle:
 
 With the HyperSpy Bundle
@@ -62,12 +65,6 @@ With the HyperSpy Bundle
 kikuchipy is available in the HyperSpy Bundle. See :ref:`hyperspy:hyperspy-bundle` for
 instructions.
 
-.. warning::
-
-    kikuchipy is updated more frequently than the HyperSpy Bundle, thus the installed
-    version of kikuchipy will most likely not be the latest version available. See the
-    `HyperSpy Bundle repository <https://github.com/hyperspy/hyperspy-bundle>`__ for how
-    to update packages in the bundle.
 
 .. _install-from-source:
 
@@ -83,6 +80,7 @@ To install kikuchipy from source, clone the repository from `GitHub
 
 See the contributing guide for :ref:`setting-up-a-development-installation` and keeping
 it up to date.
+
 
 .. _dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ all = [
 doc = [
     "memory_profiler",
     "nbsphinx                     >= 0.7",
-    "numpydoc",
+    # Restriction due to https://github.com/pyxem/kikuchipy/issues/739
+    "numpydoc != 1.9.0",
     "nlopt",
     "pydata-sphinx-theme",
     "pyebsdindex                  ~= 0.2",


### PR DESCRIPTION
#### Description of the change
<!-- Remember to branch off the develop branch for new features and the main branch for patches. -->
This PR fixes https://github.com/pyxem/kikuchipy/issues/739 by disallowing numpydoc v1.9.0.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://kikuchipy.org/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
