### PR TITLE
Skip test if no display available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,15 +39,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        display: ['true']
         python-version: ['3.11', '3.12']
         include:
           - os: ubuntu-latest
             python-version: '3.10'
-            DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy>=2 matplotlib==3.5 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.2.0 scikit-image==0.21.0
+            DEPENDENCIES: dask==2021.8.1 diffsims==0.5.2 hyperspy>=2.2 matplotlib==3.5 numba==0.57 numpy==1.23.0 orix==0.12.1 pooch==1.3.0 pyebsdindex==0.2.0 scikit-image==0.21.0
             LABEL: -oldest
+            display: 'true'
           - os: ubuntu-latest
             python-version: '3.12'
             LABEL: -minimum_requirement
+            display: 'false'
+          - os: ubuntu-latest
+            python-version: '3.12'
+            LABEL: -no_display
+            display: 'false'
+          - os: windows-latest
+            python-version: '3.12'
+            LABEL: -no_display
+            display: 'false'
+
     steps:
       - uses: actions/checkout@v4
 
@@ -88,14 +100,14 @@ jobs:
           pip list
 
       - name: Set up headless display necessary for PyVista on Linux
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.display == 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
           /sbin/ldconfig -p | grep stdc++ # Temporarily check location
 
       - name: Set up headless display necessary for PyVista on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.display == 'true' }}
         uses: pyvista/setup-headless-display-action@v4
 
       - name: Run docstring tests
@@ -105,11 +117,16 @@ jobs:
           xvfb-run pytest src --doctest-modules --doctest-continue-on-failure
 
       - name: Run tests in a virtual X server environment on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.display == 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
           xvfb-run pytest ${{ env.PYTEST_ARGS }}
+
+      - name: Run tests on ubuntu without display
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.display == 'false' }}
+        run: |
+          pytest ${{ env.PYTEST_ARGS }}
 
       - name: Run tests on Windows or macOS
         if: ${{ matrix.os != 'ubuntu-latest' }}

--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,12 @@ from kikuchipy.data._dummy_files.bruker_h5ebsd import (
 from kikuchipy.data._dummy_files.oxford_h5ebsd import create_dummy_oxford_h5ebsd_file
 from kikuchipy.io.plugins._h5ebsd import _dict2hdf5group
 
+DATA_PATH = Path(kp.data.__file__).parent.resolve()
+
+
+# ----------------------------- pyvista ----------------------------- #
+
+
 if dependency_version["pyvista"] is not None:
     import pyvista as pv
 
@@ -57,7 +63,13 @@ if dependency_version["pyvista"] is not None:
     pv.global_theme.interactive = False
 
 
-DATA_PATH = Path(kp.data.__file__).parent.resolve()
+@pytest.fixture(autouse=False)
+def skip_if_no_pyvista_or_no_display():
+    if dependency_version["pyvista"] is None:
+        pytest.skip("Skipping test: pyvista not installed")
+    if "DISPLAY" not in os.environ:
+        pytest.skip("Skipping test: no DISPLAY environment variable set")
+
 
 # ------------------------------ Setup ------------------------------ #
 

--- a/tests/test_signals/test_ebsd_master_pattern.py
+++ b/tests/test_signals/test_ebsd_master_pattern.py
@@ -546,10 +546,7 @@ class TestProjectFromLambert:
 
 
 class TestMasterPatternPlotting:
-    @pytest.mark.skipif(
-        dependency_version["pyvista"] is None, reason="PyVista is not installed"
-    )
-    def test_plot_spherical(self):
+    def test_plot_spherical(self, skip_if_no_pyvista_or_no_display):
         """Returns expected data and raises correct error."""
         import pyvista as pv
 

--- a/tests/test_signals/test_ecp_master_pattern.py
+++ b/tests/test_signals/test_ecp_master_pattern.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2024 The kikuchipy developers
+#
+# Copyright 2019-2025 the kikuchipy developers
 #
 # This file is part of kikuchipy.
 #
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kikuchipy. If not, see <http://www.gnu.org/licenses/>.
+#
 
 import dask.array as da
 import numpy as np
@@ -21,7 +23,6 @@ from orix.crystal_map import Phase
 import pytest
 
 import kikuchipy as kp
-from kikuchipy.constants import dependency_version
 
 
 class TestECPMasterPattern:
@@ -71,10 +72,9 @@ class TestECPMasterPattern:
         assert np.allclose(mp_upper, data[1])
         assert np.allclose(mp_lower, data[1])
 
-    @pytest.mark.skipif(
-        dependency_version["pyvista"] is None, reason="PyVista is not installed"
-    )
-    def test_plot_spherical(self, emsoft_ecp_master_pattern_file):
+    def test_plot_spherical(
+        self, emsoft_ecp_master_pattern_file, skip_if_no_pyvista_or_no_display
+    ):
         """Cover inherited method only included for documentation
         purposes (tested rigorously elsewhere).
         """

--- a/tests/test_simulations/test_kikuchi_pattern_simulator.py
+++ b/tests/test_simulations/test_kikuchi_pattern_simulator.py
@@ -276,7 +276,7 @@ class TestPlot:
 
         plt.close("all")
 
-    def test_spherical(self):
+    def test_plot_spherical_matplotlib(self):
         """Spherical plot with Matplotlib."""
         simulator = self.simulator
         fig1 = simulator.plot("spherical", return_figure=True)
@@ -297,10 +297,7 @@ class TestPlot:
 
         plt.close("all")
 
-    @pytest.mark.skipif(
-        dependency_version["pyvista"] is None, reason="PyVista is not installed"
-    )
-    def test_spherical_pyvista(self):
+    def test_plot_spherical(self, skip_if_no_pyvista_or_no_display):
         """Spherical plot with PyVista."""
         import pyvista as pv
 


### PR DESCRIPTION
Add pytest fixture to skip tests when pyvista is not installed or no display is available.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] New contributors are added to `kikuchipy/__init__.py` and `.zenodo.json`.
